### PR TITLE
smite-ir: drop `Program::context` field

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use rand::{Rng, RngExt};
 
-use super::{Instruction, Operation, Program, ProgramContext, VariableType};
+use super::{Instruction, Operation, Program, VariableType};
 
 /// A candidate variable that can satisfy a type request.
 #[derive(Debug, Clone)]
@@ -172,10 +172,9 @@ impl ProgramBuilder {
 
     /// Builds the final program from the accumulated instructions.
     #[must_use]
-    pub fn build(self, context: ProgramContext) -> Program {
+    pub fn build(self) -> Program {
         Program {
             instructions: self.instructions,
-            context,
         }
     }
 

--- a/smite-ir/src/program.rs
+++ b/smite-ir/src/program.rs
@@ -4,13 +4,14 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use super::context::ProgramContext;
 use super::instruction::Instruction;
 
-/// An IR program: an ordered list of instructions plus execution context.
+/// An IR program: an ordered list of instructions.
 ///
 /// Programs are serialized with postcard for transport between the AFL++ custom
-/// mutator and the scenario executor.
+/// mutator and the scenario executor. Execution context (target pubkey, chain
+/// hash, etc.) is supplied separately by the executor at run time and is not
+/// part of the serialized program.
 // TODO: add `validate` method for mutators to check deserialized programs
 // before mutation. Invalid programs should be rejected so that we don't panic
 // when modifying and rebuilding them via `ProgramBuilder`.
@@ -18,8 +19,6 @@ use super::instruction::Instruction;
 pub struct Program {
     /// Instructions in SSA order.
     pub instructions: Vec<Instruction>,
-    /// Snapshot context (target pubkey, chain hash, etc.).
-    pub context: ProgramContext,
 }
 
 impl fmt::Display for Program {

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -14,15 +14,6 @@ fn key(byte: u8) -> [u8; 32] {
     k
 }
 
-fn sample_context() -> ProgramContext {
-    ProgramContext {
-        target_pubkey: [0x02; 33],
-        chain_hash: [0; 32],
-        block_height: 800_000,
-        target_features: vec![],
-    }
-}
-
 #[test]
 #[allow(clippy::too_many_lines)]
 fn display_open_channel_program() {
@@ -159,10 +150,7 @@ fn display_open_channel_program() {
         },
     ];
 
-    let program = Program {
-        instructions,
-        context: sample_context(),
-    };
+    let program = Program { instructions };
     let text = program.to_string();
     let lines: Vec<&str> = text.lines().collect();
 
@@ -239,7 +227,6 @@ fn postcard_roundtrip() {
                 inputs: vec![],
             },
         ],
-        context: sample_context(),
     };
 
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
@@ -283,7 +270,7 @@ fn generate_program(seed: u64) -> Program {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut builder = ProgramBuilder::new();
     OpenChannelGenerator.generate(&mut builder, &mut rng);
-    builder.build(sample_context())
+    builder.build()
 }
 
 // If OpenChannelGenerator completes without panicking, every instruction has
@@ -405,7 +392,7 @@ fn append_void_reference_panics() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
     OpenChannelGenerator.generate(&mut builder, &mut rng);
-    let program = builder.build(sample_context());
+    let program = builder.build();
     // SendMessage is second-to-last and has void output.
     let send_idx = program.instructions.len() - 2;
     assert!(


### PR DESCRIPTION
The context cannot be populated until scenario execution, so it really doesn't make sense to include it within `Program`.  Generators and mutators could write placeholder bytes for the context, but it would just be overwritten anyway by scenarios.

We can simplify and avoid unnecessary postcard (de)serialization by dropping this field.