### PR TITLE
smite-ir: implement basic mutators

### DIFF
--- a/smite-ir/src/lib.rs
+++ b/smite-ir/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod builder;
 pub mod generators;
 pub mod instruction;
+pub mod mutators;
 pub mod operation;
 pub mod program;
 pub mod variable;
@@ -21,6 +22,7 @@ pub mod variable;
 pub use builder::ProgramBuilder;
 pub use generators::Generator;
 pub use instruction::Instruction;
+pub use mutators::Mutator;
 pub use operation::Operation;
 pub use program::Program;
 pub use variable::{Variable, VariableType};

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -1,0 +1,15 @@
+//! IR program mutators.
+//!
+//! Mutators transform programs to explore new protocol states while preserving
+//! structural validity. Each mutator makes a small, targeted change.
+
+use rand::Rng;
+
+use super::Program;
+
+/// A mutator that transforms an IR program in place.
+pub trait Mutator {
+    /// Applies a single mutation to the program. Returns `true` if a mutation
+    /// was made.
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool;
+}

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -3,8 +3,10 @@
 //! Mutators transform programs to explore new protocol states while preserving
 //! structural validity. Each mutator makes a small, targeted change.
 
+mod input_swap;
 mod operation_param;
 
+pub use input_swap::InputSwapMutator;
 pub use operation_param::OperationParamMutator;
 
 use rand::Rng;

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -3,6 +3,10 @@
 //! Mutators transform programs to explore new protocol states while preserving
 //! structural validity. Each mutator makes a small, targeted change.
 
+mod operation_param;
+
+pub use operation_param::OperationParamMutator;
+
 use rand::Rng;
 
 use super::Program;

