### PR TITLE
bolt: add tx_init_rbf and tx_ack_rbf codecs

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -17,7 +17,9 @@ mod pong;
 mod shutdown;
 mod tlv;
 mod tx_abort;
+mod tx_ack_rbf;
 mod tx_complete;
+mod tx_init_rbf;
 mod tx_remove_input;
 mod tx_remove_output;
 mod types;
@@ -38,7 +40,9 @@ pub use pong::Pong;
 pub use shutdown::Shutdown;
 pub use tlv::{TlvRecord, TlvStream};
 pub use tx_abort::TxAbort;
+pub use tx_ack_rbf::{TxAckRbf, TxAckRbfTlvs};
 pub use tx_complete::TxComplete;
+pub use tx_init_rbf::{TxInitRbf, TxInitRbfTlvs};
 pub use tx_remove_input::TxRemoveInput;
 pub use tx_remove_output::TxRemoveOutput;
 pub use types::{
@@ -133,6 +137,10 @@ pub mod msg_type {
     pub const TX_REMOVE_OUTPUT: u16 = 69;
     /// `tx_complete` message (BOLT 2).
     pub const TX_COMPLETE: u16 = 70;
+    /// `tx_init_rbf` message (BOLT 2).
+    pub const TX_INIT_RBF: u16 = 72;
+    /// `tx_ack_rbf` message (BOLT 2).
+    pub const TX_ACK_RBF: u16 = 73;
     /// `tx_abort` message (BOLT 2).
     pub const TX_ABORT: u16 = 74;
     /// Gossip timestamp filter message (BOLT 7).
@@ -173,6 +181,10 @@ pub enum Message {
     TxRemoveOutput(TxRemoveOutput),
     /// `tx_complete` message (type 70).
     TxComplete(TxComplete),
+    /// `tx_init_rbf` message (type 72).
+    TxInitRbf(TxInitRbf),
+    /// `tx_ack_rbf` message (type 73).
+    TxAckRbf(TxAckRbf),
     /// `tx_abort` message (type 74).
     TxAbort(TxAbort),
     /// Gossip timestamp filter message (type 265).
@@ -209,6 +221,8 @@ impl Message {
             Self::TxRemoveInput(_) => msg_type::TX_REMOVE_INPUT,
             Self::TxRemoveOutput(_) => msg_type::TX_REMOVE_OUTPUT,
             Self::TxComplete(_) => msg_type::TX_COMPLETE,
+            Self::TxInitRbf(_) => msg_type::TX_INIT_RBF,
+            Self::TxAckRbf(_) => msg_type::TX_ACK_RBF,
             Self::TxAbort(_) => msg_type::TX_ABORT,
             Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => *msg_type,
@@ -236,6 +250,8 @@ impl Message {
             Self::TxRemoveInput(m) => out.extend(m.encode()),
             Self::TxRemoveOutput(m) => out.extend(m.encode()),
             Self::TxComplete(m) => out.extend(m.encode()),
+            Self::TxInitRbf(m) => out.extend(m.encode()),
+            Self::TxAckRbf(m) => out.extend(m.encode()),
             Self::TxAbort(m) => out.extend(m.encode()),
             Self::GossipTimestampFilter(m) => out.extend(m.encode()),
             Self::Unknown { payload, .. } => out.extend(payload),
@@ -270,6 +286,8 @@ impl Message {
             msg_type::TX_REMOVE_INPUT => Ok(Self::TxRemoveInput(TxRemoveInput::decode(cursor)?)),
             msg_type::TX_REMOVE_OUTPUT => Ok(Self::TxRemoveOutput(TxRemoveOutput::decode(cursor)?)),
             msg_type::TX_COMPLETE => Ok(Self::TxComplete(TxComplete::decode(cursor)?)),
+            msg_type::TX_INIT_RBF => Ok(Self::TxInitRbf(TxInitRbf::decode(cursor)?)),
+            msg_type::TX_ACK_RBF => Ok(Self::TxAckRbf(TxAckRbf::decode(cursor)?)),
             msg_type::TX_ABORT => Ok(Self::TxAbort(TxAbort::decode(cursor)?)),
             msg_type::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
                 GossipTimestampFilter::decode(cursor)?,
@@ -589,6 +607,32 @@ mod tests {
     }
 
     #[test]
+    fn message_tx_init_rbf_roundtrip() {
+        let tx_init_rbf = TxInitRbf {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            locktime: 800_000,
+            feerate: 5_000,
+            tlvs: TxInitRbfTlvs::default(),
+        };
+        let msg = Message::TxInitRbf(tx_init_rbf.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::TxInitRbf(tx_init_rbf));
+    }
+
+    #[test]
+    fn message_tx_ack_rbf_roundtrip() {
+        let tx_ack_rbf = TxAckRbf {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            tlvs: TxAckRbfTlvs::default(),
+        };
+        let msg = Message::TxAckRbf(tx_ack_rbf.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::TxAckRbf(tx_ack_rbf));
+    }
+
+    #[test]
     fn message_tx_abort_roundtrip() {
         let tx_abort = TxAbort::new(ChannelId::new([0xcd; CHANNEL_ID_SIZE]), "abort reason");
         let msg = Message::TxAbort(tx_abort.clone());
@@ -671,6 +715,24 @@ mod tests {
             })
             .msg_type(),
             msg_type::TX_COMPLETE
+        );
+        assert_eq!(
+            Message::TxInitRbf(TxInitRbf {
+                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                locktime: 0,
+                feerate: 0,
+                tlvs: TxInitRbfTlvs::default(),
+            })
+            .msg_type(),
+            msg_type::TX_INIT_RBF
+        );
+        assert_eq!(
+            Message::TxAckRbf(TxAckRbf {
+                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                tlvs: TxAckRbfTlvs::default(),
+            })
+            .msg_type(),
+            msg_type::TX_ACK_RBF
         );
         assert_eq!(
             Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),

--- a/smite/src/bolt/tx_ack_rbf.rs
+++ b/smite/src/bolt/tx_ack_rbf.rs
@@ -1,0 +1,234 @@
+//! BOLT 2 `tx_ack_rbf` message.
+
+use super::BoltError;
+use super::tlv::TlvStream;
+use super::types::ChannelId;
+use super::wire::WireFormat;
+
+/// TLV type for funding output contribution.
+const TLV_FUNDING_OUTPUT_CONTRIBUTION: u64 = 0;
+
+/// TLV type for require confirmed inputs.
+const TLV_REQUIRE_CONFIRMED_INPUTS: u64 = 2;
+
+/// BOLT 2 `tx_ack_rbf` message (type 73).
+///
+/// Sent by the non-initiator to acknowledge an RBF attempt initiated by
+/// the peer via `tx_init_rbf`.  After this message, both sides begin a
+/// new interactive transaction construction for the replacement transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxAckRbf {
+    /// The channel ID.
+    pub channel_id: ChannelId,
+    /// Optional TLV extensions.
+    pub tlvs: TxAckRbfTlvs,
+}
+
+/// TLV extensions for the `tx_ack_rbf` message.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TxAckRbfTlvs {
+    /// The amount the sender will contribute to the funding output (TLV type 0).
+    ///
+    /// Signed 64-bit integer; may be negative if the sender is removing funds.
+    pub funding_output_contribution: Option<i64>,
+
+    /// Whether the sender requires all inputs to be confirmed (TLV type 2).
+    ///
+    /// Presence of this TLV (even with empty value) signals the requirement.
+    pub require_confirmed_inputs: bool,
+}
+
+impl TxAckRbf {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+
+        // Encode TLVs
+        let mut tlv_stream = TlvStream::new();
+        if let Some(contribution) = self.tlvs.funding_output_contribution {
+            tlv_stream.add(
+                TLV_FUNDING_OUTPUT_CONTRIBUTION,
+                contribution.to_be_bytes().to_vec(),
+            );
+        }
+        if self.tlvs.require_confirmed_inputs {
+            tlv_stream.add(TLV_REQUIRE_CONFIRMED_INPUTS, vec![]);
+        }
+        out.extend(tlv_stream.encode());
+
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short, or TLV errors
+    /// if the TLV stream is malformed.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let channel_id = WireFormat::read(&mut cursor)?;
+
+        // Decode TLVs (remaining bytes)
+        let tlv_stream = TlvStream::decode_with_known(
+            cursor,
+            &[
+                TLV_FUNDING_OUTPUT_CONTRIBUTION,
+                TLV_REQUIRE_CONFIRMED_INPUTS,
+            ],
+        )?;
+        let tlvs = TxAckRbfTlvs::from_stream(&tlv_stream)?;
+
+        Ok(Self { channel_id, tlvs })
+    }
+}
+
+impl TxAckRbfTlvs {
+    /// Extracts TLVs from a parsed TLV stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if `funding_output_contribution` has invalid length.
+    fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
+        let funding_output_contribution =
+            if let Some(data) = stream.get(TLV_FUNDING_OUTPUT_CONTRIBUTION) {
+                let mut cursor = data;
+                Some(i64::read(&mut cursor)?)
+            } else {
+                None
+            };
+
+        let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
+
+        Ok(Self {
+            funding_output_contribution,
+            require_confirmed_inputs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CHANNEL_ID_SIZE;
+    use super::*;
+
+    fn sample_msg() -> TxAckRbf {
+        TxAckRbf {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            tlvs: TxAckRbfTlvs::default(),
+        }
+    }
+
+    #[test]
+    fn encode_fixed_field_size() {
+        let msg = TxAckRbf {
+            channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+            tlvs: TxAckRbfTlvs::default(),
+        };
+        let encoded = msg.encode();
+        assert_eq!(encoded.len(), CHANNEL_ID_SIZE);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = sample_msg();
+        let encoded = original.encode();
+        let decoded = TxAckRbf::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_funding_output_contribution() {
+        let mut msg = sample_msg();
+        msg.tlvs.funding_output_contribution = Some(500_000);
+        let encoded = msg.encode();
+        let decoded = TxAckRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_negative_contribution() {
+        let mut msg = sample_msg();
+        msg.tlvs.funding_output_contribution = Some(-100_000);
+        let encoded = msg.encode();
+        let decoded = TxAckRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_require_confirmed_inputs() {
+        let mut msg = sample_msg();
+        msg.tlvs.require_confirmed_inputs = true;
+        let encoded = msg.encode();
+        let decoded = TxAckRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_all_tlvs() {
+        let mut msg = sample_msg();
+        msg.tlvs.funding_output_contribution = Some(1_000_000);
+        msg.tlvs.require_confirmed_inputs = true;
+        let encoded = msg.encode();
+        let decoded = TxAckRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn decode_unknown_odd_tlv_ignored() {
+        let mut encoded = sample_msg().encode();
+        // Append an unknown odd TLV (type 3, len 2, value 0xffff)
+        encoded.extend_from_slice(&[0x03, 0x02, 0xff, 0xff]);
+        let decoded = TxAckRbf::decode(&encoded).unwrap();
+        assert_eq!(decoded.channel_id, ChannelId::new([0xab; CHANNEL_ID_SIZE]));
+    }
+
+    #[test]
+    fn decode_unknown_even_tlv_rejected() {
+        let mut encoded = sample_msg().encode();
+        // Append an unknown even TLV (type 4, len 1, value 0x00)
+        encoded.extend_from_slice(&[0x04, 0x01, 0x00]);
+        assert!(matches!(
+            TxAckRbf::decode(&encoded),
+            Err(BoltError::TlvUnknownEvenType(4))
+        ));
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        assert_eq!(
+            TxAckRbf::decode(&[0x00; 20]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 20
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_funding_output_contribution() {
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        // TLV type 0 (funding_output_contribution), length 4, only 4 bytes of value
+        data.extend_from_slice(&[0x00, 0x04, 0x00, 0x00, 0x00, 0x01]);
+        assert_eq!(
+            TxAckRbf::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 4
+            })
+        );
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            TxAckRbf::decode(&[]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 0
+            })
+        );
+    }
+}

--- a/smite/src/bolt/tx_init_rbf.rs
+++ b/smite/src/bolt/tx_init_rbf.rs
@@ -1,0 +1,283 @@
+//! BOLT 2 `tx_init_rbf` message.
+
+use super::BoltError;
+use super::tlv::TlvStream;
+use super::types::ChannelId;
+use super::wire::WireFormat;
+
+/// TLV type for funding output contribution.
+const TLV_FUNDING_OUTPUT_CONTRIBUTION: u64 = 0;
+
+/// TLV type for require confirmed inputs.
+const TLV_REQUIRE_CONFIRMED_INPUTS: u64 = 2;
+
+/// BOLT 2 `tx_init_rbf` message (type 72).
+///
+/// Sent by the initiator to begin an RBF attempt for an interactive
+/// transaction that has not yet confirmed.  The message carries the new
+/// locktime and feerate that will apply to the replacement transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxInitRbf {
+    /// The channel ID.
+    pub channel_id: ChannelId,
+    /// The locktime for the replacement transaction.
+    pub locktime: u32,
+    /// The feerate for the replacement transaction (satoshis per kilo-weight).
+    pub feerate: u32,
+    /// Optional TLV extensions.
+    pub tlvs: TxInitRbfTlvs,
+}
+
+/// TLV extensions for the `tx_init_rbf` message.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TxInitRbfTlvs {
+    /// The amount the sender will contribute to the funding output (TLV type 0).
+    ///
+    /// Signed 64-bit integer; may be negative if the sender is removing funds.
+    pub funding_output_contribution: Option<i64>,
+
+    /// Whether the sender requires all inputs to be confirmed (TLV type 2).
+    ///
+    /// Presence of this TLV (even with empty value) signals the requirement.
+    pub require_confirmed_inputs: bool,
+}
+
+impl TxInitRbf {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+        self.locktime.write(&mut out);
+        self.feerate.write(&mut out);
+
+        // Encode TLVs
+        let mut tlv_stream = TlvStream::new();
+        if let Some(contribution) = self.tlvs.funding_output_contribution {
+            tlv_stream.add(
+                TLV_FUNDING_OUTPUT_CONTRIBUTION,
+                contribution.to_be_bytes().to_vec(),
+            );
+        }
+        if self.tlvs.require_confirmed_inputs {
+            tlv_stream.add(TLV_REQUIRE_CONFIRMED_INPUTS, vec![]);
+        }
+        out.extend(tlv_stream.encode());
+
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short for any fixed field,
+    /// or TLV errors if the TLV stream is malformed.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let channel_id = WireFormat::read(&mut cursor)?;
+        let locktime = WireFormat::read(&mut cursor)?;
+        let feerate = WireFormat::read(&mut cursor)?;
+
+        // Decode TLVs (remaining bytes)
+        let tlv_stream = TlvStream::decode_with_known(
+            cursor,
+            &[
+                TLV_FUNDING_OUTPUT_CONTRIBUTION,
+                TLV_REQUIRE_CONFIRMED_INPUTS,
+            ],
+        )?;
+        let tlvs = TxInitRbfTlvs::from_stream(&tlv_stream)?;
+
+        Ok(Self {
+            channel_id,
+            locktime,
+            feerate,
+            tlvs,
+        })
+    }
+}
+
+impl TxInitRbfTlvs {
+    /// Extracts TLVs from a parsed TLV stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if `funding_output_contribution` has invalid length.
+    fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
+        let funding_output_contribution =
+            if let Some(data) = stream.get(TLV_FUNDING_OUTPUT_CONTRIBUTION) {
+                let mut cursor = data;
+                Some(i64::read(&mut cursor)?)
+            } else {
+                None
+            };
+
+        let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
+
+        Ok(Self {
+            funding_output_contribution,
+            require_confirmed_inputs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CHANNEL_ID_SIZE;
+    use super::*;
+
+    fn sample_msg() -> TxInitRbf {
+        TxInitRbf {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            locktime: 800_000,
+            feerate: 5_000,
+            tlvs: TxInitRbfTlvs::default(),
+        }
+    }
+
+    #[test]
+    fn encode_fixed_field_size() {
+        let msg = TxInitRbf {
+            channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+            locktime: 800_000,
+            feerate: 5_000,
+            tlvs: TxInitRbfTlvs::default(),
+        };
+        let encoded = msg.encode();
+        // channel_id(32) + locktime(4) + feerate(4) = 40
+        assert_eq!(encoded.len(), 40);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = sample_msg();
+        let encoded = original.encode();
+        let decoded = TxInitRbf::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_funding_output_contribution() {
+        let mut msg = sample_msg();
+        msg.tlvs.funding_output_contribution = Some(500_000);
+        let encoded = msg.encode();
+        let decoded = TxInitRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_negative_contribution() {
+        let mut msg = sample_msg();
+        msg.tlvs.funding_output_contribution = Some(-100_000);
+        let encoded = msg.encode();
+        let decoded = TxInitRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_require_confirmed_inputs() {
+        let mut msg = sample_msg();
+        msg.tlvs.require_confirmed_inputs = true;
+        let encoded = msg.encode();
+        let decoded = TxInitRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn roundtrip_with_all_tlvs() {
+        let mut msg = sample_msg();
+        msg.tlvs.funding_output_contribution = Some(1_000_000);
+        msg.tlvs.require_confirmed_inputs = true;
+        let encoded = msg.encode();
+        let decoded = TxInitRbf::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn decode_unknown_odd_tlv_ignored() {
+        let mut encoded = sample_msg().encode();
+        // Append an unknown odd TLV (type 3, len 2, value 0xffff)
+        encoded.extend_from_slice(&[0x03, 0x02, 0xff, 0xff]);
+        let decoded = TxInitRbf::decode(&encoded).unwrap();
+        assert_eq!(decoded.channel_id, ChannelId::new([0xab; CHANNEL_ID_SIZE]));
+    }
+
+    #[test]
+    fn decode_unknown_even_tlv_rejected() {
+        let mut encoded = sample_msg().encode();
+        // Append an unknown even TLV (type 4, len 1, value 0x00)
+        encoded.extend_from_slice(&[0x04, 0x01, 0x00]);
+        assert!(matches!(
+            TxInitRbf::decode(&encoded),
+            Err(BoltError::TlvUnknownEvenType(4))
+        ));
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        assert_eq!(
+            TxInitRbf::decode(&[0x00; 20]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 20
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_locktime() {
+        // Full channel_id (32 bytes) + only 2 bytes of locktime
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 2]);
+        assert_eq!(
+            TxInitRbf::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_feerate() {
+        // Full channel_id (32 bytes) + full locktime (4 bytes) + only 2 bytes of feerate
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x00; 4]); // locktime
+        data.extend_from_slice(&[0x00; 2]); // partial feerate
+        assert_eq!(
+            TxInitRbf::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_funding_output_contribution() {
+        let mut data = vec![0xaa; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&800_000u32.to_be_bytes()); // locktime
+        data.extend_from_slice(&5_000u32.to_be_bytes()); // feerate
+        // TLV type 0 (funding_output_contribution), length 4, only 4 bytes of value
+        data.extend_from_slice(&[0x00, 0x04, 0x00, 0x00, 0x00, 0x01]);
+        assert_eq!(
+            TxInitRbf::decode(&data),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 4
+            })
+        );
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            TxInitRbf::decode(&[]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 0
+            })
+        );
+    }
+}

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -60,6 +60,7 @@ impl_wire_format_int!(u8);
 impl_wire_format_int!(u16);
 impl_wire_format_int!(u32);
 impl_wire_format_int!(u64);
+impl_wire_format_int!(i64);
 
 impl WireFormat for PublicKey {
     fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
@@ -355,6 +356,79 @@ mod tests {
             let mut cursor: &[u8] = &buf;
             assert_eq!(u64::read(&mut cursor).unwrap(), value);
         }
+    }
+
+    #[test]
+    fn i64_read_valid() {
+        // Two values back-to-back; verify cursor advances after each read.
+        let mut data: &[u8] = &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // 1
+        ];
+        assert_eq!(i64::read(&mut data).unwrap(), 0);
+        assert_eq!(data.len(), 8);
+        assert_eq!(i64::read(&mut data).unwrap(), 1);
+        assert!(data.is_empty());
+
+        // Negative (-1 = 0xffffffffffffffff in two's complement)
+        let mut data: &[u8] = &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+        assert_eq!(i64::read(&mut data).unwrap(), -1);
+
+        // Negative (-100_000)
+        let mut data: &[u8] = &(-100_000i64).to_be_bytes();
+        assert_eq!(i64::read(&mut data).unwrap(), -100_000);
+
+        // i64::MAX
+        let mut data: &[u8] = &i64::MAX.to_be_bytes();
+        assert_eq!(i64::read(&mut data).unwrap(), i64::MAX);
+
+        // i64::MIN
+        let mut data: &[u8] = &i64::MIN.to_be_bytes();
+        assert_eq!(i64::read(&mut data).unwrap(), i64::MIN);
+    }
+
+    #[test]
+    fn i64_read_truncated() {
+        let mut empty: &[u8] = &[];
+        assert_eq!(
+            i64::read(&mut empty),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 0
+            })
+        );
+
+        let mut short: &[u8] = &[0x00; 7];
+        assert_eq!(
+            i64::read(&mut short),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 7
+            })
+        );
+    }
+
+    #[test]
+    fn i64_write_roundtrip() {
+        for value in [0i64, 1, -1, i64::MAX, i64::MIN, -100_000, 500_000] {
+            let mut buf = Vec::new();
+            value.write(&mut buf);
+            assert_eq!(buf.len(), 8);
+            let mut cursor: &[u8] = &buf;
+            assert_eq!(i64::read(&mut cursor).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn i64_negative_wire_encoding() {
+        // Verify negative values use big-endian two's complement
+        let mut buf = Vec::new();
+        (-1i64).write(&mut buf);
+        assert_eq!(buf, vec![0xff; 8]);
+
+        let mut buf = Vec::new();
+        i64::MIN.write(&mut buf);
+        assert_eq!(buf, vec![0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
     }
 
     #[test]


### PR DESCRIPTION
Add encoding/decoding support for two interactive transaction RBF messages from BOLT 2:

- **`tx_init_rbf`** (type 72): `channel_id` (32) + `locktime` (u32, 4) + `feerate` (u32, 4) — 40 bytes total
- **`tx_ack_rbf`** (type 73): `channel_id` (32) — 32 bytes total

Both messages are part of the interactive transaction protocol's RBF (Replace-By-Fee) flow, where `tx_init_rbf` initiates an RBF attempt and `tx_ack_rbf` acknowledges it.

## Changes

- **`smite/src/bolt/tx_init_rbf.rs`** — New codec: `TxInitRbf` struct with `encode()`/`decode()` and tests (roundtrip, field sizes, truncation for each field, empty payload)
- **`smite/src/bolt/tx_ack_rbf.rs`** — New codec: `TxAckRbf` struct with `encode()`/`decode()` and tests (roundtrip, field sizes, truncation, empty payload, trailing bytes)
- **`smite/src/bolt.rs`** — Wire both codecs into the `Message` enum with msg_type constants (`TX_INIT_RBF = 72`, `TX_ACK_RBF = 73`), `msg_type()`/`encode()`/`decode()` match arms, and Message-level roundtrip + type_values tests

## Testing

- All 261 bolt tests pass
- `cargo clippy` clean (0 warnings)
- `cargo fmt --all --check` clean

## Notes

TLV streams (`funding_output_contribution`, `require_confirmed_inputs`) are omitted for now, consistent with how existing codecs handle optional TLVs.