### PR TITLE
smite: implement update_fulfill_htlc and update_fail_htlc message codecs

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -5,6 +5,7 @@
 
 mod accept_channel;
 mod accept_channel2;
+mod attribution_data;
 mod channel_ready;
 mod error;
 mod funding_created;
@@ -24,12 +25,15 @@ mod tx_init_rbf;
 mod tx_remove_input;
 mod tx_remove_output;
 mod types;
+mod update_fail_htlc;
 mod update_fail_malformed_htlc;
+mod update_fulfill_htlc;
 mod warning;
 mod wire;
 
 pub use accept_channel::{AcceptChannel, AcceptChannelTlvs};
 pub use accept_channel2::{AcceptChannel2, AcceptChannel2Tlvs};
+pub use attribution_data::{AttributionData, TruncatedHmac};
 pub use channel_ready::{ChannelReady, ChannelReadyTlvs};
 pub use error::Error;
 pub use funding_created::FundingCreated;
@@ -52,7 +56,9 @@ pub use types::{
     BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, MAX_MESSAGE_SIZE, PUBLIC_KEY_SIZE,
     SHA256_HASH_SIZE, TXID_SIZE, Txid,
 };
+pub use update_fail_htlc::{UpdateFailHtlc, UpdateFailHtlcTlvs};
 pub use update_fail_malformed_htlc::UpdateFailMalformedHtlc;
+pub use update_fulfill_htlc::{UpdateFulfillHtlc, UpdateFulfillHtlcTlvs};
 pub use warning::Warning;
 pub use wire::WireFormat;
 
