### PR TITLE
BOLT 7: announcement_signature. Type: 259

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -4,6 +4,7 @@
 //! protocol messages as specified in the BOLT specifications.
 
 mod accept_channel;
+mod announcement_signature;
 mod error;
 mod funding_created;
 mod funding_signed;
@@ -23,6 +24,7 @@ mod warning;
 mod wire;
 
 pub use accept_channel::{AcceptChannel, AcceptChannelTlvs};
+pub use announcement_signature::AnnouncementSignatures;
 pub use error::Error;
 pub use funding_created::FundingCreated;
 pub use funding_signed::FundingSigned;
@@ -38,7 +40,8 @@ pub use tx_complete::TxComplete;
 pub use tx_remove_input::TxRemoveInput;
 pub use tx_remove_output::TxRemoveOutput;
 pub use types::{
-    BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, MAX_MESSAGE_SIZE, TXID_SIZE, Txid,
+    BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, MAX_MESSAGE_SIZE, SIGNATURE_SIZE,
+    ShortChannelId, Signature, TXID_SIZE, Txid,
 };
 pub use warning::Warning;
 pub use wire::WireFormat;
@@ -126,6 +129,8 @@ pub mod msg_type {
     pub const TX_COMPLETE: u16 = 70;
     /// `tx_abort` message (BOLT 2).
     pub const TX_ABORT: u16 = 74;
+    /// `announcement_signatures` message (BOLT 7).
+    pub const ANNOUNCEMENT_SIGNATURES: u16 = 259;
     /// Gossip timestamp filter message (BOLT 7).
     pub const GOSSIP_TIMESTAMP_FILTER: u16 = 265;
 }
@@ -162,6 +167,8 @@ pub enum Message {
     TxComplete(TxComplete),
     /// `tx_abort` message (type 74).
     TxAbort(TxAbort),
+    /// `announcement_signatures` message (type 259).
+    AnnouncementSignatures(AnnouncementSignatures),
     /// Gossip timestamp filter message (type 265).
     GossipTimestampFilter(GossipTimestampFilter),
     /// Unknown message type.
@@ -195,6 +202,7 @@ impl Message {
             Self::TxRemoveOutput(_) => msg_type::TX_REMOVE_OUTPUT,
             Self::TxComplete(_) => msg_type::TX_COMPLETE,
             Self::TxAbort(_) => msg_type::TX_ABORT,
+            Self::AnnouncementSignatures(_) => msg_type::ANNOUNCEMENT_SIGNATURES,
             Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => *msg_type,
         }
@@ -220,6 +228,7 @@ impl Message {
             Self::TxRemoveOutput(m) => out.extend(m.encode()),
             Self::TxComplete(m) => out.extend(m.encode()),
             Self::TxAbort(m) => out.extend(m.encode()),
+            Self::AnnouncementSignatures(m) => out.extend(m.encode()),
             Self::GossipTimestampFilter(m) => out.extend(m.encode()),
             Self::Unknown { payload, .. } => out.extend(payload),
         }
@@ -252,6 +261,9 @@ impl Message {
             msg_type::TX_REMOVE_OUTPUT => Ok(Self::TxRemoveOutput(TxRemoveOutput::decode(cursor)?)),
             msg_type::TX_COMPLETE => Ok(Self::TxComplete(TxComplete::decode(cursor)?)),
             msg_type::TX_ABORT => Ok(Self::TxAbort(TxAbort::decode(cursor)?)),
+            msg_type::ANNOUNCEMENT_SIGNATURES => Ok(Self::AnnouncementSignatures(
+                AnnouncementSignatures::decode(cursor)?,
+            )),
             msg_type::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
                 GossipTimestampFilter::decode(cursor)?,
             )),
@@ -445,6 +457,16 @@ mod tests {
         }
     }
 
