### PR TITLE
added crate level documentation for smite core library

### DIFF
--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -1,3 +1,18 @@
+//! Core library for the smite coverage-guided fuzzing framework.
+//!
+//! Smite finds bugs in Lightning Network implementations by sending
+//! fuzz-derived protocol messages to target nodes (LND, LDK, CLN, Eclair)
+//! and checking whether they crash or violate invariants. This crate
+//! provides the building blocks that scenarios and targets are built on.
+//!
+//! # Modules
+//! - [`bolt`] - BOLT message encoding and decoding.
+//! - [`noise`] - BOLT 8 `Noise_XK` encrypted transport.
+//! - [`oracles`] - Post-scenario invariant checks.
+//! - [`process`] - Managed subprocess utilities.
+//! - [`runners`] - Fuzz input delivery (Nyx and local modes).
+//! - [`scenarios`] - Scenario trait and the [`scenarios::smite_run`] entry point.
+
 pub mod bolt;
 pub mod noise;
 pub mod oracles;

--- a/smite/src/oracles.rs
+++ b/smite/src/oracles.rs
@@ -1,3 +1,7 @@
+//! Oracle trait for post-scenario invariant checks.
+//!
+//! Oracles evaluate conditions beyond simple crashes.
+
 /// Result of an oracle evaluation
 pub enum OracleResult {
     /// The check passed

--- a/smite/src/process.rs
+++ b/smite/src/process.rs
@@ -1,4 +1,7 @@
 //! Process management utilities for spawning and controlling subprocesses.
+//!
+//! Wraps [`std::process::Child`] with graceful shutdown support
+//! and automatic cleanup on drop.
 
 use std::io;
 use std::process::{Child, Command, ExitStatus};

--- a/smite/src/runners.rs
+++ b/smite/src/runners.rs
@@ -1,3 +1,12 @@
+//! Fuzz input delivery for Nyx and local modes.
+//!
+//! The [`Runner`] trait abstracts how fuzz inputs reach a scenario.
+//! [`NyxRunner`] (requires the `nyx` cargo feature) communicates with
+//! the Nyx hypervisor for fast snapshot-based fuzzing.  [`LocalRunner`]
+//! reads input from a file or stdin for crash reproduction.
+//! [`StdRunner`] auto-selects between them based on the `SMITE_NYX`
+//! environment variable.
+
 #[cfg(feature = "nyx")]
 use smite_nyx_sys::{nyx_fail, nyx_get_fuzz_input, nyx_init, nyx_release, nyx_skip};
 

--- a/smite/src/scenarios.rs
+++ b/smite/src/scenarios.rs
@@ -1,3 +1,11 @@
+//! Scenario trait and the [`smite_run`] entry point.
+//!
+//! A [`Scenario`] defines how fuzz input is turned into protocol
+//! interactions, from raw encrypted bytes to structured IR programs.
+//! [`smite_run`] is the main function for all scenario binaries: it
+//! initializes the runner, creates the scenario, delivers input and
+//! reports results.
+
 use crate::{bolt::BoltError, noise::ConnectionError};
 
 /// `ScenarioResult` describes the outcomes of running a scenario


### PR DESCRIPTION
The smite crate's `lib.rs` had no documentation. This pr adds crate level doc comment explaining the library's purpose and descriptions of each module.