### PR TITLE
scripts: handle AMD and Intel KVM modules correctly

### DIFF
--- a/scripts/enable-vmware-backdoor.sh
+++ b/scripts/enable-vmware-backdoor.sh
@@ -1,7 +1,16 @@
 #!/bin/bash -eu
 
-sudo modprobe -r kvm-intel
+if grep -q AuthenticAMD /proc/cpuinfo; then
+    KVM_MOD="kvm-amd"
+elif grep -q GenuineIntel /proc/cpuinfo; then
+    KVM_MOD="kvm-intel"
+else
+    echo "Unsupported CPU vendor"
+    exit 1
+fi
+
+sudo modprobe -r "$KVM_MOD"
 sudo modprobe -r kvm
 sudo modprobe  kvm enable_vmware_backdoor=y
-sudo modprobe  kvm-intel
+sudo modprobe  "$KVM_MOD"
 cat /sys/module/kvm/parameters/enable_vmware_backdoor | grep -q Y && echo OK || echo KVM module problem


### PR DESCRIPTION
Detect CPU vendor and unload/load the appropriate KVM module instead of hardcoding kvm-intel.