### PR TITLE
Codec for BOLT-07 gossip routing

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -4,11 +4,14 @@
 //! protocol messages as specified in the BOLT specifications.
 
 mod accept_channel;
+mod channel_announcement;
+mod channel_update;
 mod error;
 mod funding_created;
 mod funding_signed;
 mod gossip_timestamp_filter;
 mod init;
+mod node_announcement;
 mod open_channel;
 mod ping;
 mod pong;
@@ -23,11 +26,14 @@ mod warning;
 mod wire;
 
 pub use accept_channel::{AcceptChannel, AcceptChannelTlvs};
+pub use channel_announcement::ChannelAnnouncement;
+pub use channel_update::ChannelUpdate;
 pub use error::Error;
 pub use funding_created::FundingCreated;
 pub use funding_signed::FundingSigned;
 pub use gossip_timestamp_filter::GossipTimestampFilter;
 pub use init::{Init, InitTlvs};
+pub use node_announcement::NodeAnnouncement;
 pub use open_channel::{OpenChannel, OpenChannelTlvs};
 pub use ping::Ping;
 pub use pong::Pong;
@@ -38,7 +44,9 @@ pub use tx_complete::TxComplete;
 pub use tx_remove_input::TxRemoveInput;
 pub use tx_remove_output::TxRemoveOutput;
 pub use types::{
-    BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, MAX_MESSAGE_SIZE, TXID_SIZE, Txid,
+    BigSize, CHAIN_HASH_SIZE, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChainHash, ChannelId,
+    MAX_MESSAGE_SIZE, NODE_ID_SIZE, NodeId, SIGNATURE_SIZE, ShortChannelId, Signature, TXID_SIZE,
+    Txid,
 };
 pub use warning::Warning;
 pub use wire::WireFormat;
@@ -126,6 +134,12 @@ pub mod msg_type {
     pub const TX_COMPLETE: u16 = 70;
     /// `tx_abort` message (BOLT 2).
     pub const TX_ABORT: u16 = 74;
+    /// `channel_announcement` message (BOLT 7).
+    pub const CHANNEL_ANNOUNCEMENT: u16 = 256;
+    /// `node_announcement` message (BOLT 7).
+    pub const NODE_ANNOUNCEMENT: u16 = 257;
+    /// `channel_update` message (BOLT 7).
+    pub const CHANNEL_UPDATE: u16 = 258;
     /// Gossip timestamp filter message (BOLT 7).
     pub const GOSSIP_TIMESTAMP_FILTER: u16 = 265;
 }
@@ -162,6 +176,12 @@ pub enum Message {
     TxComplete(TxComplete),
     /// `tx_abort` message (type 74).
     TxAbort(TxAbort),
+    /// `channel_announcement` message (type 256).
+    ChannelAnnouncement(ChannelAnnouncement),
+    /// `node_announcement` message (type 257).
+    NodeAnnouncement(NodeAnnouncement),
+    /// `channel_update` message (type 258).
+    ChannelUpdate(ChannelUpdate),
     /// Gossip timestamp filter message (type 265).
     GossipTimestampFilter(GossipTimestampFilter),
     /// Unknown message type.
@@ -195,6 +215,9 @@ impl Message {
             Self::TxRemoveOutput(_) => msg_type::TX_REMOVE_OUTPUT,
             Self::TxComplete(_) => msg_type::TX_COMPLETE,
             Self::TxAbort(_) => msg_type::TX_ABORT,
+            Self::ChannelAnnouncement(_) => msg_type::CHANNEL_ANNOUNCEMENT,
+            Self::NodeAnnouncement(_) => msg_type::NODE_ANNOUNCEMENT,
+            Self::ChannelUpdate(_) => msg_type::CHANNEL_UPDATE,
             Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => *msg_type,
         }
@@ -220,6 +243,9 @@ impl Message {
             Self::TxRemoveOutput(m) => out.extend(m.encode()),
             Self::TxComplete(m) => out.extend(m.encode()),
             Self::TxAbort(m) => out.extend(m.encode()),
+            Self::ChannelAnnouncement(m) => out.extend(m.encode()),
+            Self::NodeAnnouncement(m) => out.extend(m.encode()),
+            Self::ChannelUpdate(m) => out.extend(m.encode()),
             Self::GossipTimestampFilter(m) => out.extend(m.encode()),
             Self::Unknown { payload, .. } => out.extend(payload),
         }
@@ -252,6 +278,13 @@ impl Message {
             msg_type::TX_REMOVE_OUTPUT => Ok(Self::TxRemoveOutput(TxRemoveOutput::decode(cursor)?)),
             msg_type::TX_COMPLETE => Ok(Self::TxComplete(TxComplete::decode(cursor)?)),
             msg_type::TX_ABORT => Ok(Self::TxAbort(TxAbort::decode(cursor)?)),
+            msg_type::CHANNEL_ANNOUNCEMENT => {
+                Ok(Self::ChannelAnnouncement(ChannelAnnouncement::decode(cursor)?))
+            }
+            msg_type::NODE_ANNOUNCEMENT => {
+                Ok(Self::NodeAnnouncement(NodeAnnouncement::decode(cursor)?))
+            }
+            msg_type::CHANNEL_UPDATE => Ok(Self::ChannelUpdate(ChannelUpdate::decode(cursor)?)),
             msg_type::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
                 GossipTimestampFilter::decode(cursor)?,
             )),
