### PR TITLE
smite-ir: implement `OpenChannelGenerator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -370,7 +379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -381,6 +390,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rustix"
@@ -402,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand",
+ "rand 0.9.2",
  "secp256k1-sys",
 ]
 
@@ -505,6 +520,7 @@ name = "smite-ir"
 version = "0.0.0"
 dependencies = [
  "postcard",
+ "rand 0.10.0",
  "secp256k1",
  "serde",
  "smite",

--- a/smite-ir/Cargo.toml
+++ b/smite-ir/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 smite = { path = "../smite" }
+rand = { version = "0.10", default-features = false }
 serde.workspace = true
 postcard.workspace = true
 secp256k1.workspace = true

--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -44,7 +44,35 @@ impl ProgramBuilder {
 
     /// Appends an instruction and registers its output variable (if any) as a
     /// candidate. Returns the instruction index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inputs have the wrong count, reference out-of-bounds or
+    /// void instructions, or have mismatched types.
     pub fn append(&mut self, operation: Operation, inputs: &[usize]) -> usize {
+        let expected = operation.input_types();
+        assert_eq!(
+            inputs.len(),
+            expected.len(),
+            "{operation:?}: expected {} inputs, got {}",
+            expected.len(),
+            inputs.len(),
+        );
+        let len = self.instructions.len();
+        for (i, (&input_idx, &expected_type)) in inputs.iter().zip(expected.iter()).enumerate() {
+            let actual_type = self
+                .instructions
+                .get(input_idx)
+                .and_then(|instr| instr.operation.output_type())
+                .unwrap_or_else(|| {
+                    panic!("{operation:?} input {i}: index {input_idx} out of bounds ({len})")
+                });
+            assert_eq!(
+                actual_type, expected_type,
+                "{operation:?} input {i}: expected {expected_type:?}, got {actual_type:?}",
+            );
+        }
+
         let idx = self.instructions.len();
 
         if let Some(out_type) = operation.output_type() {

--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -1,0 +1,171 @@
+//! Program builder for generators.
+//!
+//! `ProgramBuilder` maintains an instruction list and a type-indexed variable
+//! registry. Generators call builder methods to emit instructions -- they never
+//! manipulate instruction indices directly.
+
+use std::collections::HashMap;
+
+use rand::{Rng, RngExt};
+
+use super::{Instruction, Operation, Program, ProgramContext, VariableType};
+
+/// A candidate variable that can satisfy a type request.
+#[derive(Debug, Clone)]
+enum Candidate {
+    /// Variable at this instruction index is directly usable.
+    Direct(usize),
+    /// A field can be extracted from a compound variable.
+    Extract {
+        /// Instruction index of the compound variable.
+        compound_idx: usize,
+        /// The operation required to extract the field.
+        operation: Operation,
+    },
+}
+
+/// Builds an IR program by appending instructions and tracking available
+/// variables by type.
+pub struct ProgramBuilder {
+    instructions: Vec<Instruction>,
+    /// Candidate variables indexed by output type.
+    candidates: HashMap<VariableType, Vec<Candidate>>,
+}
+
+impl ProgramBuilder {
+    /// Creates an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            instructions: Vec::new(),
+            candidates: HashMap::new(),
+        }
+    }
+
+    /// Appends an instruction and registers its output variable (if any) as a
+    /// candidate. Returns the instruction index.
+    pub fn append(&mut self, operation: Operation, inputs: &[usize]) -> usize {
+        let idx = self.instructions.len();
+
+        if let Some(out_type) = operation.output_type() {
+            // Register extractable fields for compound types.
+            for (extract_op, field_type) in operation.extractable_fields() {
+                self.candidates
+                    .entry(field_type)
+                    .or_default()
+                    .push(Candidate::Extract {
+                        compound_idx: idx,
+                        operation: extract_op,
+                    });
+            }
+
+            self.candidates
+                .entry(out_type)
+                .or_default()
+                .push(Candidate::Direct(idx));
+        }
+
+        self.instructions.push(Instruction {
+            operation,
+            inputs: inputs.to_vec(),
+        });
+
+        idx
+    }
+
+    /// Selects or creates a variable of the given type using probabilistic
+    /// variable selection (75% most recent, 15% any existing, 10% fresh).
+    #[allow(clippy::missing_panics_doc)] // candidates is always non-empty
+    pub fn pick_variable(&mut self, var_type: VariableType, rng: &mut impl Rng) -> usize {
+        let Some(candidates) = self.candidates.get(&var_type) else {
+            return self.generate_fresh(var_type, rng);
+        };
+
+        let roll = rng.random_range(0..20);
+        match roll {
+            // 10%: generate a fresh value even though candidates exist.
+            0..=1 => self.generate_fresh(var_type, rng),
+            // 15%: pick any existing candidate.
+            2..=4 => {
+                let i = rng.random_range(0..candidates.len());
+                let candidate = candidates[i].clone();
+                self.resolve_candidate(candidate)
+            }
+            // 75%: pick the most recent candidate.
+            _ => {
+                let candidate = candidates.last().expect("non-empty").clone();
+                self.resolve_candidate(candidate)
+            }
+        }
+    }
+
+    /// Emits instructions that produce a fresh value of the given type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `var_type` is `Message` (requires composed inputs) or
+    /// `AcceptChannel` (requires protocol interaction).
+    pub fn generate_fresh(&mut self, var_type: VariableType, rng: &mut impl Rng) -> usize {
+        match var_type {
+            VariableType::Amount => self.append(Operation::LoadAmount(rng.random()), &[]),
+            VariableType::FeeratePerKw => {
+                self.append(Operation::LoadFeeratePerKw(rng.random()), &[])
+            }
+            VariableType::BlockHeight => self.append(Operation::LoadBlockHeight(rng.random()), &[]),
+            VariableType::U16 => self.append(Operation::LoadU16(rng.random()), &[]),
+            VariableType::U8 => self.append(Operation::LoadU8(rng.random()), &[]),
+            VariableType::Bytes => {
+                let len = rng.random_range(0..=256);
+                let mut bytes = vec![0u8; len];
+                rng.fill(&mut bytes[..]);
+                self.append(Operation::LoadBytes(bytes), &[])
+            }
+            VariableType::Features => {
+                let len = rng.random_range(0..=16);
+                let mut bytes = vec![0u8; len];
+                rng.fill(&mut bytes[..]);
+                self.append(Operation::LoadFeatures(bytes), &[])
+            }
+            VariableType::PrivateKey => self.append(Operation::LoadPrivateKey(rng.random()), &[]),
+            VariableType::ChannelId => self.append(Operation::LoadChannelId(rng.random()), &[]),
+            VariableType::ChainHash => self.append(Operation::LoadChainHashFromContext, &[]),
+            VariableType::Point => {
+                let sk_idx = self.generate_fresh(VariableType::PrivateKey, rng);
+                self.append(Operation::DerivePoint, &[sk_idx])
+            }
+            VariableType::Message => {
+                panic!("cannot generate fresh Message: requires composed inputs")
+            }
+            VariableType::AcceptChannel => {
+                panic!("cannot generate fresh AcceptChannel: requires protocol interaction")
+            }
+        }
+    }
+
+    /// Builds the final program from the accumulated instructions.
+    #[must_use]
+    pub fn build(self, context: ProgramContext) -> Program {
+        Program {
+            instructions: self.instructions,
+            context,
+        }
+    }
+
+    /// Resolves a candidate to a variable index, inserting an Extract
+    /// instruction if needed.
+    fn resolve_candidate(&mut self, candidate: Candidate) -> usize {
+        match candidate {
+            Candidate::Direct(idx) => idx,
+            Candidate::Extract {
+                compound_idx,
+                operation,
+            } => self.append(operation, &[compound_idx]),
+        }
+    }
+}
+
+impl Default for ProgramBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -1,0 +1,20 @@
+//! IR program generators.
+//!
+//! Generators produce type-correct instruction sequences that represent
+//! interesting protocol interactions. Each generator knows the *shape* of a
+//! protocol flow but delegates value selection and variable reuse to
+//! `ProgramBuilder`.
+
+mod open_channel;
+
+pub use open_channel::OpenChannelGenerator;
+
+use rand::Rng;
+
+use super::builder::ProgramBuilder;
+
+/// A generator that emits instructions into a `ProgramBuilder`.
+pub trait Generator {
+    /// Emits instructions for this generator's protocol interaction.
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng);
+}

--- a/smite-ir/src/generators/open_channel.rs
+++ b/smite-ir/src/generators/open_channel.rs
@@ -1,0 +1,74 @@
+//! Generator for `open_channel` message flow.
+
+use rand::Rng;
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::{Operation, VariableType};
+
+/// Generates an `open_channel` -> `accept_channel` flow.
+///
+/// Emits instructions to:
+/// 1. Generate channel parameters
+/// 2. Build and send `open_channel`
+/// 3. Receive and parse `accept_channel`
+pub struct OpenChannelGenerator;
+
+impl Generator for OpenChannelGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        // Public keys are generated fresh to ensure they're distinct.
+        let funding_pubkey = builder.generate_fresh(VariableType::Point, rng);
+        let revocation_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let payment_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let delayed_payment_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let htlc_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let first_per_commitment_point = builder.generate_fresh(VariableType::Point, rng);
+
+        // Channel parameters.
+        let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
+        let temporary_channel_id = builder.pick_variable(VariableType::ChannelId, rng);
+        let funding_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let push_msat = builder.pick_variable(VariableType::Amount, rng);
+        let dust_limit_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let max_htlc_value_in_flight_msat = builder.pick_variable(VariableType::Amount, rng);
+        let channel_reserve_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let htlc_minimum_msat = builder.pick_variable(VariableType::Amount, rng);
+        let feerate_per_kw = builder.pick_variable(VariableType::FeeratePerKw, rng);
+        let to_self_delay = builder.pick_variable(VariableType::U16, rng);
+        let max_accepted_htlcs = builder.pick_variable(VariableType::U16, rng);
+        let channel_flags = builder.pick_variable(VariableType::U8, rng);
+        let upfront_shutdown_script = builder.pick_variable(VariableType::Bytes, rng);
+        let channel_type = builder.pick_variable(VariableType::Features, rng);
+
+        // Build and send open_channel.
+        let msg = builder.append(
+            Operation::BuildOpenChannel,
+            &[
+                chain_hash,
+                temporary_channel_id,
+                funding_satoshis,
+                push_msat,
+                dust_limit_satoshis,
+                max_htlc_value_in_flight_msat,
+                channel_reserve_satoshis,
+                htlc_minimum_msat,
+                feerate_per_kw,
+                to_self_delay,
+                max_accepted_htlcs,
+                funding_pubkey,
+                revocation_basepoint,
+                payment_basepoint,
+                delayed_payment_basepoint,
+                htlc_basepoint,
+                first_per_commitment_point,
+                channel_flags,
+                upfront_shutdown_script,
+                channel_type,
+            ],
+        );
+        builder.append(Operation::SendMessage, &[msg]);
+
+        // Receive accept_channel.
+        builder.append(Operation::RecvAcceptChannel, &[]);
+    }
+}

--- a/smite-ir/src/lib.rs
+++ b/smite-ir/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod builder;
 pub mod context;
+pub mod generators;
 pub mod instruction;
 pub mod operation;
 pub mod program;
@@ -14,6 +15,7 @@ pub mod variable;
 
 pub use builder::ProgramBuilder;
 pub use context::ProgramContext;
+pub use generators::Generator;
 pub use instruction::Instruction;
 pub use operation::Operation;
 pub use program::Program;

--- a/smite-ir/src/lib.rs
+++ b/smite-ir/src/lib.rs
@@ -5,12 +5,14 @@
 //! and transform structured fuzzing programs.  It is engine-agnostic -- no
 //! dependency on AFL++ or `LibAFL`.
 
+pub mod builder;
 pub mod context;
 pub mod instruction;
 pub mod operation;
 pub mod program;
 pub mod variable;
 
+pub use builder::ProgramBuilder;
 pub use context::ProgramContext;
 pub use instruction::Instruction;
 pub use operation::Operation;

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -107,6 +107,26 @@ impl fmt::Display for AcceptChannelField {
 }
 
 impl AcceptChannelField {
+    /// All variants. Keep in sync with the enum definition.
+    pub const ALL: &[Self] = &[
+        Self::TemporaryChannelId,
+        Self::DustLimitSatoshis,
+        Self::MaxHtlcValueInFlightMsat,
+        Self::ChannelReserveSatoshis,
+        Self::HtlcMinimumMsat,
+        Self::MinimumDepth,
+        Self::ToSelfDelay,
+        Self::MaxAcceptedHtlcs,
+        Self::FundingPubkey,
+        Self::RevocationBasepoint,
+        Self::PaymentBasepoint,
+        Self::DelayedPaymentBasepoint,
+        Self::HtlcBasepoint,
+        Self::FirstPerCommitmentPoint,
+        Self::UpfrontShutdownScript,
+        Self::ChannelType,
+    ];
+
     /// Returns the variable type produced by extracting this field.
     #[must_use]
     pub fn output_type(self) -> VariableType {
@@ -238,6 +258,22 @@ impl Operation {
                 VariableType::Bytes,        // upfront_shutdown_script
                 VariableType::Features,     // channel_type
             ],
+        }
+    }
+
+    /// Returns extraction operations for compound variable types.
+    ///
+    /// For example, `RecvAcceptChannel` produces an `AcceptChannel` compound
+    /// variable, so this returns `ExtractAcceptChannel` operations for each
+    /// field.  Non-compound operations return an empty vec.
+    #[must_use]
+    pub fn extractable_fields(&self) -> Vec<(Operation, VariableType)> {
+        match self {
+            Self::RecvAcceptChannel => AcceptChannelField::ALL
+                .iter()
+                .map(|&f| (Self::ExtractAcceptChannel(f), f.output_type()))
+                .collect(),
+            _ => vec![],
         }
     }
 

--- a/smite-ir/src/program.rs
+++ b/smite-ir/src/program.rs
@@ -11,6 +11,9 @@ use super::instruction::Instruction;
 ///
 /// Programs are serialized with postcard for transport between the AFL++ custom
 /// mutator and the scenario executor.
+// TODO: add `validate` method for mutators to check deserialized programs
+// before mutation. Invalid programs should be rejected so that we don't panic
+// when modifying and rebuilding them via `ProgramBuilder`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Program {
     /// Instructions in SSA order.

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -242,3 +242,35 @@ fn postcard_roundtrip() {
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);
 }
+
+// Ensure AcceptChannelField and AcceptChannelField::ALL stay in sync. The
+// exhaustive match in this test will fail to compile if a variant is added
+// without updating it, and the assertion will fail if the match is updated
+// without updating AcceptChannelField::ALL.
+#[test]
+fn accept_channel_field_all_is_complete() {
+    let variant_count = |f: AcceptChannelField| -> usize {
+        match f {
+            AcceptChannelField::TemporaryChannelId
+            | AcceptChannelField::DustLimitSatoshis
+            | AcceptChannelField::MaxHtlcValueInFlightMsat
+            | AcceptChannelField::ChannelReserveSatoshis
+            | AcceptChannelField::HtlcMinimumMsat
+            | AcceptChannelField::MinimumDepth
+            | AcceptChannelField::ToSelfDelay
+            | AcceptChannelField::MaxAcceptedHtlcs
+            | AcceptChannelField::FundingPubkey
+            | AcceptChannelField::RevocationBasepoint
+            | AcceptChannelField::PaymentBasepoint
+            | AcceptChannelField::DelayedPaymentBasepoint
+            | AcceptChannelField::HtlcBasepoint
+            | AcceptChannelField::FirstPerCommitmentPoint
+            | AcceptChannelField::UpfrontShutdownScript
+            | AcceptChannelField::ChannelType => 16,
+        }
+    };
+    assert_eq!(
+        AcceptChannelField::ALL.len(),
+        variant_count(AcceptChannelField::ALL[0]),
+    );
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1,6 +1,10 @@
 //! Tests for IR types.
 
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
 use super::*;
+use generators::OpenChannelGenerator;
 use operation::AcceptChannelField;
 
 /// Helper to build a private key with a single distinguishing byte.
@@ -273,4 +277,156 @@ fn accept_channel_field_all_is_complete() {
         AcceptChannelField::ALL.len(),
         variant_count(AcceptChannelField::ALL[0]),
     );
+}
+
+fn generate_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    builder.build(sample_context())
+}
+
+// If OpenChannelGenerator completes without panicking, every instruction has
+// correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_program(seed);
+    }
+}
+
+#[test]
+fn generated_program_structure() {
+    let program = generate_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    // Must end with SendMessage, RecvAcceptChannel.
+    assert!(
+        matches!(ops[ops.len() - 2], Operation::SendMessage),
+        "second-to-last instruction should be SendMessage",
+    );
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::RecvAcceptChannel),
+        "last instruction should be RecvAcceptChannel",
+    );
+
+    // At least one BuildOpenChannel.
+    assert!(
+        ops.iter()
+            .any(|op| matches!(op, Operation::BuildOpenChannel)),
+        "expected at least one BuildOpenChannel",
+    );
+
+    // At least 6 DerivePoint instructions (fresh basepoints).
+    let derive_count = program
+        .instructions
+        .iter()
+        .filter(|i| matches!(i.operation, Operation::DerivePoint))
+        .count();
+    assert!(
+        derive_count >= 6,
+        "expected at least 6 DerivePoint, got {derive_count}"
+    );
+}
+
+#[test]
+fn generated_program_postcard_roundtrip() {
+    let program = generate_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generate_fresh_produces_distinct_indices() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    let a = builder.generate_fresh(VariableType::Amount, &mut rng);
+    let b = builder.generate_fresh(VariableType::Amount, &mut rng);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn pick_variable_reuses_existing() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+
+    // Generate one Amount variable.
+    let first = builder.generate_fresh(VariableType::Amount, &mut rng);
+
+    // pick_variable should mostly reuse the existing variable. Over 100 calls,
+    // at least some should return the original index.
+    let mut reuse_count = 0;
+    for _ in 0..100 {
+        let idx = builder.pick_variable(VariableType::Amount, &mut rng);
+        if idx == first {
+            reuse_count += 1;
+        }
+    }
+    assert!(
+        reuse_count > 0,
+        "pick_variable never reused existing variable"
+    );
+}
+
+#[test]
+#[should_panic(expected = "cannot generate fresh Message")]
+fn generate_fresh_message_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    builder.generate_fresh(VariableType::Message, &mut rng);
+}
+
+#[test]
+#[should_panic(expected = "cannot generate fresh AcceptChannel")]
+fn generate_fresh_accept_channel_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    builder.generate_fresh(VariableType::AcceptChannel, &mut rng);
+}
+
+#[test]
+#[should_panic(expected = "expected 1 inputs, got 0")]
+fn append_wrong_input_count_panics() {
+    let mut builder = ProgramBuilder::new();
+    builder.append(Operation::DerivePoint, &[]);
+}
+
+#[test]
+#[should_panic(expected = "index 99 out of bounds")]
+fn append_out_of_bounds_panics() {
+    let mut builder = ProgramBuilder::new();
+    builder.append(Operation::DerivePoint, &[99]);
+}
+
+#[test]
+#[should_panic(expected = "out of bounds")]
+fn append_void_reference_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    let program = builder.build(sample_context());
+    // SendMessage is second-to-last and has void output.
+    let send_idx = program.instructions.len() - 2;
+    assert!(
+        program.instructions[send_idx]
+            .operation
+            .output_type()
+            .is_none(),
+        "expected void operation",
+    );
+    // Rebuild the same program and try to reference the void instruction.
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    builder.append(Operation::SendMessage, &[send_idx]);
+}
+
+#[test]
+#[should_panic(expected = "expected PrivateKey, got Amount")]
+fn append_type_mismatch_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    let amount = builder.generate_fresh(VariableType::Amount, &mut rng);
+    builder.append(Operation::DerivePoint, &[amount]);
 }


### PR DESCRIPTION
Adds the functionality needed to generate IR programs that exercise the `open_channel -> accept_channel` flow.

Key pieces:
- `ProgramBuilder` is the toolkit for building type-correct programs.
- `Generator` is the trait defining the generator interface.
- `OpenChannelGenerator` generates IR programs that build and sends `open_channel` messages, then wait for the `accept_channel` reply.

Ref: #5 (Milestone 1)