### PR TITLE
smite: implement gossip_timestamp_filter codec

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -4,6 +4,7 @@
 //! protocol messages as specified in the BOLT specifications.
 
 mod error;
+mod gossip_timestamp_filter;
 mod init;
 mod open_channel;
 mod ping;
@@ -14,6 +15,7 @@ mod warning;
 mod wire;
 
 pub use error::Error;
+pub use gossip_timestamp_filter::GossipTimestampFilter;
 pub use init::{Init, InitTlvs};
 pub use open_channel::{OpenChannel, OpenChannelTlvs};
 pub use ping::Ping;
@@ -89,6 +91,8 @@ pub mod msg_type {
     pub const PONG: u16 = 19;
     /// `open_channel` message (BOLT 2).
     pub const OPEN_CHANNEL: u16 = 32;
+    /// Gossip timestamp filter message (BOLT 7).
+    pub const GOSSIP_TIMESTAMP_FILTER: u16 = 265;
 }
 
 /// A decoded BOLT message.
@@ -107,6 +111,8 @@ pub enum Message {
     Pong(Pong),
     /// `open_channel` message (type 32).
     OpenChannel(OpenChannel),
+    /// Gossip timestamp filter message (type 265).
+    GossipTimestampFilter(GossipTimestampFilter),
     /// Unknown message type.
     ///
     /// Stored for odd types that we don't recognize but must accept.
@@ -130,6 +136,7 @@ impl Message {
             Self::Ping(_) => msg_type::PING,
             Self::Pong(_) => msg_type::PONG,
             Self::OpenChannel(_) => msg_type::OPEN_CHANNEL,
+            Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => *msg_type,
         }
     }
@@ -146,6 +153,7 @@ impl Message {
             Self::Ping(m) => out.extend(m.encode()),
             Self::Pong(m) => out.extend(m.encode()),
             Self::OpenChannel(m) => out.extend(m.encode()),
+            Self::GossipTimestampFilter(m) => out.extend(m.encode()),
             Self::Unknown { payload, .. } => out.extend(payload),
         }
         out
