### PR TITLE
refactor: Move ScenarioError into smite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "sha2",
  "simple_logger",
  "smite-nyx-sys",
+ "thiserror",
 ]
 
 [[package]]
@@ -531,7 +532,6 @@ dependencies = [
  "smite",
  "smite-nyx-sys",
  "tempfile",
- "thiserror",
 ]
 
 [[package]]

--- a/smite-scenarios/Cargo.toml
+++ b/smite-scenarios/Cargo.toml
@@ -23,4 +23,3 @@ libc = "0.2"
 serde.workspace = true
 serde_json = "1"
 tempfile = "3"
-thiserror = "2"

--- a/smite-scenarios/src/scenarios.rs
+++ b/smite-scenarios/src/scenarios.rs
@@ -7,14 +7,15 @@ mod noise;
 pub use encrypted_bytes::EncryptedBytesScenario;
 pub use init::InitScenario;
 pub use noise::NoiseScenario;
+use smite::scenarios::ScenarioError;
 
 use std::time::Duration;
 
 use secp256k1::SecretKey;
-use smite::bolt::{BoltError, Init, Message, Ping};
-use smite::noise::{ConnectionError, NoiseConnection};
+use smite::bolt::{Init, Message, Ping};
+use smite::noise::NoiseConnection;
 
-use crate::targets::{Target, TargetError};
+use crate::targets::Target;
 
 /// Static keys for Noise handshake. Using fixed keys ensures reproducibility
 /// of fuzz failures across runs.
@@ -26,39 +27,6 @@ const EPHEMERAL_KEY: [u8; 32] = [
     0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12,
     0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12,
 ];
