### PR TITLE
smite: extract read_var_bytes for length-prefixed field decoding

### DIFF
--- a/smite/src/bolt/error.rs
+++ b/smite/src/bolt/error.rs
@@ -1,7 +1,7 @@
 //! BOLT 1 error message.
 
 use super::BoltError;
-use super::types::{ChannelId, MAX_MESSAGE_SIZE, read_u16_be, write_u16_be};
+use super::types::{ChannelId, MAX_MESSAGE_SIZE, read_var_bytes, write_u16_be};
 
 /// BOLT 1 error message (type 17).
 ///
@@ -72,19 +72,9 @@ impl Error {
     pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
         let mut cursor = payload;
         let channel_id = ChannelId::decode(&mut cursor)?;
-        let data_len = read_u16_be(&mut cursor)? as usize;
+        let data = read_var_bytes(&mut cursor)?;
 
-        if cursor.len() < data_len {
-            return Err(BoltError::Truncated {
-                expected: data_len,
-                actual: cursor.len(),
-            });
-        }
-
-        Ok(Self {
-            channel_id,
-            data: cursor[..data_len].to_vec(),
-        })
+        Ok(Self { channel_id, data })
     }
 
     /// Returns data as a string if it's valid UTF-8.

--- a/smite/src/bolt/init.rs
+++ b/smite/src/bolt/init.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::{read_u16_be, write_u16_be};
+use super::types::{read_var_bytes, write_u16_be};
 
 /// TLV type for chain hash list.
 const TLV_NETWORKS: u64 = 1;
@@ -108,26 +108,10 @@ impl Init {
         let mut cursor = payload;
 
         // Decode globalfeatures
-        let gflen = read_u16_be(&mut cursor)? as usize;
-        if cursor.len() < gflen {
-            return Err(BoltError::Truncated {
-                expected: gflen,
-                actual: cursor.len(),
-            });
-        }
-        let globalfeatures = cursor[..gflen].to_vec();
-        cursor = &cursor[gflen..];
+        let globalfeatures = read_var_bytes(&mut cursor)?;
 
         // Decode features
-        let flen = read_u16_be(&mut cursor)? as usize;
-        if cursor.len() < flen {
-            return Err(BoltError::Truncated {
-                expected: flen,
-                actual: cursor.len(),
-            });
-        }
-        let features = cursor[..flen].to_vec();
-        cursor = &cursor[flen..];
+        let features = read_var_bytes(&mut cursor)?;
 
         // Decode TLVs (remaining bytes)
         // Init TLVs are all odd (1, 3), so no known even types

--- a/smite/src/bolt/ping.rs
+++ b/smite/src/bolt/ping.rs
@@ -1,7 +1,7 @@
 //! BOLT 1 ping message.
 
 use super::BoltError;
-use super::types::{read_u16_be, write_u16_be};
+use super::types::{read_u16_be, read_var_bytes, write_u16_be};
 
 /// BOLT 1 ping message (type 18).
 ///
@@ -52,18 +52,11 @@ impl Ping {
     pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
         let mut cursor = payload;
         let num_pong_bytes = read_u16_be(&mut cursor)?;
-        let byteslen = read_u16_be(&mut cursor)? as usize;
-
-        if cursor.len() < byteslen {
-            return Err(BoltError::Truncated {
-                expected: byteslen,
-                actual: cursor.len(),
-            });
-        }
+        let ignored = read_var_bytes(&mut cursor)?;
 
         Ok(Self {
             num_pong_bytes,
-            ignored: cursor[..byteslen].to_vec(),
+            ignored,
         })
     }
 }

--- a/smite/src/bolt/pong.rs
+++ b/smite/src/bolt/pong.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::ping::Ping;
-use super::types::{read_u16_be, write_u16_be};
+use super::types::{read_var_bytes, write_u16_be};
 
 /// BOLT 1 pong message (type 19).
 ///
@@ -45,18 +45,9 @@ impl Pong {
     /// Returns `Truncated` if the payload is too short.
     pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
         let mut cursor = payload;
-        let byteslen = read_u16_be(&mut cursor)? as usize;
+        let ignored = read_var_bytes(&mut cursor)?;
 
-        if cursor.len() < byteslen {
-            return Err(BoltError::Truncated {
-                expected: byteslen,
-                actual: cursor.len(),
-            });
-        }
-
-        Ok(Self {
-            ignored: cursor[..byteslen].to_vec(),
-        })
+        Ok(Self { ignored })
     }
 }
 

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -164,6 +164,24 @@ pub fn read_u16_be(data: &mut &[u8]) -> Result<u16, BoltError> {
     Ok(value)
 }
 