@@ -169,6 +177,9 @@ impl Message {
             msg_type::PING => Ok(Self::Ping(Ping::decode(cursor)?)),
             msg_type::PONG => Ok(Self::Pong(Pong::decode(cursor)?)),
             msg_type::OPEN_CHANNEL => Ok(Self::OpenChannel(OpenChannel::decode(cursor)?)),
+            msg_type::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
+                GossipTimestampFilter::decode(cursor)?,
+            )),
             _ => {
                 // Unknown even types must be rejected per BOLT 1
                 if msg_type % 2 == 0 {
@@ -249,17 +260,6 @@ mod tests {
         assert_eq!(decoded, Message::Pong(pong));
     }
 
-    #[test]
-    fn message_unknown_roundtrip() {
-        let msg = Message::Unknown {
-            msg_type: 101,
-            payload: vec![0x11, 0x22, 0x33],
-        };
-        let encoded = msg.encode();
-        let decoded = Message::decode(&encoded).unwrap();
-        assert_eq!(decoded, msg);
-    }
-
     /// Valid `OpenChannel` message for testing.
     fn sample_open_channel() -> OpenChannel {
         let secp = Secp256k1::new();
@@ -299,6 +299,27 @@ mod tests {
     }
 
     #[test]
+    fn message_gossip_timestamp_filter_roundtrip() {
+        let chain_hash = [0x6f; 32];
+        let filter = GossipTimestampFilter::new(chain_hash, 1_000_000, 86400);
+        let msg = Message::GossipTimestampFilter(filter.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::GossipTimestampFilter(filter));
+    }
+
+    #[test]
+    fn message_unknown_roundtrip() {
+        let msg = Message::Unknown {
+            msg_type: 101,
+            payload: vec![0x11, 0x22, 0x33],
+        };
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
     fn message_type_values() {
         assert_eq!(
             Message::Warning(Warning::all_channels("")).msg_type(),
@@ -314,6 +335,10 @@ mod tests {
         assert_eq!(
             Message::OpenChannel(sample_open_channel()).msg_type(),
             msg_type::OPEN_CHANNEL
+        );
+        assert_eq!(
+            Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),
+            msg_type::GOSSIP_TIMESTAMP_FILTER
         );
         assert_eq!(
             Message::Unknown {

--- a/smite/src/bolt/gossip_timestamp_filter.rs
+++ b/smite/src/bolt/gossip_timestamp_filter.rs
@@ -1,0 +1,158 @@
+//! BOLT 7 `gossip_timestamp_filter` message.
+
+use super::BoltError;
+use super::types::CHAIN_HASH_SIZE;
+use super::wire::WireFormat;
+
+/// BOLT 7 `gossip_timestamp_filter` message (type 265).
+///
+/// Allows a node to constrain future gossip messages to a specific range.
+/// A node which wants any gossip messages has to send this, otherwise no
+/// gossip messages would be received.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GossipTimestampFilter {
+    /// The 32-byte hash that uniquely identifies the chain for the gossip.
+    pub chain_hash: [u8; CHAIN_HASH_SIZE],
+    /// Lower bound (inclusive) of the timestamp range.
+    pub first_timestamp: u32,
+    /// Number of seconds in the range (exclusive upper bound).
+    pub timestamp_range: u32,
+}
+
+impl GossipTimestampFilter {
+    /// Creates a gossip timestamp filter.
+    #[must_use]
+    pub fn new(
+        chain_hash: [u8; CHAIN_HASH_SIZE],
+        first_timestamp: u32,
+        timestamp_range: u32,
+    ) -> Self {
+        Self {
+            chain_hash,
+            first_timestamp,
+            timestamp_range,
+        }
+    }
+
+    /// Creates a filter that requests no gossip.
+    ///
+    /// Per BOLT 7: set `first_timestamp` to 0xFFFFFFFF and `timestamp_range` to 0.
+    #[must_use]
+    pub fn no_gossip(chain_hash: [u8; CHAIN_HASH_SIZE]) -> Self {
+        Self {
+            chain_hash,
+            first_timestamp: u32::MAX,
+            timestamp_range: 0,
+        }
+    }
+
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&self.chain_hash);
+        self.first_timestamp.write(&mut out);
+        self.timestamp_range.write(&mut out);
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let chain_hash: [u8; CHAIN_HASH_SIZE] = WireFormat::read(&mut cursor)?;
+        let first_timestamp = u32::read(&mut cursor)?;
+        let timestamp_range = u32::read(&mut cursor)?;
+        Ok(Self {
+            chain_hash,
+            first_timestamp,
+            timestamp_range,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::CHAIN_HASH_SIZE;
+    use super::*;
+
+    // Bitcoin mainnet genesis block hash
+    const BITCOIN_MAINNET: [u8; CHAIN_HASH_SIZE] = [
+        0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72, 0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7,
+        0x4f, 0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c, 0x68, 0xd6, 0x19, 0x00, 0x00, 0x00,
+        0x00, 0x00,
+    ];
+
+    #[test]
+    fn new_creates_filter() {
+        let filter = GossipTimestampFilter::new(BITCOIN_MAINNET, 1_000_000, 86400);
+        assert_eq!(filter.chain_hash, BITCOIN_MAINNET);
+        assert_eq!(filter.first_timestamp, 1_000_000);
+        assert_eq!(filter.timestamp_range, 86400);
+    }
+
+    #[test]
+    fn no_gossip_creates_no_gossip_filter() {
+        let filter = GossipTimestampFilter::no_gossip(BITCOIN_MAINNET);
+        assert_eq!(filter.chain_hash, BITCOIN_MAINNET);
+        assert_eq!(filter.first_timestamp, u32::MAX);
+        assert_eq!(filter.timestamp_range, 0);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let filter = GossipTimestampFilter::new(BITCOIN_MAINNET, 1_234_567, 1_209_600);
+        let encoded = filter.encode();
+        let decoded = GossipTimestampFilter::decode(&encoded).unwrap();
+        assert_eq!(filter, decoded);
+    }
+
+    #[test]
+    fn encode_no_gossip_filter() {
+        let filter = GossipTimestampFilter::no_gossip(BITCOIN_MAINNET);
+        let encoded = filter.encode();
+        assert_eq!(encoded.len(), 40);
+        assert_eq!(encoded[..CHAIN_HASH_SIZE], BITCOIN_MAINNET);
+        assert_eq!(encoded[32..36], u32::MAX.to_be_bytes());
+        assert_eq!(encoded[36..40], 0u32.to_be_bytes());
+    }
+
+    #[test]
+    fn decode_truncated_chain_hash() {
+        let data = [0x00u8; 20];
+        assert_eq!(
+            GossipTimestampFilter::decode(&data),
+            Err(BoltError::Truncated {
+                expected: CHAIN_HASH_SIZE,
+                actual: 20
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_first_timestamp() {
+        let data = [0x00u8; CHAIN_HASH_SIZE + 1];
+        assert_eq!(
+            GossipTimestampFilter::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 1
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_timestamp_range() {
+        let data = [0x00u8; CHAIN_HASH_SIZE + 6];
+        assert_eq!(
+            GossipTimestampFilter::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 2
+            })
+        );
+    }
+}


### PR DESCRIPTION
I saw https://github.com/morehouse/smite/issues/5#issuecomment-4101143436 and decided to add [`gossip_timestamp_filter`](https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#the-gossip_timestamp_filter-message) as a simple message to get started.

Things worth mentioning:

* Added helper functions for u32 similar to the existing ones for u16. When #7 is merged, I can rebase this to use the new `WireFormat` trait.
* Moved `CHAIN_HASH_SIZE` and `BITCOIN_MAINNET` from init.rs to types.rs so I can reuse them in gossip_timestamp_filter.rs. This creates a [small conflict](https://github.com/morehouse/smite/pull/7/changes#diff-f45231f82f4b67291619ee291d90dd387b8a293a56596aaf3d2a7368ab989556R16) with #7.
* I'm new to rust, and I've let [Composer 1.5](https://cursor.com/docs/models/cursor-composer-1-5) help me write this code. I made sure to keep the changes consistent with the existing code, and to only make small improvements like the move to types.rs (instead of letting it run wild).