-
-/// Error from scenario operations.
-#[derive(Debug, thiserror::Error)]
-pub enum ScenarioError {
-    /// Target failed to start or crashed.
-    #[error("target error: {0}")]
-    Target(#[from] TargetError),
-
-    /// Connection or handshake failed.
-    #[error("connection failed: {0}")]
-    Connection(#[from] ConnectionError),
-
-    /// Failed to decode a BOLT message.
-    #[error("decode error: {0}")]
-    Decode(#[from] BoltError),
-
-    /// Protocol error (e.g., unexpected message).
-    #[error("protocol error: {0}")]
-    Protocol(String),
-}
-
-impl ScenarioError {
-    /// Returns true if this error is a timeout (potential hang).
-    #[must_use]
-    pub fn is_timeout(&self) -> bool {
-        use std::io::ErrorKind;
-        if let Self::Connection(ConnectionError::Io(e)) = self {
-            matches!(e.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock)
-        } else {
-            false
-        }
-    }
-}
 
 /// Connect to a target and perform the init handshake.
 ///

--- a/smite-scenarios/src/scenarios/encrypted_bytes.rs
+++ b/smite-scenarios/src/scenarios/encrypted_bytes.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use smite::noise::NoiseConnection;
-use smite::scenarios::{Scenario, ScenarioResult};
+use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
 
 use super::{connect_to_target, ping_pong};
 use crate::targets::Target;
@@ -19,17 +19,16 @@ pub struct EncryptedBytesScenario<T: Target> {
 }
 
 impl<T: Target> Scenario for EncryptedBytesScenario<T> {
-    fn new(_args: &[String]) -> Result<Self, String> {
+    fn new(_args: &[String]) -> Result<Self, ScenarioError> {
         let config = T::Config::default();
-        let target = T::start(config).map_err(|e| e.to_string())?;
-        let mut conn =
-            connect_to_target(&target, Duration::from_secs(5)).map_err(|e| e.to_string())?;
+        let target = T::start(config)?;
+        let mut conn = connect_to_target(&target, Duration::from_secs(5))?;
 
         // Warm up the target's message handling path before the Nyx snapshot.
         // For JVM-based targets (i.e. Eclair), this  causes the necessary
         // classes to load and be JIT compiled before we take the snapshot,
         // speeding up every subsequent iteration.
-        ping_pong(&mut conn).map_err(|e| e.to_string())?;
+        ping_pong(&mut conn)?;
 
         Ok(Self { target, conn })
     }

--- a/smite-scenarios/src/scenarios/init.rs
+++ b/smite-scenarios/src/scenarios/init.rs
@@ -6,7 +6,7 @@ use secp256k1::SecretKey;
 use smite::bolt;
 use smite::bolt::Message;
 use smite::noise::{MAX_MESSAGE_SIZE, NoiseConnection};
-use smite::scenarios::{Scenario, ScenarioResult};
+use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
 
 use super::{EPHEMERAL_KEY, STATIC_KEY, connect_to_target, ping_pong};
 use crate::targets::Target;
@@ -30,15 +30,15 @@ pub struct InitScenario<T: Target> {
 }
 
 impl<T: Target> Scenario for InitScenario<T> {
-    fn new(_args: &[String]) -> Result<Self, String> {
+    fn new(_args: &[String]) -> Result<Self, ScenarioError> {
         let config = T::Config::default();
-        let target = T::start(config).map_err(|e| e.to_string())?;
+        let target = T::start(config)?;
 
         // Establish a warmup connection for ping-pong. This warms up the
         // target's message handling code paths before the Nyx snapshot
         // (important for JVM targets like Eclair).
-        let mut warmup_conn = connect_to_target(&target, TIMEOUT).map_err(|e| e.to_string())?;
-        ping_pong(&mut warmup_conn).map_err(|e| e.to_string())?;
+        let mut warmup_conn = connect_to_target(&target, TIMEOUT)?;
+        ping_pong(&mut warmup_conn)?;
         drop(warmup_conn);
 
         // Establish the fuzz connection, complete the handshake, and receive
@@ -52,12 +52,11 @@ impl<T: Target> Scenario for InitScenario<T> {
             local_static,
             local_ephemeral,
             TIMEOUT,
-        )
-        .map_err(|e| e.to_string())?;
+        )?;
 
-        let init_bytes = conn.recv_message().map_err(|e| e.to_string())?;
-        let Message::Init(_) = Message::decode(&init_bytes).map_err(|e| e.to_string())? else {
-            return Err("expected init message".into());
+        let init_bytes = conn.recv_message()?;
+        let Message::Init(_) = Message::decode(&init_bytes)? else {
+            return Err(ScenarioError::Protocol("expected init message".into()));
         };
 
         Ok(Self { target, conn })

--- a/smite-scenarios/src/scenarios/noise.rs
+++ b/smite-scenarios/src/scenarios/noise.rs
@@ -9,7 +9,7 @@ use smite::bolt::{Init, Message};
 use smite::noise::{
     ACT_TWO_SIZE, ENCRYPTED_LENGTH_SIZE, MAC_SIZE, NoiseCipher, NoiseConnection, NoiseHandshake,
 };
-use smite::scenarios::{Scenario, ScenarioResult};
+use smite::scenarios::{Scenario, ScenarioError, ScenarioResult, TargetError};
 
 use super::{EPHEMERAL_KEY, connect_to_target, ping_pong};
 use crate::targets::Target;
@@ -225,27 +225,27 @@ fn recv_message(stream: &mut TcpStream, cipher: &mut NoiseCipher) -> Vec<u8> {
 }
 
 impl<T: Target> Scenario for NoiseScenario<T> {
-    fn new(_args: &[String]) -> Result<Self, String> {
+    fn new(_args: &[String]) -> Result<Self, ScenarioError> {
         let config = T::Config::default();
-        let target = T::start(config).map_err(|e| e.to_string())?;
+        let target = T::start(config)?;
 
         // Establish a connection for ping-pong synchronization. This also warms
         // up the target's message handling code paths before the Nyx snapshot,
         // improving fuzzing efficiency for JVM targets.
-        let mut sync_conn = connect_to_target(&target, TIMEOUT).map_err(|e| e.to_string())?;
-        ping_pong(&mut sync_conn).map_err(|e| e.to_string())?;
+        let mut sync_conn = connect_to_target(&target, TIMEOUT)?;
+        ping_pong(&mut sync_conn)?;
 
         // Establish the fuzz connection that will be snapshotted in its
         // pre-handshake state.
-        let stream = TcpStream::connect_timeout(&target.addr(), TIMEOUT)
-            .map_err(|e| format!("TCP connect: {e}"))?;
-        stream.set_nodelay(true).map_err(|e| e.to_string())?;
+        let stream =
+            TcpStream::connect_timeout(&target.addr(), TIMEOUT).map_err(TargetError::Io)?;
+        stream.set_nodelay(true).map_err(TargetError::Io)?;
         stream
             .set_read_timeout(Some(TIMEOUT))
-            .map_err(|e| e.to_string())?;
+            .map_err(TargetError::Io)?;
         stream
             .set_write_timeout(Some(TIMEOUT))
-            .map_err(|e| e.to_string())?;
+            .map_err(TargetError::Io)?;
 
         Ok(Self {
             target,

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -10,6 +10,7 @@ pub use cln::{ClnConfig, ClnTarget};
 pub use eclair::{EclairConfig, EclairTarget};
 pub use ldk::{LdkConfig, LdkTarget};
 pub use lnd::{LndConfig, LndTarget};
+use smite::scenarios::TargetError;
 
 use std::net::SocketAddr;
 
@@ -36,22 +37,6 @@ pub fn check_crash_log() -> Result<(), TargetError> {
         return Err(TargetError::Crashed);
     }
     Ok(())
-}
-
-/// Error from target operations.
-#[derive(Debug, thiserror::Error)]
-pub enum TargetError {
-    /// Target failed to start.
-    #[error("failed to start: {0}")]
-    StartFailed(String),
-
-    /// Target crashed.
-    #[error("target crashed")]
-    Crashed,
-
-    /// I/O error.
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
 }
 
 /// A Lightning implementation that can be fuzzed.

--- a/smite/Cargo.toml
+++ b/smite/Cargo.toml
@@ -30,3 +30,4 @@ nix = { version = "0.30", default-features = false, features = [
   "process",
 ] }
 hex = "0.4"
+thiserror = "2"

--- a/smite/src/scenarios.rs
+++ b/smite/src/scenarios.rs
@@ -1,3 +1,5 @@
+use crate::{bolt::BoltError, noise::ConnectionError};
+
 /// `ScenarioResult` describes the outcomes of running a scenario
 pub enum ScenarioResult {
     /// Scenario ran successfully
@@ -8,13 +10,62 @@ pub enum ScenarioResult {
     Fail(String),
 }
 
+/// Error from scenario operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ScenarioError {
+    /// Target failed to start or crashed.
+    #[error("target error: {0}")]
+    Target(#[from] TargetError),
+
+    /// Connection or handshake failed.
+    #[error("connection failed: {0}")]
+    Connection(#[from] ConnectionError),
+
+    /// Failed to decode a BOLT message.
+    #[error("decode error: {0}")]
+    Decode(#[from] BoltError),
+
+    /// Protocol error (e.g., unexpected message).
+    #[error("protocol error: {0}")]
+    Protocol(String),
+}
+
+impl ScenarioError {
+    /// Returns true if this error is a timeout (potential hang).
+    #[must_use]
+    pub fn is_timeout(&self) -> bool {
+        use std::io::ErrorKind;
+        if let Self::Connection(ConnectionError::Io(e)) = self {
+            matches!(e.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock)
+        } else {
+            false
+        }
+    }
+}
+
+/// Error from target operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TargetError {
+    /// Target failed to start.
+    #[error("failed to start: {0}")]
+    StartFailed(String),
+
+    /// Target crashed.
+    #[error("target crashed")]
+    Crashed,
+
+    /// I/O error.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
 /// `Scenario` is the interface for test scenarios that can be run against a target node
 pub trait Scenario: Sized {
     /// Create a new instance of the scenario, preparing the initial state of the test
     ///
     /// # Errors
     /// Returns an error if scenario initialization fails.
-    fn new(args: &[String]) -> Result<Self, String>;
+    fn new(args: &[String]) -> Result<Self, ScenarioError>;
 
     /// Run the test with the given fuzz input
     fn run(&mut self, input: &[u8]) -> ScenarioResult;


### PR DESCRIPTION
related: https://github.com/morehouse/smite/pull/13#issuecomment-4180370162

Despite the error name `ScenarioError`, `Scenario::new` was expecting `String` as errors. This also meant we had to map `ScenarioError` to `String` with `map_err` in a lot of places.

This moves `ScenarioError` to the smite package, and uses it instead of `String`.

To avoid a circular dependency between smite-scenarios and smite, `TargetError` is also moved.