+/// Reads a `[u16:len][len*byte]` variable-length field, advancing past both.
+///
+/// # Errors
+///
+/// Returns `Truncated` if there are fewer bytes than the declared length.
+pub fn read_var_bytes(data: &mut &[u8]) -> Result<Vec<u8>, BoltError> {
+    let len = read_u16_be(data)? as usize;
+    if data.len() < len {
+        return Err(BoltError::Truncated {
+            expected: len,
+            actual: data.len(),
+        });
+    }
+    let bytes = data[..len].to_vec();
+    *data = &data[len..];
+    Ok(bytes)
+}
+
 /// Writes a u16 big-endian to a vector.
 pub fn write_u16_be(value: u16, out: &mut Vec<u8>) {
     out.extend_from_slice(&value.to_be_bytes());
@@ -322,6 +340,54 @@ mod tests {
             Err(BoltError::Truncated {
                 expected: 2,
                 actual: 1
+            })
+        );
+    }
+
+    #[test]
+    fn read_var_bytes_empty_field() {
+        let mut data: &[u8] = &[0x00, 0x00];
+        let result = read_var_bytes(&mut data).unwrap();
+        assert_eq!(result, Vec::<u8>::new());
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn read_var_bytes_valid() {
+        let mut data: &[u8] = &[0x00, 0x03, 0xaa, 0xbb, 0xcc];
+        let result = read_var_bytes(&mut data).unwrap();
+        assert_eq!(result, vec![0xaa, 0xbb, 0xcc]);
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn read_var_bytes_advances_cursor() {
+        let mut data: &[u8] = &[0x00, 0x02, 0xaa, 0xbb, 0xff, 0xff];
+        let result = read_var_bytes(&mut data).unwrap();
+        assert_eq!(result, vec![0xaa, 0xbb]);
+        assert_eq!(data, &[0xff, 0xff]);
+    }
+
+    #[test]
+    fn read_var_bytes_truncated_length() {
+        let mut data: &[u8] = &[0x00];
+        assert_eq!(
+            read_var_bytes(&mut data),
+            Err(BoltError::Truncated {
+                expected: 2,
+                actual: 1
+            })
+        );
+    }
+
+    #[test]
+    fn read_var_bytes_truncated_data() {
+        let mut data: &[u8] = &[0x00, 0x05, 0xaa, 0xbb];
+        assert_eq!(
+            read_var_bytes(&mut data),
+            Err(BoltError::Truncated {
+                expected: 5,
+                actual: 2
             })
         );
     }

--- a/smite/src/bolt/warning.rs
+++ b/smite/src/bolt/warning.rs
@@ -1,7 +1,7 @@
 //! BOLT 1 warning message.
 
 use super::BoltError;
-use super::types::{ChannelId, MAX_MESSAGE_SIZE, read_u16_be, write_u16_be};
+use super::types::{ChannelId, MAX_MESSAGE_SIZE, read_var_bytes, write_u16_be};
 
 /// BOLT 1 warning message (type 1).
 ///
@@ -72,19 +72,9 @@ impl Warning {
     pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
         let mut cursor = payload;
         let channel_id = ChannelId::decode(&mut cursor)?;
-        let data_len = read_u16_be(&mut cursor)? as usize;
+        let data = read_var_bytes(&mut cursor)?;
 
-        if cursor.len() < data_len {
-            return Err(BoltError::Truncated {
-                expected: data_len,
-                actual: cursor.len(),
-            });
-        }
-
-        Ok(Self {
-            channel_id,
-            data: cursor[..data_len].to_vec(),
-        })
+        Ok(Self { channel_id, data })
     }
 
     /// Returns data as a string if it's valid UTF-8.


### PR DESCRIPTION
Add a `read_var_bytes` helper in `types.rs` that decodes the `[u16:len][len*byte]` pattern used across BOLT message payloads. This replaces 7 duplicate read-validate-copy blocks in `init`, `ping`, `pong`, `shutdown`, `error`, and `warning` decoders.