@@ -133,6 +139,10 @@ pub mod msg_type {
     pub const TX_ACK_RBF: u16 = 73;
     /// `tx_abort` message (BOLT 2).
     pub const TX_ABORT: u16 = 74;
+    /// `update_fulfill_htlc` message (BOLT 2).
+    pub const UPDATE_FULFILL_HTLC: u16 = 130;
+    /// `update_fail_htlc` message (BOLT 2).
+    pub const UPDATE_FAIL_HTLC: u16 = 131;
     /// `update_fail_malformed_htlc` message (BOLT 2).
     pub const UPDATE_FAIL_MALFORMED_HTLC: u16 = 135;
     /// Gossip timestamp filter message (BOLT 7).
@@ -181,6 +191,10 @@ pub enum Message {
     TxAckRbf(TxAckRbf),
     /// `tx_abort` message (type 74).
     TxAbort(TxAbort),
+    /// `update_fulfill_htlc` message (type 130).
+    UpdateFulfillHtlc(UpdateFulfillHtlc),
+    /// `update_fail_htlc` message (type 131).
+    UpdateFailHtlc(UpdateFailHtlc),
     /// `update_fail_malformed_htlc` message (type 135).
     UpdateFailMalformedHtlc(UpdateFailMalformedHtlc),
     /// Gossip timestamp filter message (type 265).
@@ -221,6 +235,8 @@ impl Message {
             Self::TxInitRbf(_) => msg_type::TX_INIT_RBF,
             Self::TxAckRbf(_) => msg_type::TX_ACK_RBF,
             Self::TxAbort(_) => msg_type::TX_ABORT,
+            Self::UpdateFulfillHtlc(_) => msg_type::UPDATE_FULFILL_HTLC,
+            Self::UpdateFailHtlc(_) => msg_type::UPDATE_FAIL_HTLC,
             Self::UpdateFailMalformedHtlc(_) => msg_type::UPDATE_FAIL_MALFORMED_HTLC,
             Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => *msg_type,
@@ -252,6 +268,8 @@ impl Message {
             Self::TxInitRbf(m) => out.extend(m.encode()),
             Self::TxAckRbf(m) => out.extend(m.encode()),
             Self::TxAbort(m) => out.extend(m.encode()),
+            Self::UpdateFulfillHtlc(m) => out.extend(m.encode()),
+            Self::UpdateFailHtlc(m) => out.extend(m.encode()),
             Self::UpdateFailMalformedHtlc(m) => out.extend(m.encode()),
             Self::GossipTimestampFilter(m) => out.extend(m.encode()),
             Self::Unknown { payload, .. } => out.extend(payload),
@@ -290,6 +308,10 @@ impl Message {
             msg_type::TX_INIT_RBF => Ok(Self::TxInitRbf(TxInitRbf::decode(cursor)?)),
             msg_type::TX_ACK_RBF => Ok(Self::TxAckRbf(TxAckRbf::decode(cursor)?)),
             msg_type::TX_ABORT => Ok(Self::TxAbort(TxAbort::decode(cursor)?)),
+            msg_type::UPDATE_FULFILL_HTLC => {
+                Ok(Self::UpdateFulfillHtlc(UpdateFulfillHtlc::decode(cursor)?))
+            }
+            msg_type::UPDATE_FAIL_HTLC => Ok(Self::UpdateFailHtlc(UpdateFailHtlc::decode(cursor)?)),
             msg_type::UPDATE_FAIL_MALFORMED_HTLC => Ok(Self::UpdateFailMalformedHtlc(
                 UpdateFailMalformedHtlc::decode(cursor)?,
             )),
@@ -679,6 +701,32 @@ mod tests {
     }
 
     #[test]
+    fn message_update_fulfill_htlc_roundtrip() {
+        let msg = UpdateFulfillHtlc {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            id: 42,
+            payment_preimage: [0xcd; 32],
+            tlvs: UpdateFulfillHtlcTlvs::default(),
+        };
+        let encoded = Message::UpdateFulfillHtlc(msg.clone()).encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::UpdateFulfillHtlc(msg));
+    }
+
+    #[test]
+    fn message_update_fail_htlc_roundtrip() {
+        let msg = UpdateFailHtlc {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            id: 7,
+            reason: vec![0xde, 0xad, 0xbe, 0xef],
+            tlvs: UpdateFailHtlcTlvs::default(),
+        };
+        let encoded = Message::UpdateFailHtlc(msg.clone()).encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::UpdateFailHtlc(msg));
+    }
+
+    #[test]
     fn message_update_fail_malformed_htlc_roundtrip() {
         let msg = UpdateFailMalformedHtlc {
             channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
@@ -802,6 +850,26 @@ mod tests {
         assert_eq!(
             Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),
             msg_type::TX_ABORT
+        );
+        assert_eq!(
+            Message::UpdateFulfillHtlc(UpdateFulfillHtlc {
+                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                id: 0,
+                payment_preimage: [0; 32],
+                tlvs: UpdateFulfillHtlcTlvs::default(),
+            })
+            .msg_type(),
+            msg_type::UPDATE_FULFILL_HTLC
+        );
+        assert_eq!(
+            Message::UpdateFailHtlc(UpdateFailHtlc {
+                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                id: 0,
+                reason: vec![],
+                tlvs: UpdateFailHtlcTlvs::default(),
+            })
+            .msg_type(),
+            msg_type::UPDATE_FAIL_HTLC
         );
         assert_eq!(
             Message::UpdateFailMalformedHtlc(UpdateFailMalformedHtlc {

--- a/smite/src/bolt/attribution_data.rs
+++ b/smite/src/bolt/attribution_data.rs
@@ -1,0 +1,142 @@
+//! BOLT 4 attribution data, shared by `update_fail_htlc` and
+//! `update_fulfill_htlc` as TLV type 1.
+
+use super::BoltError;
+use super::wire::WireFormat;
+
+/// Maximum number of hops for failure attribution.
+const ATTRIBUTION_MAX_HOPS: usize = 20;
+
+/// Number of truncated HMACs in attribution data.
+const ATTRIBUTION_NUM_HMACS: usize = 210;
+
+/// Size of each truncated HMAC in bytes.
+const TRUNCATED_HMAC_SIZE: usize = 4;
+
+/// A 4-byte truncated SHA-256 HMAC used in failure attribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TruncatedHmac(pub [u8; TRUNCATED_HMAC_SIZE]);
+
+impl WireFormat for TruncatedHmac {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        let bytes: [u8; TRUNCATED_HMAC_SIZE] = WireFormat::read(data)?;
+        Ok(Self(bytes))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.0.write(out);
+    }
+}
+
+/// Attribution data for failure/fulfill attribution (TLV type 1).
+///
+/// Fixed-size structure (920 bytes) containing per-hop hold times and
+/// truncated HMACs for attribution verification, always padded to the
+/// maximum of 20 hops.  Defined in the BOLT 4 attribution proposal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttributionData {
+    /// Per-hop hold times in milliseconds.
+    pub htlc_hold_times: [u32; ATTRIBUTION_MAX_HOPS],
+    /// Truncated HMACs for hop-by-hop verification.
+    pub truncated_hmacs: [TruncatedHmac; ATTRIBUTION_NUM_HMACS],
+}
+
+impl AttributionData {
+    /// Total wire size in bytes (920).
+    ///
+    /// Computed directly from the field counts so that any future change
+    /// to the struct layout (e.g. compiler-introduced padding) cannot
+    /// silently change the on-the-wire size.
+    pub const SIZE: usize = ATTRIBUTION_MAX_HOPS * 4 + ATTRIBUTION_NUM_HMACS * TRUNCATED_HMAC_SIZE;
+
+    /// Encodes attribution data to bytes for inclusion in a TLV value.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(Self::SIZE);
+        for &t in &self.htlc_hold_times {
+            t.write(&mut out);
+        }
+        for hmac in &self.truncated_hmacs {
+            hmac.write(&mut out);
+        }
+        out
+    }
+
+    /// Decodes attribution data from the raw TLV value bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the data is not exactly 920 bytes.
+    pub fn decode(data: &[u8]) -> Result<Self, BoltError> {
+        if data.len() != Self::SIZE {
+            return Err(BoltError::Truncated {
+                expected: Self::SIZE,
+                actual: data.len(),
+            });
+        }
+        let mut cursor = data;
+        let mut htlc_hold_times = [0u32; ATTRIBUTION_MAX_HOPS];
+        for ht in &mut htlc_hold_times {
+            *ht = WireFormat::read(&mut cursor)?;
+        }
+        let mut truncated_hmacs = [TruncatedHmac::default(); ATTRIBUTION_NUM_HMACS];
+        for hmac in &mut truncated_hmacs {
+            *hmac = WireFormat::read(&mut cursor)?;
+        }
+        Ok(Self {
+            htlc_hold_times,
+            truncated_hmacs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_constant() {
+        // 20 hold times * 4 bytes + 210 hmacs * 4 bytes = 80 + 840 = 920
+        assert_eq!(AttributionData::SIZE, 920);
+    }
+
+    #[test]
+    fn encode_size() {
+        let attr = AttributionData {
+            htlc_hold_times: [0u32; ATTRIBUTION_MAX_HOPS],
+            truncated_hmacs: [TruncatedHmac::default(); ATTRIBUTION_NUM_HMACS],
+        };
+        assert_eq!(attr.encode().len(), AttributionData::SIZE);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let mut htlc_hold_times = [0u32; ATTRIBUTION_MAX_HOPS];
+        for (i, ht) in htlc_hold_times.iter_mut().enumerate() {
+            *ht = u32::try_from(i).unwrap() * 1000;
+        }
+        let mut truncated_hmacs = [TruncatedHmac::default(); ATTRIBUTION_NUM_HMACS];
+        for (i, hmac) in truncated_hmacs.iter_mut().enumerate() {
+            let byte = u8::try_from(i & 0xff).unwrap();
+            *hmac = TruncatedHmac([byte; TRUNCATED_HMAC_SIZE]);
+        }
+        let original = AttributionData {
+            htlc_hold_times,
+            truncated_hmacs,
+        };
+        let encoded = original.encode();
+        let decoded = AttributionData::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn decode_wrong_size() {
+        assert_eq!(
+            AttributionData::decode(&[0u8; 100]),
+            Err(BoltError::Truncated {
+                expected: AttributionData::SIZE,
+                actual: 100,
+            })
+        );
+    }
+}

--- a/smite/src/bolt/update_fail_htlc.rs
+++ b/smite/src/bolt/update_fail_htlc.rs
@@ -1,0 +1,275 @@
+//! BOLT 2 `update_fail_htlc` message.
+
+use super::BoltError;
+use super::attribution_data::AttributionData;
+use super::tlv::TlvStream;
+use super::types::ChannelId;
+use super::wire::WireFormat;
+
+/// TLV type for attribution data.
+const TLV_ATTRIBUTION_DATA: u64 = 1;
+
+/// BOLT 2 `update_fail_htlc` message (type 131).
+///
+/// Sent to fail an HTLC back to the sender.  The `reason` field contains an
+/// encrypted failure message that is relayed back along the payment path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateFailHtlc {
+    /// The channel ID.
+    pub channel_id: ChannelId,
+    /// The HTLC ID being failed.
+    pub id: u64,
+    /// Encrypted reason for the failure, relayed back to the sender.
+    pub reason: Vec<u8>,
+    /// Optional TLV extensions.
+    pub tlvs: UpdateFailHtlcTlvs,
+}
+
+/// TLV extensions for the `update_fail_htlc` message.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpdateFailHtlcTlvs {
+    /// Attribution data for failure attribution (TLV type 1).
+    pub attribution_data: Option<AttributionData>,
+}
+
+impl UpdateFailHtlc {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+        self.id.write(&mut out);
+        self.reason.write(&mut out);
+
+        // Encode TLVs
+        let mut tlv_stream = TlvStream::new();
+        if let Some(attr) = &self.tlvs.attribution_data {
+            tlv_stream.add(TLV_ATTRIBUTION_DATA, attr.encode());
+        }
+        out.extend(tlv_stream.encode());
+
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short, or TLV errors
+    /// if the TLV stream is malformed.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let channel_id = WireFormat::read(&mut cursor)?;
+        let id = WireFormat::read(&mut cursor)?;
+        let reason = WireFormat::read(&mut cursor)?;
+
+        // Decode TLVs (remaining bytes)
+        // attribution_data is type 1 (odd), so no known even types
+        let tlv_stream = TlvStream::decode(cursor)?;
+        let tlvs = UpdateFailHtlcTlvs::from_stream(&tlv_stream)?;
+
+        Ok(Self {
+            channel_id,
+            id,
+            reason,
+            tlvs,
+        })
+    }
+}
+
+impl UpdateFailHtlcTlvs {
+    /// Extracts TLVs from a parsed TLV stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if `attribution_data` has invalid length.
+    fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
+        let attribution_data = stream
+            .get(TLV_ATTRIBUTION_DATA)
+            .map(AttributionData::decode)
+            .transpose()?;
+        Ok(Self { attribution_data })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CHANNEL_ID_SIZE;
+    use super::super::attribution_data::TruncatedHmac;
+    use super::*;
+
+    fn sample_msg() -> UpdateFailHtlc {
+        UpdateFailHtlc {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            id: 42,
+            reason: vec![0xde, 0xad, 0xbe, 0xef],
+            tlvs: UpdateFailHtlcTlvs::default(),
+        }
+    }
+
+    #[test]
+    fn encode_field_sizes() {
+        let msg = UpdateFailHtlc {
+            channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+            id: 1,
+            reason: vec![0xaa, 0xbb],
+            tlvs: UpdateFailHtlcTlvs::default(),
+        };
+        let encoded = msg.encode();
+        // channel_id(32) + id(8) + len(2) + reason(2) = 44
+        assert_eq!(encoded.len(), 44);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = sample_msg();
+        let encoded = original.encode();
+        let decoded = UpdateFailHtlc::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_empty_reason() {
+        let original = UpdateFailHtlc {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            id: 7,
+            reason: vec![],
+            tlvs: UpdateFailHtlcTlvs::default(),
+        };
+        let encoded = original.encode();
+        let decoded = UpdateFailHtlc::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_attribution_data() {
+        let mut msg = sample_msg();
+        msg.tlvs.attribution_data = Some(AttributionData {
+            htlc_hold_times: [100; 20],
+            truncated_hmacs: [TruncatedHmac([0xaa; 4]); 210],
+        });
+        let encoded = msg.encode();
+        let decoded = UpdateFailHtlc::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn decode_truncated_attribution_data() {
+        let msg = sample_msg();
+        let mut encoded = msg.encode();
+        // Append a TLV type 1 with only 100 bytes (should be 920)
+        encoded.push(0x01); // type
+        encoded.push(0x64); // length = 100
+        encoded.extend_from_slice(&[0x00; 100]);
+        assert_eq!(
+            UpdateFailHtlc::decode(&encoded),
+            Err(BoltError::Truncated {
+                expected: AttributionData::SIZE,
+                actual: 100
+            })
+        );
+    }
+
+    #[test]
+    fn decode_unknown_odd_tlv_ignored() {
+        let mut msg = sample_msg();
+        let mut encoded = msg.encode();
+        // Append an unknown odd TLV (type 3, len 2, value 0xffff)
+        encoded.extend_from_slice(&[0x03, 0x02, 0xff, 0xff]);
+        let decoded = UpdateFailHtlc::decode(&encoded).unwrap();
+        msg.tlvs = UpdateFailHtlcTlvs::default();
+        assert_eq!(decoded.channel_id, msg.channel_id);
+        assert_eq!(decoded.id, msg.id);
+        assert_eq!(decoded.reason, msg.reason);
+    }
+
+    #[test]
+    fn decode_unknown_even_tlv_rejected() {
+        let mut encoded = sample_msg().encode();
+        // Append an unknown even TLV (type 2, len 1, value 0x00)
+        encoded.extend_from_slice(&[0x02, 0x01, 0x00]);
+        assert!(matches!(
+            UpdateFailHtlc::decode(&encoded),
+            Err(BoltError::TlvUnknownEvenType(2))
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds maximum size")]
+    fn encode_panics_on_oversized_reason() {
+        let msg = UpdateFailHtlc {
+            channel_id: ChannelId::new([0x00; CHANNEL_ID_SIZE]),
+            id: 0,
+            reason: vec![0x00; u16::MAX as usize + 1],
+            tlvs: UpdateFailHtlcTlvs::default(),
+        };
+        let _ = msg.encode();
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        assert_eq!(
+            UpdateFailHtlc::decode(&[0x00; 20]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 20
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_id() {
+        // Full channel_id (32 bytes) + only 4 bytes of id
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 4]);
+        assert_eq!(
+            UpdateFailHtlc::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 4
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_len() {
+        // Full channel_id (32 bytes) + full id (8 bytes) + only 1 byte of len
+        let mut data = vec![0x00u8; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 8]);
+        data.push(0x00);
+        assert_eq!(
+            UpdateFailHtlc::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 2,
+                actual: 1
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_reason() {
+        // Full channel_id (32 bytes) + full id (8 bytes) + len = 16 + only 5 bytes
+        let mut data = vec![0x00u8; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 8]);
+        data.extend_from_slice(&[0x00, 0x10]); // len = 16
+        data.extend_from_slice(b"short"); // only 5 bytes
+        assert_eq!(
+            UpdateFailHtlc::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 16,
+                actual: 5
+            })
+        );
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            UpdateFailHtlc::decode(&[]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 0
+            })
+        );
+    }
+}

--- a/smite/src/bolt/update_fulfill_htlc.rs
+++ b/smite/src/bolt/update_fulfill_htlc.rs
@@ -1,0 +1,238 @@
+//! BOLT 2 `update_fulfill_htlc` message.
+
+use super::BoltError;
+use super::attribution_data::AttributionData;
+use super::tlv::TlvStream;
+use super::types::ChannelId;
+use super::wire::WireFormat;
+
+/// Size of a payment preimage in bytes.
+const PAYMENT_PREIMAGE_SIZE: usize = 32;
+
+/// TLV type for attribution data.
+const TLV_ATTRIBUTION_DATA: u64 = 1;
+
+/// BOLT 2 `update_fulfill_htlc` message (type 130).
+///
+/// Sent to fulfill an HTLC by providing the payment preimage.  Upon receiving
+/// this message, the peer should remove the corresponding HTLC from the
+/// commitment transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateFulfillHtlc {
+    /// The channel ID.
+    pub channel_id: ChannelId,
+    /// The HTLC ID being fulfilled.
+    pub id: u64,
+    /// The payment preimage (32 bytes).
+    pub payment_preimage: [u8; PAYMENT_PREIMAGE_SIZE],
+    /// Optional TLV extensions.
+    pub tlvs: UpdateFulfillHtlcTlvs,
+}
+
+/// TLV extensions for the `update_fulfill_htlc` message.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpdateFulfillHtlcTlvs {
+    /// Attribution data for failure attribution (TLV type 1).
+    pub attribution_data: Option<AttributionData>,
+}
+
+impl UpdateFulfillHtlc {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+        self.id.write(&mut out);
+        self.payment_preimage.write(&mut out);
+
+        // Encode TLVs
+        let mut tlv_stream = TlvStream::new();
+        if let Some(attr) = &self.tlvs.attribution_data {
+            tlv_stream.add(TLV_ATTRIBUTION_DATA, attr.encode());
+        }
+        out.extend(tlv_stream.encode());
+
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short for any fixed field,
+    /// or TLV errors if the TLV stream is malformed.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let channel_id = WireFormat::read(&mut cursor)?;
+        let id = WireFormat::read(&mut cursor)?;
+        let payment_preimage = WireFormat::read(&mut cursor)?;
+
+        // Decode TLVs (remaining bytes)
+        // attribution_data is type 1 (odd), so no known even types
+        let tlv_stream = TlvStream::decode(cursor)?;
+        let tlvs = UpdateFulfillHtlcTlvs::from_stream(&tlv_stream)?;
+
+        Ok(Self {
+            channel_id,
+            id,
+            payment_preimage,
+            tlvs,
+        })
+    }
+}
+
+impl UpdateFulfillHtlcTlvs {
+    /// Extracts TLVs from a parsed TLV stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if `attribution_data` has invalid length.
+    fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
+        let attribution_data = stream
+            .get(TLV_ATTRIBUTION_DATA)
+            .map(AttributionData::decode)
+            .transpose()?;
+        Ok(Self { attribution_data })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CHANNEL_ID_SIZE;
+    use super::*;
+    use crate::bolt::attribution_data::TruncatedHmac;
+
+    fn sample_msg() -> UpdateFulfillHtlc {
+        UpdateFulfillHtlc {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            id: 42,
+            payment_preimage: [0xcd; PAYMENT_PREIMAGE_SIZE],
+            tlvs: UpdateFulfillHtlcTlvs::default(),
+        }
+    }
+
+    #[test]
+    fn encode_fixed_field_size() {
+        let msg = UpdateFulfillHtlc {
+            channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+            id: 1,
+            payment_preimage: [0xab; PAYMENT_PREIMAGE_SIZE],
+            tlvs: UpdateFulfillHtlcTlvs::default(),
+        };
+        let encoded = msg.encode();
+        // channel_id(32) + id(8) + payment_preimage(32) = 72
+        assert_eq!(encoded.len(), 72);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = sample_msg();
+        let encoded = original.encode();
+        let decoded = UpdateFulfillHtlc::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_attribution_data() {
+        let mut msg = sample_msg();
+        msg.tlvs.attribution_data = Some(AttributionData {
+            htlc_hold_times: [100; 20],
+            truncated_hmacs: [TruncatedHmac([0xaa; 4]); 210],
+        });
+        let encoded = msg.encode();
+        let decoded = UpdateFulfillHtlc::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn decode_truncated_attribution_data() {
+        let msg = sample_msg();
+        let mut encoded = msg.encode();
+        // Append a TLV type 1 with only 100 bytes (should be 920)
+        encoded.push(0x01); // type
+        encoded.push(0x64); // length = 100
+        encoded.extend_from_slice(&[0x00; 100]);
+        assert_eq!(
+            UpdateFulfillHtlc::decode(&encoded),
+            Err(BoltError::Truncated {
+                expected: AttributionData::SIZE,
+                actual: 100
+            })
+        );
+    }
+
+    #[test]
+    fn decode_unknown_odd_tlv_ignored() {
+        let mut msg = sample_msg();
+        let mut encoded = msg.encode();
+        // Append an unknown odd TLV (type 3, len 2, value 0xffff)
+        encoded.extend_from_slice(&[0x03, 0x02, 0xff, 0xff]);
+        let decoded = UpdateFulfillHtlc::decode(&encoded).unwrap();
+        msg.tlvs = UpdateFulfillHtlcTlvs::default();
+        assert_eq!(decoded.channel_id, msg.channel_id);
+        assert_eq!(decoded.id, msg.id);
+        assert_eq!(decoded.payment_preimage, msg.payment_preimage);
+    }
+
+    #[test]
+    fn decode_unknown_even_tlv_rejected() {
+        let mut encoded = sample_msg().encode();
+        // Append an unknown even TLV (type 2, len 1, value 0x00)
+        encoded.extend_from_slice(&[0x02, 0x01, 0x00]);
+        assert!(matches!(
+            UpdateFulfillHtlc::decode(&encoded),
+            Err(BoltError::TlvUnknownEvenType(2))
+        ));
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        assert_eq!(
+            UpdateFulfillHtlc::decode(&[0x00; 20]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 20
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_id() {
+        // Full channel_id (32 bytes) + only 4 bytes of id
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 4]);
+        assert_eq!(
+            UpdateFulfillHtlc::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 4
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_preimage() {
+        // Full channel_id (32 bytes) + full id (8 bytes) + only 16 bytes of preimage
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 8]);
+        data.extend_from_slice(&[0xbb; 16]);
+        assert_eq!(
+            UpdateFulfillHtlc::decode(&data),
+            Err(BoltError::Truncated {
+                expected: PAYMENT_PREIMAGE_SIZE,
+                actual: 16
+            })
+        );
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            UpdateFulfillHtlc::decode(&[]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 0
+            })
+        );
+    }
+}


### PR DESCRIPTION
Add codecs for the BOLT 2 HTLC update messages:

- `update_fulfill_htlc` (type 130) — fulfills an HTLC by providing the payment preimage. Wire format: `channel_id` (32 bytes) + `id` (u64) + `payment_preimage` (32 bytes). All fixed fields, 72 bytes total.
- `update_fail_htlc` (type 131) — fails an HTLC back to the sender with an encrypted failure reason. Wire format: `channel_id` (32 bytes) + `id` (u64) + `len` (u16) + `reason` (variable bytes).

**Changes:**
- New file: `smite/src/bolt/update_fulfill_htlc.rs` — `UpdateFulfillHtlc` struct with `encode()` / `decode()`
- New file: `smite/src/bolt/update_fail_htlc.rs` — `UpdateFailHtlc` struct with `encode()` / `decode()`
- Updated `smite/src/bolt.rs` — wired both into `Message` enum

**Tests:** 6 unit tests for `UpdateFulfillHtlc` + 8 unit tests for `UpdateFailHtlc` + 4 `Message`-level tests. All 264 bolt tests pass.

Part of #5 (Milestone 3).