### PR TITLE
smite-scenarios: deconstruct `connect_to_target`

### DIFF
--- a/smite-scenarios/src/scenarios.rs
+++ b/smite-scenarios/src/scenarios.rs
@@ -28,16 +28,19 @@ const EPHEMERAL_KEY: [u8; 32] = [
     0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12,
 ];
 
-/// Connect to a target and perform the init handshake.
+/// Perform a Noise handshake with a target and receive its `Init` message.
+///
+/// Returns the encrypted connection and the target's `Init`. The caller is
+/// responsible for sending its own `Init` response (e.g., via `Init::echo`).
 ///
 /// # Errors
 ///
-/// Returns an error if connection, handshake, or init exchange fails.
+/// Returns an error if connection, handshake, or init receive fails.
 #[allow(clippy::missing_panics_doc)] // Static keys are known-valid constants
-pub fn connect_to_target<T: Target>(
+pub fn handshake_with_target<T: Target>(
     target: &T,
     timeout: Duration,
-) -> Result<NoiseConnection, ScenarioError> {
+) -> Result<(NoiseConnection, Init), ScenarioError> {
     let local_static = SecretKey::from_byte_array(STATIC_KEY).expect("valid static key");
     let local_ephemeral = SecretKey::from_byte_array(EPHEMERAL_KEY).expect("valid ephemeral key");
 
@@ -55,14 +58,9 @@ pub fn connect_to_target<T: Target>(
         return Err(ScenarioError::Protocol("expected init message".into()));
     };
 
-    // Echo features back, removing TLVs
-    let init = Init::echo(&init);
-    let encoded = Message::Init(init).encode();
-    conn.send_message(&encoded)?;
+    log::debug!("Handshake complete, received target init");
 
-    log::debug!("Connected to target, init exchange complete");
-
-    Ok(conn)
+    Ok((conn, init))
 }
 
 /// Send ping and wait for pong (for synchronization).

--- a/smite-scenarios/src/scenarios/encrypted_bytes.rs
+++ b/smite-scenarios/src/scenarios/encrypted_bytes.rs
@@ -2,10 +2,11 @@
 
 use std::time::Duration;
 
+use smite::bolt::{Init, Message};
 use smite::noise::NoiseConnection;
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
 
-use super::{connect_to_target, ping_pong};
+use super::{handshake_with_target, ping_pong};
 use crate::targets::Target;
 
 /// A scenario that sends raw fuzz input as Lightning messages.
@@ -22,7 +23,9 @@ impl<T: Target> Scenario for EncryptedBytesScenario<T> {
     fn new(_args: &[String]) -> Result<Self, ScenarioError> {
         let config = T::Config::default();
         let target = T::start(config)?;
-        let mut conn = connect_to_target(&target, Duration::from_secs(5))?;
+        let (mut conn, target_init) = handshake_with_target(&target, Duration::from_secs(5))?;
+        let echo = Message::Init(Init::echo(&target_init)).encode();
+        conn.send_message(&echo)?;
 
         // Warm up the target's message handling path before the Nyx snapshot.
         // For JVM-based targets (i.e. Eclair), this  causes the necessary

--- a/smite-scenarios/src/scenarios/init.rs
+++ b/smite-scenarios/src/scenarios/init.rs
@@ -2,13 +2,12 @@
 
 use std::time::Duration;
 
-use secp256k1::SecretKey;
 use smite::bolt;
-use smite::bolt::Message;
+use smite::bolt::{Init, Message};
 use smite::noise::{MAX_MESSAGE_SIZE, NoiseConnection};
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
 
-use super::{EPHEMERAL_KEY, STATIC_KEY, connect_to_target, ping_pong};
+use super::{handshake_with_target, ping_pong};
 use crate::targets::Target;
 
 /// Timeout for connection and message operations.
@@ -37,27 +36,15 @@ impl<T: Target> Scenario for InitScenario<T> {
         // Establish a warmup connection for ping-pong. This warms up the
         // target's message handling code paths before the Nyx snapshot
         // (important for JVM targets like Eclair).
-        let mut warmup_conn = connect_to_target(&target, TIMEOUT)?;
+        let (mut warmup_conn, target_init) = handshake_with_target(&target, TIMEOUT)?;
+        let echo = Message::Init(Init::echo(&target_init)).encode();
+        warmup_conn.send_message(&echo)?;
         ping_pong(&mut warmup_conn)?;
         drop(warmup_conn);
 
         // Establish the fuzz connection, complete the handshake, and receive
         // the target's init.
-        let local_static = SecretKey::from_byte_array(STATIC_KEY).expect("valid static key");
-        let local_ephemeral =
-            SecretKey::from_byte_array(EPHEMERAL_KEY).expect("valid ephemeral key");
-        let mut conn = NoiseConnection::connect(
-            target.addr(),
-            *target.pubkey(),
-            local_static,
-            local_ephemeral,
-            TIMEOUT,
-        )?;
-
-        let init_bytes = conn.recv_message()?;
-        let Message::Init(_) = Message::decode(&init_bytes)? else {
-            return Err(ScenarioError::Protocol("expected init message".into()));
-        };
+        let (conn, _) = handshake_with_target(&target, TIMEOUT)?;
 
         Ok(Self { target, conn })
     }

--- a/smite-scenarios/src/scenarios/noise.rs
+++ b/smite-scenarios/src/scenarios/noise.rs
@@ -11,7 +11,7 @@ use smite::noise::{
 };
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
 
-use super::{EPHEMERAL_KEY, connect_to_target, ping_pong};
+use super::{EPHEMERAL_KEY, handshake_with_target, ping_pong};
 use crate::targets::Target;
 
 /// Timeout for normal TCP operations during handshake setup (Act 2 recv, etc.).
@@ -232,7 +232,9 @@ impl<T: Target> Scenario for NoiseScenario<T> {
         // Establish a connection for ping-pong synchronization. This also warms
         // up the target's message handling code paths before the Nyx snapshot,
         // improving fuzzing efficiency for JVM targets.
-        let mut sync_conn = connect_to_target(&target, TIMEOUT)?;
+        let (mut sync_conn, target_init) = handshake_with_target(&target, TIMEOUT)?;
+        let echo = Message::Init(Init::echo(&target_init)).encode();
+        sync_conn.send_message(&echo)?;
         ping_pong(&mut sync_conn)?;
 
         // Establish the fuzz connection that will be snapshotted in its


### PR DESCRIPTION
Rename `connect_to_target` to `handshake_with_target`, and no longer echo back the received `init` message.  This change has two motivations:

- Enabling future scenarios to customize the `init` message sent to the target.
- Enabling the future `IrScenario` to save the target's `init` features in the `ProgramContext`.