### PR TITLE
ci: Check order of BOLT message type constants

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all --check
 
+      - name: Check order of BOLT message type constants
+        run: scripts/check-bolt-msg-type-order.sh
+
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/scripts/check-bolt-msg-type-order.sh
+++ b/scripts/check-bolt-msg-type-order.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# This script is called in the CI pipeline. It makes sure that the BOLT message
+# type constants in smite/src/bolt.rs are listed in increasing order.
+# It also makes sure that other code blocks follow that order.
+
+set -eu
+set -o pipefail
+
+FILE=smite/src/bolt.rs
+
+order_pub_mod_msg_type() {
+    # awk '/start/,/end/ { print }' <file>
+    #   Print everything between the lines matching start and end
+    # grep x3
+    #   Print the last number of every line matching "pub const" (BOLT message type constant)
+    awk '/^pub mod msg_type {/,/^}/ { print }' $FILE | \
+        grep "pub const" | \
+        grep -oE '= [0-9]+;$' | \
+        grep -oE '[0-9]+'
+}
+
+echo "Checking pub mod msg_type { ... }"
+diff -u <(order_pub_mod_msg_type) <(order_pub_mod_msg_type | sort -n)
+echo "OK"
+
+# We now know the keys are in the correct order. We can now use a
+# canonical form of the keys to check if other blocks are in the same order.
+
+to_canonical() {
+    tr -d ':_ ' | tr '[:upper:]' '[:lower:]'
+}
+
+order_canonical_keys() {
+    # print all keys in pub mod msg_type { ... }
+    awk '/^pub mod msg_type {/,/^}/ { print }' $FILE | \
+        grep "pub const" | \
+        awk '{ print $3 }' | \
+        to_canonical
+}
+
+order_pub_enum_message() {
+    # awk:  print pub enum Message { ... }
+    # grep: only keep lines like "Warning(Warning),"
+    # sed:  remove everything after first '('
+    awk '/^pub enum Message {/,/^}/ { print }' $FILE | \
+        grep -E "[A-Za-z0-9]+\([A-Za-z0-9]+\)" | \
+        sed 's/(.*//' | \
+        to_canonical
+}
+
+impl_message_block() {
+    awk '/^impl Message {/,/^}/ { print }' $FILE
+}
+
+order_impl_message_msg_type() {
+    impl_message_block | \
+        awk '/^    pub fn msg_type/,/^    }/ { print }' | \
+        grep "Self::" | \
+        sed -e 's/Self:://' -e 's/(.*//' | \
+        grep -v "Unknown" | \
+        to_canonical
+}
+
+order_impl_message_encode() {
+    impl_message_block | \
+        awk '/^    pub fn encode/,/^    }/ { print }' | \
+        grep "Self::" | \
+        sed -e 's/Self:://' -e 's/(.*//' | \
+        grep -v "Unknown" | \
+        to_canonical
+}
+
+order_impl_message_decode() {
+    impl_message_block | \
+        awk '/^    pub fn decode/,/^    }/ { print }' | \
+        grep "msg_type::" | \
+        sed -e 's/msg_type:://' -e 's/ =>.*//' | \
+        grep -v "Unknown" | \
+        to_canonical
+}
+
+tests_block() {
+    awk '/^mod tests {/,/^}/' $FILE
+}
+
+order_tests() {
+    tests_block | \
+        grep -oE "fn message_[A-Za-z0-9_]+_roundtrip" | \
+        grep -v "message_unknown_roundtrip" | \
+        sed -e 's/fn message_//' -e 's/_roundtrip//' | \
+        to_canonical
+}
+
+order_tests_message_type_values() {
+    tests_block | \
+        awk '/^    fn message_type_values\(\) {/,/^    }/ { print }' | \
+        grep -oE "msg_type::[A-Za-z0-9_]+" | \
+        sed 's/msg_type:://' | \
+        to_canonical
+}
+
+echo "Checking pub enum Message { ... }"
+diff -u <(order_pub_enum_message) <(order_canonical_keys)
+echo "OK"
+
+echo "Checking impl Message::msg_type { ... }"
+diff -u <(order_impl_message_msg_type) <(order_canonical_keys)
+echo "OK"
+
+echo "Checking impl Message::encode { ... }"
+diff -u <(order_impl_message_encode) <(order_canonical_keys)
+echo "OK"
+
+echo "Checking impl Message::decode { ... }"
+diff -u <(order_impl_message_decode) <(order_canonical_keys)
+echo "OK"
+
+echo "Checking roundtrip tests"
+diff -u <(order_tests) <(order_canonical_keys)
+echo "OK"
+
+echo "Checking message_type_values in tests"
+diff -u <(order_tests_message_type_values) <(order_canonical_keys)
+echo "OK"

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -480,16 +480,6 @@ mod tests {
     }
 
     #[test]
-    fn message_gossip_timestamp_filter_roundtrip() {
-        let chain_hash = [0x6f; 32];
-        let filter = GossipTimestampFilter::new(chain_hash, 1_000_000, 86400);
-        let msg = Message::GossipTimestampFilter(filter.clone());
-        let encoded = msg.encode();
-        let decoded = Message::decode(&encoded).unwrap();
-        assert_eq!(decoded, Message::GossipTimestampFilter(filter));
-    }
-
-    #[test]
     fn message_shutdown_roundtrip() {
         let shutdown = Shutdown::for_channel(ChannelId::default(), vec![0x00, 0x14, 0xab, 0xcd]);
         let msg = Message::Shutdown(shutdown.clone());
@@ -579,6 +569,16 @@ mod tests {
         let encoded = msg.encode();
         let decoded = Message::decode(&encoded).unwrap();
         assert_eq!(decoded, Message::TxAbort(tx_abort));
+    }
+
+    #[test]
+    fn message_gossip_timestamp_filter_roundtrip() {
+        let chain_hash = [0x6f; 32];
+        let filter = GossipTimestampFilter::new(chain_hash, 1_000_000, 86400);
+        let msg = Message::GossipTimestampFilter(filter.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::GossipTimestampFilter(filter));
     }
 
     #[test]


### PR DESCRIPTION
Just a suggestion. I noticed this gets mentioned a lot during review. I think the script is simple enough to understand to make it worth adding to the CI without adding maintenance burden.