@@ -445,6 +478,60 @@ mod tests {
         }
     }
 
+    /// Valid `ChannelAnnouncement` message for testing.
+    fn sample_channel_announcement() -> ChannelAnnouncement {
+        ChannelAnnouncement {
+            node_signature_1: Signature::new([0x01; SIGNATURE_SIZE]),
+            node_signature_2: Signature::new([0x02; SIGNATURE_SIZE]),
+            bitcoin_signature_1: Signature::new([0x03; SIGNATURE_SIZE]),
+            bitcoin_signature_2: Signature::new([0x04; SIGNATURE_SIZE]),
+            features: vec![0x80, 0x00],
+            chain_hash: ChainHash::new([0xaa; CHAIN_HASH_SIZE]),
+            short_channel_id: ShortChannelId::new(0x0001_0002_0003),
+            node_id_1: NodeId::new([0x02; NODE_ID_SIZE]),
+            node_id_2: NodeId::new([0x03; NODE_ID_SIZE]),
+            bitcoin_key_1: NodeId::new([0x04; NODE_ID_SIZE]),
+            bitcoin_key_2: NodeId::new([0x05; NODE_ID_SIZE]),
+        }
+    }
+
+    /// Valid `NodeAnnouncement` message for testing.
+    fn sample_node_announcement() -> NodeAnnouncement {
+        let mut alias = [0u8; 32];
+        alias[..9].copy_from_slice(b"test-node");
+
+        NodeAnnouncement {
+            signature: Signature::new([0x11; SIGNATURE_SIZE]),
+            features: vec![0x80, 0x00],
+            timestamp: 1_700_000_000,
+            node_id: NodeId::new([0x22; NODE_ID_SIZE]),
+            rgb_color: [0xff, 0x80, 0x00],
+            alias,
+            addresses: vec![
+                0x01, // type: IPv4
+                127, 0, 0, 1,
+                0x23, 0x28,
+            ],
+        }
+    }
+
+    /// Valid `ChannelUpdate` message for testing.
+    fn sample_channel_update() -> ChannelUpdate {
+        ChannelUpdate {
+            signature: Signature::new([0x33; SIGNATURE_SIZE]),
+            chain_hash: ChainHash::new([0xaa; CHAIN_HASH_SIZE]),
+            short_channel_id: ShortChannelId::new(0x1234_5678_9abc),
+            timestamp: 1_700_000_000,
+            message_flags: 0x01,
+            channel_flags: 0x01,
+            cltv_expiry_delta: 40,
+            htlc_minimum_msat: 1_000,
+            fee_base_msat: 1_000,
+            fee_proportional_millionths: 100,
+            htlc_maximum_msat: Some(100_000_000),
+        }
+    }
+
     #[test]
     fn message_funding_signed_roundtrip() {
         let fs = sample_funding_signed();
@@ -452,6 +539,33 @@ mod tests {
         let encoded = msg.encode();
         let decoded = Message::decode(&encoded).unwrap();
         assert_eq!(decoded, Message::FundingSigned(fs));
+    }
+
+    #[test]
+    fn message_channel_announcement_roundtrip() {
+        let channel_announcement = sample_channel_announcement();
+        let msg = Message::ChannelAnnouncement(channel_announcement.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::ChannelAnnouncement(channel_announcement));
+    }
+
+    #[test]
+    fn message_node_announcement_roundtrip() {
+        let node_announcement = sample_node_announcement();
+        let msg = Message::NodeAnnouncement(node_announcement.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::NodeAnnouncement(node_announcement));
+    }
+
+    #[test]
+    fn message_channel_update_roundtrip() {
+        let channel_update = sample_channel_update();
+        let msg = Message::ChannelUpdate(channel_update.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::ChannelUpdate(channel_update));
     }
 
     #[test]
@@ -587,6 +701,18 @@ mod tests {
         assert_eq!(
             Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),
             msg_type::TX_ABORT
+        );
+        assert_eq!(
+            Message::ChannelAnnouncement(sample_channel_announcement()).msg_type(),
+            msg_type::CHANNEL_ANNOUNCEMENT
+        );
+        assert_eq!(
+            Message::NodeAnnouncement(sample_node_announcement()).msg_type(),
+            msg_type::NODE_ANNOUNCEMENT
+        );
+        assert_eq!(
+            Message::ChannelUpdate(sample_channel_update()).msg_type(),
+            msg_type::CHANNEL_UPDATE
         );
         assert_eq!(
             Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),

--- a/smite/src/bolt/channel_announcement.rs
+++ b/smite/src/bolt/channel_announcement.rs
@@ -1,0 +1,183 @@
+//! BOLT 7 `channel_announcement` message.
+
+use super::BoltError;
+use super::types::{ChainHash, NodeId, ShortChannelId, Signature};
+use super::wire::WireFormat;
+
+/// BOLT 7 `channel_announcement` message (type 256 / 0x0100).
+///
+/// Announces a new channel to the network. Ties each on-chain Bitcoin key to
+/// the associated Lightning node key. A channel is not usable for routing
+/// until at least one side has also sent a `channel_update`.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelAnnouncement {
+    /// Signature from node_1 over the announcement.
+    pub node_signature_1: Signature,
+    /// Signature from node_2 over the announcement.
+    pub node_signature_2: Signature,
+    /// Signature from bitcoin_key_1 over the announcement.
+    pub bitcoin_signature_1: Signature,
+    /// Signature from bitcoin_key_2 over the announcement.
+    pub bitcoin_signature_2: Signature,
+    /// Feature bits supported by this channel.
+    pub features: Vec<u8>,
+    /// Chain this channel lives on.
+    pub chain_hash: ChainHash,
+    /// Compact channel identifier: encodes block, tx index, and output index.
+    pub short_channel_id: ShortChannelId,
+    /// Compressed public key of node 1 (numerically lesser).
+    pub node_id_1: NodeId,
+    /// Compressed public key of node 2 (numerically greater).
+    pub node_id_2: NodeId,
+    /// On-chain funding public key belonging to node 1.
+    pub bitcoin_key_1: NodeId,
+    /// On-chain funding public key belonging to node 2.
+    pub bitcoin_key_2: NodeId,
+}
+
+impl ChannelAnnouncement {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.node_signature_1.write(&mut out);
+        self.node_signature_2.write(&mut out);
+        self.bitcoin_signature_1.write(&mut out);
+        self.bitcoin_signature_2.write(&mut out);       
+        (self.features.len() as u16).write(&mut out);      
+        out.extend_from_slice(&self.features);
+        self.chain_hash.write(&mut out);
+        self.short_channel_id.write(&mut out);
+        self.node_id_1.write(&mut out);
+        self.node_id_2.write(&mut out);
+        self.bitcoin_key_1.write(&mut out);
+        self.bitcoin_key_2.write(&mut out);
+        out
+}
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let node_signature_1    = Signature::read(&mut cursor)?;
+        let node_signature_2    = Signature::read(&mut cursor)?;
+        let bitcoin_signature_1 = Signature::read(&mut cursor)?;
+        let bitcoin_signature_2 = Signature::read(&mut cursor)?;
+        let len                 = u16::read(&mut cursor)?;
+        if cursor.len() < usize::from(len) {
+            return Err(BoltError::Truncated {
+                expected: usize::from(len),
+                actual: cursor.len(),
+            });
+        }
+        let features = cursor[..usize::from(len)].to_vec();
+        cursor = &cursor[usize::from(len)..];
+
+        let chain_hash          = ChainHash::read(&mut cursor)?;
+        let short_channel_id    = ShortChannelId::read(&mut cursor)?;
+        let node_id_1           = NodeId::read(&mut cursor)?;
+        let node_id_2           = NodeId::read(&mut cursor)?;
+        let bitcoin_key_1       = NodeId::read(&mut cursor)?;
+        let bitcoin_key_2       = NodeId::read(&mut cursor)?;
+
+        Ok(Self {
+            node_signature_1, node_signature_2,
+            bitcoin_signature_1, bitcoin_signature_2,
+            features, chain_hash, short_channel_id,
+            node_id_1, node_id_2,
+            bitcoin_key_1, bitcoin_key_2,
+        })
+    }
+
+    /// Returns the bytes covered by all four signatures.
+    pub fn signable_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&0x0100u16.to_be_bytes()); // message type prefix
+        (self.features.len() as u16).write(&mut out);
+        out.extend_from_slice(&self.features);
+        self.chain_hash.write(&mut out);
+        self.short_channel_id.write(&mut out);
+        self.node_id_1.write(&mut out);
+        self.node_id_2.write(&mut out);
+        self.bitcoin_key_1.write(&mut out);
+        self.bitcoin_key_2.write(&mut out);
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{SIGNATURE_SIZE, NODE_ID_SIZE, CHAIN_HASH_SIZE};
+
+    fn dummy() -> ChannelAnnouncement {
+        ChannelAnnouncement {
+            node_signature_1:    Signature::new([0x01; SIGNATURE_SIZE]),
+            node_signature_2:    Signature::new([0x02; SIGNATURE_SIZE]),
+            bitcoin_signature_1: Signature::new([0x03; SIGNATURE_SIZE]),
+            bitcoin_signature_2: Signature::new([0x04; SIGNATURE_SIZE]),
+            features:            vec![],
+            chain_hash:          ChainHash::new([0xaa; CHAIN_HASH_SIZE]),
+            short_channel_id:    ShortChannelId::new(0x0001_0002_0003),
+            node_id_1:           NodeId::new([0x02; NODE_ID_SIZE]),
+            node_id_2:           NodeId::new([0x03; NODE_ID_SIZE]),
+            bitcoin_key_1:       NodeId::new([0x04; NODE_ID_SIZE]),
+            bitcoin_key_2:       NodeId::new([0x05; NODE_ID_SIZE]),
+        }
+    }
+
+    #[test]
+    fn encode_field_sizes() {
+        let ann = dummy();
+        let encoded = ann.encode();
+        let expected = 4 * SIGNATURE_SIZE + 2 + 0
+            + CHAIN_HASH_SIZE + 8
+            + 4 * NODE_ID_SIZE;
+        assert_eq!(encoded.len(), expected);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = dummy();
+        let encoded = original.encode();
+        let decoded = ChannelAnnouncement::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_features() {
+        let mut ann = dummy();
+        ann.features = vec![0x0a, 0x0b, 0x0c];
+        let encoded = ann.encode();
+        let decoded = ChannelAnnouncement::decode(&encoded).unwrap();
+        assert_eq!(ann, decoded);
+    }
+
+    #[test]
+    fn decode_truncated_first_signature() {
+        // Only 10 bytes way short of the first 64-byte signature
+        assert_eq!(
+            ChannelAnnouncement::decode(&[0x00; 10]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 10 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_mid_payload() {
+        // 3 full signatures then truncated
+        let partial = vec![0x00u8; 3 * SIGNATURE_SIZE + 10];
+        assert!(ChannelAnnouncement::decode(&partial).is_err());
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            ChannelAnnouncement::decode(&[]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 0 })
+        );
+    }
+}

--- a/smite/src/bolt/channel_update.rs
+++ b/smite/src/bolt/channel_update.rs
@@ -1,0 +1,185 @@
+//! BOLT 7 `channel_update` message.
+
+use super::BoltError;
+use super::types::{ChainHash, ShortChannelId, Signature};
+use super::wire::WireFormat;
+
+/// BOLT 7 `channel_update` message (type 258 / 0x0102).
+///
+/// Announces the routing conditions for one direction of a channel.
+/// Each side of a channel sends its own `channel_update`. A channel
+/// has two directions; `channel_flags` bit 0 identifies which direction
+/// this update applies to (0 = node_1 to node_2, 1 = node_2 to node_1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelUpdate {
+    /// Signature from the originating node.
+    pub signature: Signature,
+    /// Chain this channel lives on.
+    pub chain_hash: ChainHash,
+    /// Compact identifier of the channel being updated.
+    pub short_channel_id: ShortChannelId,
+    /// Unix timestamp. Higher timestamp wins on conflicts.
+    pub timestamp: u32,
+    /// Flags signalling presence of optional fields.
+    ///
+    /// Bit 0: `htlc_maximum_msat` is present.
+    pub message_flags: u8,
+    /// Direction and status flags.
+    ///
+    /// Bit 0: direction (0 = from node_1, 1 = from node_2).
+    /// Bit 1: channel is disabled.
+    pub channel_flags: u8,
+    /// Blocks added to HTLC CLTV when forwarding.
+    pub cltv_expiry_delta: u16,
+    /// Minimum HTLC value accepted, in millisatoshis.
+    pub htlc_minimum_msat: u64,
+    /// Flat fee charged per HTLC, in millisatoshis.
+    pub fee_base_msat: u32,
+    /// Proportional fee in millionths of the forwarded amount.
+    pub fee_proportional_millionths: u32,
+    /// Maximum HTLC value accepted, in millisatoshis.
+    ///
+    /// Present only when `message_flags` bit 0 is set.
+    pub htlc_maximum_msat: Option<u64>,
+}
+
+/// Mask for the `htlc_maximum_msat` presence bit in `message_flags`.
+const HAS_MAX_HTLC: u8 = 0x01;
+
+impl ChannelUpdate {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.signature.write(&mut out);
+        self.chain_hash.write(&mut out);
+        self.short_channel_id.write(&mut out);
+        self.timestamp.write(&mut out);
+        self.message_flags.write(&mut out);
+        self.channel_flags.write(&mut out);
+        self.cltv_expiry_delta.write(&mut out);
+        self.htlc_minimum_msat.write(&mut out);
+        self.fee_base_msat.write(&mut out);
+        self.fee_proportional_millionths.write(&mut out);
+
+        // htlc_maximum_msat is optional — only written when flag bit is set
+        if self.message_flags & HAS_MAX_HTLC != 0 {
+            if let Some(max) = self.htlc_maximum_msat {
+                max.write(&mut out);
+            }
+        }
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let signature                   = Signature::read(&mut cursor)?;
+        let chain_hash                  = ChainHash::read(&mut cursor)?;
+        let short_channel_id            = ShortChannelId::read(&mut cursor)?;
+        let timestamp                   = u32::read(&mut cursor)?;
+        let message_flags               = u8::read(&mut cursor)?;
+        let channel_flags               = u8::read(&mut cursor)?;
+        let cltv_expiry_delta           = u16::read(&mut cursor)?;
+        let htlc_minimum_msat           = u64::read(&mut cursor)?;
+        let fee_base_msat               = u32::read(&mut cursor)?;
+        let fee_proportional_millionths = u32::read(&mut cursor)?;
+
+        // Only read htlc_maximum_msat if the flag bit tells us it's present
+        let htlc_maximum_msat = if message_flags & HAS_MAX_HTLC != 0 {
+            Some(u64::read(&mut cursor)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            signature, chain_hash, short_channel_id,
+            timestamp, message_flags, channel_flags,
+            cltv_expiry_delta, htlc_minimum_msat,
+            fee_base_msat, fee_proportional_millionths,
+            htlc_maximum_msat,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{SIGNATURE_SIZE, CHAIN_HASH_SIZE};
+
+    fn dummy(with_max_htlc: bool) -> ChannelUpdate {
+        ChannelUpdate {
+            signature:                   Signature::new([0x01; SIGNATURE_SIZE]),
+            chain_hash:                  ChainHash::new([0xaa; CHAIN_HASH_SIZE]),
+            short_channel_id:            ShortChannelId::new(0x1234_5678_9abc),
+            timestamp:                   1_700_000_000,
+            message_flags:               if with_max_htlc { HAS_MAX_HTLC } else { 0 },
+            channel_flags:               0x01, // direction: node_2 → node_1
+            cltv_expiry_delta:           40,
+            htlc_minimum_msat:           1_000,
+            fee_base_msat:               1_000,
+            fee_proportional_millionths: 100,
+            htlc_maximum_msat:           if with_max_htlc { Some(100_000_000) } else { None },
+        }
+    }
+
+    #[test]
+    fn encode_field_sizes_without_max_htlc() {
+        let encoded = dummy(false).encode();
+        // sig(64) + chain_hash(32) + scid(8) + timestamp(4)
+        // + msg_flags(1) + chan_flags(1) + cltv(2) + min(8) + base(4) + prop(4) = 128
+        assert_eq!(encoded.len(), SIGNATURE_SIZE + CHAIN_HASH_SIZE + 8 + 4 + 1 + 1 + 2 + 8 + 4 + 4);
+    }
+
+    #[test]
+    fn encode_field_sizes_with_max_htlc() {
+        let encoded = dummy(true).encode();
+        // same as above + htlc_maximum_msat(8) = 136
+        assert_eq!(
+            encoded.len(),
+            SIGNATURE_SIZE + CHAIN_HASH_SIZE + 8 + 4 + 1 + 1 + 2 + 8 + 4 + 4 + 8
+        );
+    }
+
+    #[test]
+    fn roundtrip_without_max_htlc() {
+        let original = dummy(false);
+        let decoded = ChannelUpdate::decode(&original.encode()).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_max_htlc() {
+        let original = dummy(true);
+        let decoded = ChannelUpdate::decode(&original.encode()).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn decode_truncated_signature() {
+        assert_eq!(
+            ChannelUpdate::decode(&[0x00; 10]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 10 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_optional_field() {
+        // Encode with flag set but truncate before htlc_maximum_msat bytes
+        let mut encoded = dummy(true).encode();
+        encoded.truncate(encoded.len() - 4); // remove last 4 bytes of the 8-byte field
+        assert!(ChannelUpdate::decode(&encoded).is_err());
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            ChannelUpdate::decode(&[]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 0 })
+        );
+    }
+}

--- a/smite/src/bolt/node_announcement.rs
+++ b/smite/src/bolt/node_announcement.rs
@@ -1,0 +1,211 @@
+//! BOLT 7 `node_announcement` message.
+
+use super::BoltError;
+use super::types::{NodeId, Signature};
+use super::wire::WireFormat;
+
+/// BOLT 7 `node_announcement` message (type 257 / 0x0101).
+///
+/// Broadcasts a node's existence, display information, and reachable
+/// network addresses. May be re-sent to update any of these fields.
+/// Only nodes with at least one public channel will be relayed by peers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeAnnouncement {
+    /// Signature from the announcing node's key.
+    pub signature: Signature,
+    /// Length in bytes of `features`.
+    pub features: Vec<u8>,
+    /// Unix timestamp. Higher timestamp wins on conflicts.
+    pub timestamp: u32,
+    /// The node's compressed public key (its identity).
+    pub node_id: NodeId,
+    /// A 3-byte RGB display color (cosmetic only).
+    pub rgb_color: [u8; 3],
+    /// A human-readable node alias, zero-padded to exactly 32 bytes.
+    pub alias: [u8; 32],
+    /// Encoded network addresses (IP v4/v6, Tor, etc.).
+    /// Each address is a 1-byte type descriptor followed by address bytes.
+    pub addresses: Vec<u8>,
+}
+
+impl NodeAnnouncement {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.signature.write(&mut out);
+        (self.features.len() as u16).write(&mut out);  
+        out.extend_from_slice(&self.features);
+        self.timestamp.write(&mut out);
+        self.node_id.write(&mut out);
+        out.extend_from_slice(&self.rgb_color);
+        out.extend_from_slice(&self.alias);
+        (self.addresses.len() as u16).write(&mut out);  
+        out.extend_from_slice(&self.addresses);
+        out
+    }
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let signature = Signature::read(&mut cursor)?;
+        let flen = u16::read(&mut cursor)?;
+        if cursor.len() < usize::from(flen) {
+            return Err(BoltError::Truncated {
+                expected: usize::from(flen),
+                actual: cursor.len(),
+            });
+        }
+        let features = cursor[..usize::from(flen)].to_vec();
+        cursor = &cursor[usize::from(flen)..];
+
+        let timestamp = u32::read(&mut cursor)?;
+        let node_id   = NodeId::read(&mut cursor)?;
+
+        // rgb_color: fixed 3 bytes, no length prefix
+        let rgb_color = <[u8; 3]>::read(&mut cursor)?;
+        // alias: fixed 32 bytes, zero-padded
+        let alias     = <[u8; 32]>::read(&mut cursor)?;
+
+        let addrlen = u16::read(&mut cursor)?;
+        if cursor.len() < usize::from(addrlen) {
+            return Err(BoltError::Truncated {
+                expected: usize::from(addrlen),
+                actual: cursor.len(),
+            });
+        }
+        let addresses = cursor[..usize::from(addrlen)].to_vec();
+
+        Ok(Self {
+            signature,
+            features,
+            timestamp,
+            node_id,
+            rgb_color,
+            alias,
+            addresses,
+        })
+    }
+
+    /// Returns the alias as a trimmed string, stripping trailing null bytes.
+    #[must_use]
+    pub fn alias_str(&self) -> &str {
+        let trimmed = self.alias.split(|&b| b == 0).next().unwrap_or(&[]);
+        std::str::from_utf8(trimmed).unwrap_or("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{SIGNATURE_SIZE, NODE_ID_SIZE};
+
+    fn dummy() -> NodeAnnouncement {
+        let mut alias = [0u8; 32];
+        alias[..9].copy_from_slice(b"test-node");
+
+        NodeAnnouncement {
+            signature:  Signature::new([0x01; SIGNATURE_SIZE]),
+            features:   vec![],
+            timestamp:  1_700_000_000,
+            node_id:    NodeId::new([0x02; NODE_ID_SIZE]),
+            rgb_color:  [0xff, 0x80, 0x00],
+            alias,
+            addresses:  vec![],
+        }
+    }
+
+    #[test]
+    fn encode_field_sizes() {
+        let encoded = dummy().encode();
+        // sig(64) + features_len(2) + features(0) + timestamp(4)
+        // + node_id(33) + rgb(3) + alias(32) + addr_len(2) + addr(0) = 140
+        assert_eq!(
+            encoded.len(),
+            SIGNATURE_SIZE + 2 + 0 + 4 + NODE_ID_SIZE + 3 + 32 + 2 + 0
+        );
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = dummy();
+        let decoded = NodeAnnouncement::decode(&original.encode()).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_features_and_addresses() {
+        let mut ann = dummy();
+        ann.features  = vec![0x80, 0x00];
+        ann.addresses = vec![
+            0x01,                           // type: IPv4
+            127, 0, 0, 1,                   // address
+            0x23, 0x28,                     // port 9000
+        ];
+        let decoded = NodeAnnouncement::decode(&ann.encode()).unwrap();
+        assert_eq!(ann, decoded);
+    }
+
+
+    #[test]
+    fn alias_str_trims_nulls() {
+        let ann = dummy();
+        assert_eq!(ann.alias_str(), "test-node");
+    }
+
+    #[test]
+    fn alias_str_all_nulls() {
+        let mut ann = dummy();
+        ann.alias = [0u8; 32];
+        assert_eq!(ann.alias_str(), "");
+    }
+
+    #[test]
+    fn decode_truncated_signature() {
+        assert_eq!(
+            NodeAnnouncement::decode(&[0x00; 10]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 10 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_alias() {
+    let partial = vec![0x00u8; SIGNATURE_SIZE + 2 + 4 + NODE_ID_SIZE + 3 + 10];
+    assert_eq!(
+        NodeAnnouncement::decode(&partial),
+        Err(BoltError::Truncated { expected: 32, actual: 10 })
+    );
+}
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            NodeAnnouncement::decode(&[]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 0 })
+        );
+    }
+
+    // features length says 10 but only 3 bytes follow
+    #[test]
+    fn decode_truncated_features_content() {
+        let mut data = vec![0x00u8; SIGNATURE_SIZE];
+        data.extend_from_slice(&[0x00, 0x0a]); // flen = 10
+        data.extend_from_slice(&[0x01, 0x02, 0x03]); // only 3 bytes
+        assert_eq!(
+            NodeAnnouncement::decode(&data),
+            Err(BoltError::Truncated { expected: 10, actual: 3 })
+        );
+    }
+
+    // trailing bytes after valid message
+    #[test]
+    fn decode_trailing_bytes() {
+        let mut encoded = dummy().encode();
+        encoded.extend_from_slice(&[0xff; 8]);
+        let decoded = NodeAnnouncement::decode(&encoded).unwrap();
+        assert_eq!(decoded, dummy());
+    }
+}

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -17,6 +17,12 @@ pub const TXID_SIZE: usize = 32;
 /// Size of a compact ECDSA signature in bytes.
 pub const COMPACT_SIGNATURE_SIZE: usize = 64;
 
+/// Size of a node ID (compressed public key bytes) in bytes.
+pub const NODE_ID_SIZE: usize = 33;
+
+/// Size of a gossip signature in bytes.
+pub const SIGNATURE_SIZE: usize = COMPACT_SIGNATURE_SIZE;
+
 /// A 32-byte channel identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChannelId(pub [u8; CHANNEL_ID_SIZE]);
@@ -36,6 +42,78 @@ impl ChannelId {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8; CHANNEL_ID_SIZE] {
         &self.0
+    }
+}
+
+/// A 32-byte chain hash (genesis block hash of the chain).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ChainHash(pub [u8; CHAIN_HASH_SIZE]);
+
+impl ChainHash {
+    /// Creates a chain hash from a byte array.
+    #[must_use]
+    pub const fn new(bytes: [u8; CHAIN_HASH_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the chain hash as a byte slice.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; CHAIN_HASH_SIZE] {
+        &self.0
+    }
+}
+
+/// A 64-byte compact gossip signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Signature(pub [u8; SIGNATURE_SIZE]);
+
+impl Signature {
+    /// Creates a signature from compact bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; SIGNATURE_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns compact signature bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; SIGNATURE_SIZE] {
+        &self.0
+    }
+}
+
+/// A 33-byte node identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NodeId(pub [u8; NODE_ID_SIZE]);
+
+impl NodeId {
+    /// Creates a node ID from compressed public key bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; NODE_ID_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns node ID bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; NODE_ID_SIZE] {
+        &self.0
+    }
+}
+
+/// Compact channel identifier containing block, tx, and output indexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ShortChannelId(pub u64);
+
+impl ShortChannelId {
+    /// Creates a short channel ID from its encoded 64-bit representation.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the encoded 64-bit representation.
+    #[must_use]
+    pub const fn value(self) -> u64 {
+        self.0
     }
 }
 
@@ -112,5 +190,36 @@ mod tests {
     #[test]
     fn channel_id_default_is_all() {
         assert_eq!(ChannelId::default(), ChannelId::ALL);
+    }
+
+    #[test]
+    fn chain_hash_new() {
+        let bytes = [0x11u8; CHAIN_HASH_SIZE];
+        let hash = ChainHash::new(bytes);
+        assert_eq!(hash.0, bytes);
+        assert_eq!(hash.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn signature_new() {
+        let bytes = [0x22u8; SIGNATURE_SIZE];
+        let sig = Signature::new(bytes);
+        assert_eq!(sig.0, bytes);
+        assert_eq!(sig.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn node_id_new() {
+        let bytes = [0x02u8; NODE_ID_SIZE];
+        let id = NodeId::new(bytes);
+        assert_eq!(id.0, bytes);
+        assert_eq!(id.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn short_channel_id_new() {
+        let scid = ShortChannelId::new(0x0001_0002_0003);
+        assert_eq!(scid.0, 0x0001_0002_0003);
+        assert_eq!(scid.value(), 0x0001_0002_0003);
     }
 }

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -2,7 +2,9 @@
 
 use crate::bolt::BoltError;
 use crate::bolt::types::{
-    BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, TXID_SIZE, Txid,
+    BigSize, CHAIN_HASH_SIZE, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChainHash, ChannelId,
+    NODE_ID_SIZE, NodeId, SIGNATURE_SIZE, ShortChannelId, Signature as BoltSignature, TXID_SIZE,
+    Txid,
 };
 use secp256k1::PublicKey;
 use secp256k1::ecdsa::Signature;
@@ -78,6 +80,49 @@ impl WireFormat for ChannelId {
     fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
         let bytes: [u8; CHANNEL_ID_SIZE] = WireFormat::read(data)?;
         Ok(Self(bytes))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.as_bytes().write(out);
+    }
+}
+
+impl WireFormat for ChainHash {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        let bytes: [u8; CHAIN_HASH_SIZE] = WireFormat::read(data)?;
+        Ok(Self::new(bytes))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.as_bytes().write(out);
+    }
+}
+
+impl WireFormat for NodeId {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        let bytes: [u8; NODE_ID_SIZE] = WireFormat::read(data)?;
+        Ok(Self::new(bytes))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.as_bytes().write(out);
+    }
+}
+
+impl WireFormat for ShortChannelId {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        Ok(Self::new(u64::read(data)?))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.value().write(out);
+    }
+}
+
+impl WireFormat for BoltSignature {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        let bytes: [u8; SIGNATURE_SIZE] = WireFormat::read(data)?;
+        Ok(Self::new(bytes))
     }
 
     fn write(&self, out: &mut Vec<u8>) {


### PR DESCRIPTION
**Key objectives achieved**: 
- BOLT types applied: channel_announcement (256), node_announcement (257), channel_update (258).
- Added/used gossip primitives: ChainHash, NodeId, ShortChannelId, Signature; wired message routing and wire encode/decode support.

Files changed/added:
- smite/src/bolt/channel_announcement, channel_update, node_announcement with new codec
- `smite/src/bolt/wire.rs`, `smite/src/bolt/types.rs`, `smite/src/bolt.rs `for wiring up new codecs