--- a/smite-ir/src/mutators/input_swap.rs
+++ b/smite-ir/src/mutators/input_swap.rs
@@ -1,0 +1,48 @@
+//! Mutator that swaps an instruction's input to a different variable of the
+//! same type.
+
+use rand::Rng;
+use rand::seq::IteratorRandom;
+
+use super::Mutator;
+use crate::Program;
+
+/// Swaps a randomly chosen input reference to point at a different variable of
+/// the same type.  This explores alternative data-flow paths while preserving
+/// type correctness.
+pub struct InputSwapMutator;
+
+impl Mutator for InputSwapMutator {
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool {
+        // Pick a random (instruction index, input position) pair.
+        let Some((instr_idx, input_pos)) = program
+            .instructions
+            .iter()
+            .enumerate()
+            .flat_map(|(i, instr)| (0..instr.inputs.len()).map(move |j| (i, j)))
+            .choose(rng)
+        else {
+            return false;
+        };
+
+        let current_input = program.instructions[instr_idx].inputs[input_pos];
+        let expected_type = program.instructions[instr_idx].operation.input_types()[input_pos];
+
+        // Pick an alternative variable defined before this instruction with the
+        // matching type, excluding the current input.
+        let Some(new_input) = program.instructions[..instr_idx]
+            .iter()
+            .enumerate()
+            .filter_map(|(i, instr)| {
+                let out_type = instr.operation.output_type()?;
+                (out_type == expected_type && i != current_input).then_some(i)
+            })
+            .choose(rng)
+        else {
+            return false;
+        };
+
+        program.instructions[instr_idx].inputs[input_pos] = new_input;
+        true
+    }
+}

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -1,0 +1,325 @@
+//! Mutator that tweaks embedded literal values in Load and Extract operations.
+
+use rand::seq::IteratorRandom;
+use rand::{Rng, RngExt};
+use smite::bolt::MAX_MESSAGE_SIZE;
+
+use super::Mutator;
+use crate::operation::AcceptChannelField;
+use crate::{Operation, Program};
+
+/// Mutates the embedded parameter of a randomly chosen `is_param_mutable`
+/// instruction. For numeric loads, applies a random arithmetic tweak. For byte
+/// loads, flips/adds/removes bytes. For extract operations, swaps to a random
+/// field with the same output type.
+pub struct OperationParamMutator;
+
+impl Mutator for OperationParamMutator {
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool {
+        let Some(idx) = program
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, instr)| instr.operation.is_param_mutable().then_some(i))
+            .choose(rng)
+        else {
+            return false;
+        };
+
+        mutate_operation(&mut program.instructions[idx].operation, rng)
+    }
+}
+
+/// Returns `true` if the operation was changed.
+fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
+    match op {
+        Operation::LoadAmount(v) => {
+            *v = tweak_u64(*v, rng);
+            true
+        }
+        Operation::LoadFeeratePerKw(v) | Operation::LoadBlockHeight(v) => {
+            *v = tweak_u32(*v, rng);
+            true
+        }
+        Operation::LoadU16(v) => {
+            *v = tweak_u16(*v, rng);
+            true
+        }
+        Operation::LoadU8(v) => {
+            *v = tweak_u8(*v, rng);
+            true
+        }
+        Operation::LoadBytes(bytes) | Operation::LoadFeatures(bytes) => {
+            mutate_bytes(bytes, rng);
+            true
+        }
+        Operation::LoadPrivateKey(bytes) | Operation::LoadChannelId(bytes) => {
+            mutate_fixed_bytes(bytes, rng);
+            true
+        }
+        Operation::ExtractAcceptChannel(field) => mutate_extract_field(field, rng),
+
+        // Non-mutable variants. Reaching here means `is_param_mutable` and this
+        // match have drifted out of sync.
+        Operation::DerivePoint
+        | Operation::LoadTargetPubkeyFromContext
+        | Operation::LoadChainHashFromContext
+        | Operation::BuildOpenChannel
+        | Operation::SendMessage
+        | Operation::RecvAcceptChannel => {
+            unreachable!("is_param_mutable returned true for {op:?}")
+        }
+    }
+}
+
+// -- Numeric tweaks --
+
+fn tweak_u64(v: u64, rng: &mut impl Rng) -> u64 {
+    match rng.random_range(0..4) {
+        0 => rng.random(),
+        1 => v.wrapping_add(rng.random_range(1..=256)),
+        2 => v.wrapping_sub(rng.random_range(1..=256)),
+        _ => interesting_u64(rng),
+    }
+}
+
+fn tweak_u32(v: u32, rng: &mut impl Rng) -> u32 {
+    match rng.random_range(0..4) {
+        0 => rng.random(),
+        1 => v.wrapping_add(rng.random_range(1..=256)),
+        2 => v.wrapping_sub(rng.random_range(1..=256)),
+        _ => interesting_u32(rng),
+    }
+}
+
+fn tweak_u16(v: u16, rng: &mut impl Rng) -> u16 {
+    match rng.random_range(0..4) {
+        0 => rng.random(),
+        1 => v.wrapping_add(rng.random_range(1..=16)),
+        2 => v.wrapping_sub(rng.random_range(1..=16)),
+        _ => interesting_u16(rng),
+    }
+}
+
+fn tweak_u8(v: u8, rng: &mut impl Rng) -> u8 {
+    match rng.random_range(0..4) {
+        0 => rng.random(),
+        1 => v.wrapping_add(rng.random_range(1..=8)),
+        2 => v.wrapping_sub(rng.random_range(1..=8)),
+        _ => interesting_u8(rng),
+    }
+}
+
+// -- Byte mutations --
+
+/// Shuffle a random subrange of `bytes` using Fisher-Yates.
+fn shuffle_subrange(bytes: &mut [u8], rng: &mut impl Rng) {
+    if bytes.len() < 2 {
+        return;
+    }
+    let max_len = bytes.len().min(16);
+    let len = rng.random_range(2..=max_len);
+    let start = rng.random_range(0..=bytes.len() - len);
+    for i in (1..len).rev() {
+        let j = rng.random_range(0..=i);
+        bytes.swap(start + i, start + j);
+    }
+}
+
+fn mutate_bytes(bytes: &mut Vec<u8>, rng: &mut impl Rng) {
+    match rng.random_range(0..10) {
+        // Flip a random bit.
+        0 if !bytes.is_empty() => {
+            let idx = rng.random_range(0..bytes.len());
+            bytes[idx] ^= 1 << rng.random_range(0..8u8);
+        }
+        // Change a random byte.
+        1 if !bytes.is_empty() => {
+            let idx = rng.random_range(0..bytes.len());
+            bytes[idx] = rng.random();
+        }
+        // Shuffle a random subrange.
+        2 if bytes.len() >= 2 => {
+            shuffle_subrange(bytes, rng);
+        }
+        // Insert a random byte.
+        3 if bytes.len() < MAX_MESSAGE_SIZE => {
+            let pos = rng.random_range(0..=bytes.len());
+            bytes.insert(pos, rng.random());
+        }
+        // Insert repeated bytes. Requires room for at least 2 bytes.
+        4 if bytes.len() + 2 <= MAX_MESSAGE_SIZE => {
+            let pos = rng.random_range(0..=bytes.len());
+            let max_count = (MAX_MESSAGE_SIZE - bytes.len()).min(128);
+            let count = rng.random_range(2..=max_count);
+            let byte: u8 = rng.random();
+            bytes.splice(pos..pos, std::iter::repeat_n(byte, count));
+        }
+        // Remove a random byte.
+        5 if !bytes.is_empty() => {
+            let idx = rng.random_range(0..bytes.len());
+            bytes.remove(idx);
+        }
+        // Erase a byte range (up to half the length).
+        6 if bytes.len() >= 2 => {
+            let max_erase = bytes.len() / 2;
+            let count = rng.random_range(1..=max_erase);
+            let start = rng.random_range(0..=bytes.len() - count);
+            bytes.drain(start..start + count);
+        }
+        // Add or subtract a small delta from a random byte.
+        7 if !bytes.is_empty() => {
+            let idx = rng.random_range(0..bytes.len());
+            let delta = rng.random_range(1..=35);
+            if rng.random() {
+                bytes[idx] = bytes[idx].wrapping_add(delta);
+            } else {
+                bytes[idx] = bytes[idx].wrapping_sub(delta);
+            }
+        }
+        // Copy a chunk from one position to another.
+        8 if bytes.len() >= 2 => {
+            let max_len = (bytes.len() - 1).min(32);
+            let len = rng.random_range(1..=max_len);
+            let src = rng.random_range(0..=bytes.len() - len);
+            let chunk: Vec<u8> = bytes[src..src + len].to_vec();
+            let dst = rng.random_range(0..=bytes.len() - len);
+            bytes[dst..dst + len].copy_from_slice(&chunk);
+        }
+        // Replace with random length and content.
+        _ => {
+            let len = rng.random_range(0..=256);
+            bytes.resize(len, 0);
+            rng.fill(&mut bytes[..]);
+        }
+    }
+}
+
+fn mutate_fixed_bytes(bytes: &mut [u8; 32], rng: &mut impl Rng) {
+    match rng.random_range(0..6) {
+        // Flip a random bit.
+        0 => {
+            let idx = rng.random_range(0..32);
+            bytes[idx] ^= 1 << rng.random_range(0..8u8);
+        }
+        // Change a random byte.
+        1 => {
+            let idx = rng.random_range(0..32);
+            bytes[idx] = rng.random();
+        }
+        // Shuffle a random subrange.
+        2 => shuffle_subrange(bytes, rng),
+        // Add or subtract a small delta from a random byte.
+        3 => {
+            let idx = rng.random_range(0..32);
+            let delta = rng.random_range(1..=35);
+            if rng.random() {
+                bytes[idx] = bytes[idx].wrapping_add(delta);
+            } else {
+                bytes[idx] = bytes[idx].wrapping_sub(delta);
+            }
+        }
+        // Copy a chunk from one position to another.
+        4 => {
+            let len = rng.random_range(1..=31);
+            let src = rng.random_range(0..=32 - len);
+            let chunk: Vec<u8> = bytes[src..src + len].to_vec();
+            let dst = rng.random_range(0..=32 - len);
+            bytes[dst..dst + len].copy_from_slice(&chunk);
+        }
+        // Randomize entirely.
+        _ => rng.fill(&mut bytes[..]),
+    }
+}
+
+// -- Extract field mutation --
+
+/// Returns `true` if the field was swapped, `false` if no same-type alternative
+/// field exists.
+fn mutate_extract_field(field: &mut AcceptChannelField, rng: &mut impl Rng) -> bool {
+    // Only swap to fields with the same output type to preserve program validity.
+    let target_type = field.output_type();
+    let Some(new_field) = AcceptChannelField::ALL
+        .iter()
+        .copied()
+        .filter(|f| f.output_type() == target_type && f != field)
+        .choose(rng)
+    else {
+        return false;
+    };
+    *field = new_field;
+    true
+}
+
+// -- Interesting boundary values --
+//
+// Each width includes all boundaries from narrower widths plus width-specific
+// boundaries and BOLT-relevant constants.
+
+const INTERESTING_U8: &[u8] = &[0, 1, 0x7F, 0x80, 0xFF];
+
+#[rustfmt::skip]
+const INTERESTING_U16: &[u16] = &[
+    // u8 boundaries
+    0, 1, 0x7F, 0x80, 0xFF,
+    // u16 boundaries
+    0x100, 0x7FFF, 0x8000, 0xFFFF,
+    // BOLT constants
+    6,    // minimum confirmation depth
+    144,  // blocks per day
+    483,  // max accepted HTLCs (BOLT 2)
+    2016, // blocks per 2 weeks
+];
+
+#[rustfmt::skip]
+const INTERESTING_U32: &[u32] = &[
+    // u8 boundaries
+    0, 1, 0x7F, 0x80, 0xFF,
+    // u16 boundaries
+    0x100, 0x7FFF, 0x8000, 0xFFFF,
+    // u32 boundaries
+    0x1_0000, 0x7FFF_FFFF, 0x8000_0000, 0xFFFF_FFFF,
+    // BOLT constants
+    6,    // minimum confirmation depth
+    144,  // blocks per day
+    253,  // min feerate in sat/kw
+    2016, // blocks per 2 weeks
+];
+
+#[rustfmt::skip]
+const INTERESTING_U64: &[u64] = &[
+    // u8 boundaries
+    0, 1, 0x7F, 0x80, 0xFF,
+    // u16 boundaries
+    0x100, 0x7FFF, 0x8000, 0xFFFF,
+    // u32 boundaries
+    0x1_0000, 0x7FFF_FFFF, 0x8000_0000, 0xFFFF_FFFF,
+    // u64 boundaries
+    0x1_0000_0000, 0x7FFF_FFFF_FFFF_FFFF,
+    0x8000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF,
+    // BOLT constants (sats and msats)
+    546,                        // dust limit (sats)
+    546_000,                    // dust limit (msats)
+    16_777_216,                 // non-wumbo channel limit, 2^24 (sats)
+    16_777_216_000,             // non-wumbo channel limit (msats)
+    100_000_000,                // 1 BTC (sats)
+    100_000_000_000,            // 1 BTC (msats)
+    2_100_000_000_000_000,      // 21M BTC (sats)
+    2_100_000_000_000_000_000,  // 21M BTC (msats)
+];
+
+fn interesting_u8(rng: &mut impl Rng) -> u8 {
+    INTERESTING_U8[rng.random_range(0..INTERESTING_U8.len())]
+}
+
+fn interesting_u16(rng: &mut impl Rng) -> u16 {
+    INTERESTING_U16[rng.random_range(0..INTERESTING_U16.len())]
+}
+
+fn interesting_u32(rng: &mut impl Rng) -> u32 {
+    INTERESTING_U32[rng.random_range(0..INTERESTING_U32.len())]
+}
+
+fn interesting_u64(rng: &mut impl Rng) -> u64 {
+    INTERESTING_U64[rng.random_range(0..INTERESTING_U64.len())]
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -2,9 +2,11 @@
 
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use smite::bolt::MAX_MESSAGE_SIZE;
 
 use super::*;
 use generators::OpenChannelGenerator;
+use mutators::{InputSwapMutator, OperationParamMutator};
 use operation::AcceptChannelField;
 
 /// Helper to build a private key with a single distinguishing byte.
@@ -416,4 +418,203 @@ fn append_type_mismatch_panics() {
     let mut builder = ProgramBuilder::new();
     let amount = builder.generate_fresh(VariableType::Amount, &mut rng);
     builder.append(Operation::DerivePoint, &[amount]);
+}
+
+// -- OperationParamMutator tests --
+
+#[test]
+fn param_mutator_changes_values() {
+    let original = generate_program(0);
+    let mut program = original.clone();
+    let mutator = OperationParamMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for _ in 0..100 {
+        mutator.mutate(&mut program, &mut rng);
+    }
+    assert_ne!(
+        program, original,
+        "OperationParamMutator never changed the program"
+    );
+}
+
+#[test]
+fn param_mutator_returns_false_on_empty_program() {
+    let mut program = Program {
+        instructions: vec![],
+    };
+    let mutator = OperationParamMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+    assert!(!mutator.mutate(&mut program, &mut rng));
+}
+
+#[test]
+fn param_mutator_returns_false_for_singleton_extract_field() {
+    // TemporaryChannelId is the only AcceptChannelField with output type
+    // ChannelId, so ExtractAcceptChannel(TemporaryChannelId) has no type-
+    // compatible alternative to swap to. With it as the only mutable op, the
+    // mutator must report no change.
+    let mut program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::RecvAcceptChannel,
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::ExtractAcceptChannel(AcceptChannelField::TemporaryChannelId),
+                inputs: vec![0],
+            },
+        ],
+    };
+    let mutator = OperationParamMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+    assert!(!mutator.mutate(&mut program, &mut rng));
+}
+
+#[test]
+fn param_mutator_caps_byte_length() {
+    // Start at exactly MAX_MESSAGE_SIZE so any growth would exceed the cap.
+    let mut program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::LoadBytes(vec![0; MAX_MESSAGE_SIZE]),
+            inputs: vec![],
+        }],
+    };
+
+    let mutator = OperationParamMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for _ in 0..10_000 {
+        mutator.mutate(&mut program, &mut rng);
+        let Operation::LoadBytes(b) = &program.instructions[0].operation else {
+            panic!("operation type changed");
+        };
+        assert!(
+            b.len() <= MAX_MESSAGE_SIZE,
+            "bytes exceeded MAX_MESSAGE_SIZE: got {}",
+            b.len(),
+        );
+    }
+}
+
+#[test]
+fn param_mutator_preserves_extract_field_type() {
+    // One ExtractAcceptChannel instruction per field variant.
+    let mut instructions = vec![Instruction {
+        operation: Operation::RecvAcceptChannel,
+        inputs: vec![],
+    }];
+    for &field in AcceptChannelField::ALL {
+        instructions.push(Instruction {
+            operation: Operation::ExtractAcceptChannel(field),
+            inputs: vec![0],
+        });
+    }
+
+    let mut program = Program { instructions };
+    let original_types: Vec<VariableType> = AcceptChannelField::ALL
+        .iter()
+        .map(|f| f.output_type())
+        .collect();
+
+    let mutator = OperationParamMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for _ in 0..100 {
+        mutator.mutate(&mut program, &mut rng);
+
+        for (i, &expected_type) in original_types.iter().enumerate() {
+            let field = match &program.instructions[i + 1].operation {
+                Operation::ExtractAcceptChannel(f) => *f,
+                other => panic!("expected ExtractAcceptChannel, got {other:?}"),
+            };
+            assert_eq!(
+                field.output_type(),
+                expected_type,
+                "{field:?} has type {:?}, expected {expected_type:?}",
+                field.output_type(),
+            );
+        }
+    }
+}
+
+// -- InputSwapMutator tests --
+
+#[test]
+fn input_swap_changes_references() {
+    let original = generate_program(0);
+    let mut program = original.clone();
+    let mutator = InputSwapMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for _ in 0..100 {
+        mutator.mutate(&mut program, &mut rng);
+    }
+    assert_ne!(
+        program, original,
+        "InputSwapMutator never changed the program"
+    );
+}
+
+#[test]
+fn input_swap_returns_false_on_empty_program() {
+    let mut program = Program {
+        instructions: vec![],
+    };
+    let mutator = InputSwapMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+    assert!(!mutator.mutate(&mut program, &mut rng));
+}
+
+#[test]
+fn input_swap_returns_false_when_no_alternatives() {
+    // DerivePoint consumes the only PrivateKey -- no alternative to swap to.
+    let mut program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::LoadPrivateKey(key(1)),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![0],
+            },
+        ],
+    };
+    let mutator = InputSwapMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+    assert!(!mutator.mutate(&mut program, &mut rng));
+}
+
+#[test]
+fn input_swap_preserves_types() {
+    let original = generate_program(0);
+    let mutator = InputSwapMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for _ in 0..100 {
+        let mut program = original.clone();
+        if mutator.mutate(&mut program, &mut rng) {
+            for (i, instr) in program.instructions.iter().enumerate() {
+                let expected_types = instr.operation.input_types();
+                for (j, &input_idx) in instr.inputs.iter().enumerate() {
+                    assert!(
+                        input_idx < i,
+                        "instruction {i} input {j}: references undefined variable {input_idx}",
+                    );
+                    let actual_type = program.instructions[input_idx]
+                        .operation
+                        .output_type()
+                        .unwrap_or_else(|| {
+                            panic!("instruction {i} input {j}: references void at {input_idx}")
+                        });
+                    assert_eq!(
+                        actual_type, expected_types[j],
+                        "instruction {i} input {j}: expected {:?}, got {actual_type:?}",
+                        expected_types[j],
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implement two simple mutators:

- `OperationParamMutator` mutates a single operation, changing its parameter to some other type-compatible value.
- `InputSwapMutator` mutates a single instruction, changing one of its input variables to another variable of compatible type.

Ref: #5 (Milestone 1)