### PR TITLE
feat: add support for kAFL_hypercall and cpuid for ARM64 architectures

### DIFF
--- a/smite-nyx-sys/src/nyx.h
+++ b/smite-nyx-sys/src/nyx.h
@@ -232,6 +232,13 @@ static inline uint64_t kAFL_hypercall(uint64_t rbx, uint64_t rcx){
 	return 0;
 }
 #endif
+#else
+/* Stub kAFL_hypercall for non-x86 architectures (e.g., ARM64) */
+static inline uint64_t kAFL_hypercall(uint64_t rbx, uint64_t rcx){
+	(void)rbx;
+	(void)rcx;
+	return 0;
+}
 #endif
 
 //extern uint8_t* hprintf_buffer;
@@ -319,10 +326,19 @@ enum nyx_cpu_type{
 	nyx_cpu_v2  /* Nyx CPU used by vanilla KVM + VMWare backdoor */
 };
 
+#if defined(__x86_64__) || defined(__i386__)
 #define cpuid(in,a,b,c,d)\
   asm("cpuid": "=a" (a), "=b" (b), "=c" (c), "=d" (d) : "a" (in));
+#else
+/* ARM64/other architectures: cpuid is not available, use stub */
+#define cpuid(in,a,b,c,d) \
+  do { \
+    (void)(in); (void)(a); (void)(b); (void)(c); (void)(d); \
+  } while(0)
+#endif
 
-static int is_nyx_vcpu(void){
+#if defined(__x86_64__) || defined(__i386__)
+static int __attribute__((unused)) is_nyx_vcpu(void){
   unsigned long eax,ebx,ecx,edx;
   char str[8];
   cpuid(0x80000004,eax,ebx,ecx,edx);
@@ -334,8 +350,14 @@ static int is_nyx_vcpu(void){
 
   return !memcmp(&str, "NYX vCPU", 8);
 }
+#else
+static int __attribute__((unused)) is_nyx_vcpu(void){
+  return 0;  /* ARM64/other architectures don't support CPUID */
+}
+#endif
 
-static int get_nyx_cpu_type(void){
+#if defined(__x86_64__) || defined(__i386__)
+static int __attribute__((unused)) get_nyx_cpu_type(void){
 	unsigned long eax,ebx,ecx,edx;
   char str[9];
   cpuid(0x80000004,eax,ebx,ecx,edx);
@@ -363,6 +385,11 @@ static int get_nyx_cpu_type(void){
 	str[8] = 0;
 	printf("ECX: %s\n", str);
 }
+#else
+static int __attribute__((unused)) get_nyx_cpu_type(void){
+  return unkown;  /* ARM64/other architectures don't support CPUID */
+}
+#endif
 
 typedef struct req_data_bulk_s{
 	char file_name[256];


### PR DESCRIPTION

- Added architecture guards (`#if defined(__x86_64__) || defined(__i386__)`)
- Provided ARM64 stub implementations for `kAFL_hypercall`, `cpuid` macro, and related functions

fixes #47 

Proof Manifests
```bash
kartik@Macbook-4 smite %  cargo clippy --all-targets --all-features -- -D warnings
   Compiling version_check v0.9.5
   Compiling typenum v1.19.0
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.43
   Compiling libc v0.2.180
   Compiling unicode-ident v1.0.22
   Compiling find-msvc-tools v0.1.6
   Compiling shlex v1.3.0
    Checking subtle v2.6.1
    Checking cfg-if v1.0.4
   Compiling bitcoin-io v0.1.4
   Compiling thiserror v2.0.18
   Compiling cc v1.2.51
    Checking bitflags v2.10.0
    Checking zeroize v1.8.2
    Checking arrayvec v0.7.6
   Compiling cfg_aliases v0.2.1
   Compiling generic-array v0.14.7
   Compiling serde_core v1.0.228
    Checking hex-conservative v0.2.2
   Compiling nix v0.30.1
    Checking opaque-debug v0.3.1
    Checking log v0.4.29
   Compiling secp256k1-sys v0.11.0
   Compiling smite-nyx-sys v0.0.0 (/Users/kartik/summerofbitcoin/smite/smite-nyx-sys)
   Compiling serde v1.0.228
   Compiling syn v2.0.114
    Checking cpufeatures v0.2.17
    Checking simple_logger v5.1.0
    Checking hex v0.4.3
    Checking bitcoin_hashes v0.14.1
   Compiling rustix v1.1.3
   Compiling getrandom v0.3.4
   Compiling zmij v1.0.17
   Compiling thiserror-impl v2.0.18
    Checking crypto-common v0.1.7
    Checking block-buffer v0.10.4
    Checking digest v0.10.7
    Checking inout v0.1.4
    Checking universal-hash v0.5.1
    Checking poly1305 v0.8.0
    Checking cipher v0.4.4
    Checking chacha20 v0.9.1
    Checking hmac v0.12.1
    Checking aead v0.5.2
    Checking chacha20poly1305 v0.10.1
    Checking hkdf v0.12.4
    Checking sha2 v0.10.9
   Compiling serde_derive v1.0.228
    Checking errno v0.3.14
   Compiling serde_json v1.0.149
    Checking memchr v2.7.6
warning: smite-nyx-sys@0.0.0: In file included from src/nyx-agent.c:16:
warning: smite-nyx-sys@0.0.0: src/nyx.h:354:45: warning: GCC does not allow 'unused' attribute in this position on a function definition [-Wgcc-compat]
warning: smite-nyx-sys@0.0.0:   354 | static int is_nyx_vcpu(void) __attribute__((unused)){
warning: smite-nyx-sys@0.0.0:       |                                             ^
warning: smite-nyx-sys@0.0.0: src/nyx.h:389:50: warning: GCC does not allow 'unused' attribute in this position on a function definition [-Wgcc-compat]
warning: smite-nyx-sys@0.0.0:   389 | static int get_nyx_cpu_type(void) __attribute__((unused)){
warning: smite-nyx-sys@0.0.0:       |                                                  ^
warning: smite-nyx-sys@0.0.0: 2 warnings generated.
    Checking fastrand v2.3.0
    Checking once_cell v1.21.3
    Checking itoa v1.0.17
    Checking rand_core v0.10.0
    Checking rand v0.10.0
    Checking secp256k1 v0.31.1
    Checking smite v0.0.0 (/Users/kartik/summerofbitcoin/smite/smite)
    Checking cobs v0.3.0
    Checking tempfile v3.24.0
    Checking smite-scenarios v0.0.0 (/Users/kartik/summerofbitcoin/smite/smite-scenarios)
    Checking postcard v1.1.3
    Checking smite-ir v0.0.0 (/Users/kartik/summerofbitcoin/smite/smite-ir)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.15s
```