+    /// Valid `AnnouncementSignatures` message for testing.
+    fn sample_announcement_signatures() -> AnnouncementSignatures {
+        AnnouncementSignatures {
+            channel_id: ChannelId::new([0xaa; CHANNEL_ID_SIZE]),
+            short_channel_id: ShortChannelId::new(0x0001_0002_0003),
+            node_signature: Signature::new([0x01; SIGNATURE_SIZE]),
+            bitcoin_signature: Signature::new([0x02; SIGNATURE_SIZE]),
+        }
+    }
+
     #[test]
     fn message_funding_signed_roundtrip() {
         let fs = sample_funding_signed();
@@ -452,6 +474,15 @@ mod tests {
         let encoded = msg.encode();
         let decoded = Message::decode(&encoded).unwrap();
         assert_eq!(decoded, Message::FundingSigned(fs));
+    }
+
+    #[test]
+    fn message_announcement_signatures_roundtrip() {
+        let announcement_signatures = sample_announcement_signatures();
+        let msg = Message::AnnouncementSignatures(announcement_signatures.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::AnnouncementSignatures(announcement_signatures));
     }
 
     #[test]
@@ -587,6 +618,10 @@ mod tests {
         assert_eq!(
             Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),
             msg_type::TX_ABORT
+        );
+        assert_eq!(
+            Message::AnnouncementSignatures(sample_announcement_signatures()).msg_type(),
+            msg_type::ANNOUNCEMENT_SIGNATURES
         );
         assert_eq!(
             Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),

--- a/smite/src/bolt/announcement_signature.rs
+++ b/smite/src/bolt/announcement_signature.rs
@@ -1,0 +1,166 @@
+//! BOLT 7 `announcement_signatures` message.
+
+use super::BoltError;
+use super::types::{ChannelId, ShortChannelId, Signature};
+use super::wire::WireFormat;
+
+/// BOLT 7 `announcement_signatures` message (type 259 / 0x0103).
+///
+/// Sent directly between the two endpoints of a channel. Signals the
+/// sender's willingness to announce the channel publicly and provides
+/// the signatures needed to construct the `channel_announcement` message.
+///
+/// Only sent when `announce_channel` was set in `channel_flags` during
+/// channel opening (BOLT 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnouncementSignatures {
+    /// The channel this message refers to.
+    pub channel_id: ChannelId,
+    /// The compact on-chain identifier of the channel's funding output.
+    pub short_channel_id: ShortChannelId,
+    /// The sender's node signature over the `channel_announcement`.
+    pub node_signature: Signature,
+    /// The sender's bitcoin key signature over the `channel_announcement`.
+    pub bitcoin_signature: Signature,
+}
+
+impl AnnouncementSignatures {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+        self.short_channel_id.write(&mut out);
+        self.node_signature.write(&mut out);
+        self.bitcoin_signature.write(&mut out);
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short for any field.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let channel_id       = ChannelId::read(&mut cursor)?;
+        let short_channel_id = ShortChannelId::read(&mut cursor)?;
+        let node_signature   = Signature::read(&mut cursor)?;
+        let bitcoin_signature = Signature::read(&mut cursor)?;
+
+        Ok(Self {
+            channel_id,
+            short_channel_id,
+            node_signature,
+            bitcoin_signature,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{CHANNEL_ID_SIZE, SIGNATURE_SIZE};
+
+    fn dummy() -> AnnouncementSignatures {
+        AnnouncementSignatures {
+            channel_id:        ChannelId::new([0xaa; CHANNEL_ID_SIZE]),
+            short_channel_id:  ShortChannelId::new(0x0001_0002_0003),
+            node_signature:    Signature::new([0x01; SIGNATURE_SIZE]),
+            bitcoin_signature: Signature::new([0x02; SIGNATURE_SIZE]),
+        }
+    }
+
+    #[test]
+    fn encode_field_sizes() {
+        let encoded = dummy().encode();
+        // channel_id(32) + short_channel_id(8) + node_sig(64) + bitcoin_sig(64)
+        assert_eq!(
+            encoded.len(),
+            CHANNEL_ID_SIZE + 8 + SIGNATURE_SIZE + SIGNATURE_SIZE
+        );
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = dummy();
+        let decoded = AnnouncementSignatures::decode(&original.encode()).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_different_values() {
+        let msg = AnnouncementSignatures {
+            channel_id:        ChannelId::new([0xff; CHANNEL_ID_SIZE]),
+            short_channel_id:  ShortChannelId::new(0xffff_ffff_ffff_ffff),
+            node_signature:    Signature::new([0xab; SIGNATURE_SIZE]),
+            bitcoin_signature: Signature::new([0xcd; SIGNATURE_SIZE]),
+        };
+        let decoded = AnnouncementSignatures::decode(&msg.encode()).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            AnnouncementSignatures::decode(&[]),
+            Err(BoltError::Truncated { expected: CHANNEL_ID_SIZE, actual: 0 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        assert_eq!(
+            AnnouncementSignatures::decode(&[0x00; 20]),
+            Err(BoltError::Truncated { expected: CHANNEL_ID_SIZE, actual: 20 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_short_channel_id() {
+        // full channel_id(32) then 3 of 8 bytes of short_channel_id
+        assert_eq!(
+            AnnouncementSignatures::decode(&[0x00; CHANNEL_ID_SIZE + 3]),
+            Err(BoltError::Truncated { expected: 8, actual: 3 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_node_signature() {
+        // full channel_id(32) + short_channel_id(8) then 10 of 64 bytes of node_sig
+        assert_eq!(
+            AnnouncementSignatures::decode(&[0x00; CHANNEL_ID_SIZE + 8 + 10]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 10 })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_bitcoin_signature() {
+        // full channel_id(32) + short_channel_id(8) + node_sig(64) then 20 of 64 bytes
+        assert_eq!(
+            AnnouncementSignatures::decode(&[0x00; CHANNEL_ID_SIZE + 8 + SIGNATURE_SIZE + 20]),
+            Err(BoltError::Truncated { expected: SIGNATURE_SIZE, actual: 20 })
+        );
+    }
+
+    #[test]
+    fn decode_trailing_bytes() {
+        // valid payload with extra bytes at the end — should succeed
+        let mut encoded = dummy().encode();
+        encoded.extend_from_slice(&[0xff; 10]);
+        let decoded = AnnouncementSignatures::decode(&encoded).unwrap();
+        assert_eq!(decoded, dummy());
+    }
+
+    #[test]
+    fn short_channel_id_roundtrip_boundary_values() {
+        for scid in [0u64, 1, u64::MAX] {
+            let msg = AnnouncementSignatures {
+                short_channel_id: ShortChannelId::new(scid),
+                ..dummy()
+            };
+            let decoded = AnnouncementSignatures::decode(&msg.encode()).unwrap();
+            assert_eq!(decoded.short_channel_id, msg.short_channel_id);
+        }
+    }
+}

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -17,6 +17,9 @@ pub const TXID_SIZE: usize = 32;
 /// Size of a compact ECDSA signature in bytes.
 pub const COMPACT_SIGNATURE_SIZE: usize = 64;
 
+/// Size of a compact gossip signature in bytes.
+pub const SIGNATURE_SIZE: usize = COMPACT_SIGNATURE_SIZE;
+
 /// A 32-byte channel identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChannelId(pub [u8; CHANNEL_ID_SIZE]);
@@ -35,6 +38,42 @@ impl ChannelId {
     /// Returns the channel ID as a byte slice.
     #[must_use]
     pub fn as_bytes(&self) -> &[u8; CHANNEL_ID_SIZE] {
+        &self.0
+    }
+}
+
+/// Compact channel identifier containing block, tx, and output indexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ShortChannelId(pub u64);
+
+impl ShortChannelId {
+    /// Creates a short channel ID from its encoded 64-bit representation.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the encoded 64-bit representation.
+    #[must_use]
+    pub const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// A 64-byte compact gossip signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Signature(pub [u8; SIGNATURE_SIZE]);
+
+impl Signature {
+    /// Creates a signature from compact bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; SIGNATURE_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns compact signature bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; SIGNATURE_SIZE] {
         &self.0
     }
 }
@@ -112,5 +151,20 @@ mod tests {
     #[test]
     fn channel_id_default_is_all() {
         assert_eq!(ChannelId::default(), ChannelId::ALL);
+    }
+
+    #[test]
+    fn short_channel_id_new() {
+        let scid = ShortChannelId::new(0x0001_0002_0003);
+        assert_eq!(scid.0, 0x0001_0002_0003);
+        assert_eq!(scid.value(), 0x0001_0002_0003);
+    }
+
+    #[test]
+    fn signature_new() {
+        let bytes = [0x22u8; SIGNATURE_SIZE];
+        let sig = Signature::new(bytes);
+        assert_eq!(sig.0, bytes);
+        assert_eq!(sig.as_bytes(), &bytes);
     }
 }

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -2,7 +2,8 @@
 
 use crate::bolt::BoltError;
 use crate::bolt::types::{
-    BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, TXID_SIZE, Txid,
+    BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, SIGNATURE_SIZE, ShortChannelId,
+    Signature as BoltSignature, TXID_SIZE, Txid,
 };
 use secp256k1::PublicKey;
 use secp256k1::ecdsa::Signature;
@@ -78,6 +79,27 @@ impl WireFormat for ChannelId {
     fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
         let bytes: [u8; CHANNEL_ID_SIZE] = WireFormat::read(data)?;
         Ok(Self(bytes))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.as_bytes().write(out);
+    }
+}
+
+impl WireFormat for ShortChannelId {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        Ok(Self::new(u64::read(data)?))
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        self.value().write(out);
+    }
+}
+
+impl WireFormat for BoltSignature {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
+        let bytes: [u8; SIGNATURE_SIZE] = WireFormat::read(data)?;
+        Ok(Self::new(bytes))
     }
 
     fn write(&self, out: &mut Vec<u8>) {


### PR DESCRIPTION
- Adds BOLT 7 announcement_signatures support (type 259, 0x0103) with full encode and decode coverage.
- Wires the message into the top-level BOLT dispatcher and exports.
- Adds and uses typed primitives plus wire-format support for ShortChannelId and gossip Signature.
 
To test: 

- cargo test -p smite announcement_signature::tests -- --nocapture
- cargo test -p smite message_announcement_signatures_roundtrip -- --nocapture