### PR TITLE
smite: assert Vec<u8> length <= MAX_MESSAGE_SIZE

### DIFF
--- a/smite/src/bolt/error.rs
+++ b/smite/src/bolt/error.rs
@@ -1,7 +1,7 @@
 //! BOLT 1 error message.
 
 use super::BoltError;
-use super::types::{ChannelId, MAX_MESSAGE_SIZE};
+use super::types::ChannelId;
 use super::wire::WireFormat;
 
 /// BOLT 1 error message (type 17).
@@ -21,16 +21,8 @@ pub struct Error {
 
 impl Error {
     /// Creates an error for all channels.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `msg` exceeds `MAX_MESSAGE_SIZE` bytes.
     #[must_use]
     pub fn all_channels(msg: &str) -> Self {
-        assert!(
-            msg.len() <= MAX_MESSAGE_SIZE,
-            "error message exceeds maximum size"
-        );
         Self {
             channel_id: ChannelId::ALL,
             data: msg.as_bytes().to_vec(),
@@ -38,16 +30,8 @@ impl Error {
     }
 
     /// Creates an error for a specific channel.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `msg` exceeds `MAX_MESSAGE_SIZE` bytes.
     #[must_use]
     pub fn for_channel(channel_id: ChannelId, msg: &str) -> Self {
-        assert!(
-            msg.len() <= MAX_MESSAGE_SIZE,
-            "error message exceeds maximum size"
-        );
         Self {
             channel_id,
             data: msg.as_bytes().to_vec(),
@@ -85,7 +69,7 @@ impl Error {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CHANNEL_ID_SIZE;
+    use super::super::{CHANNEL_ID_SIZE, MAX_MESSAGE_SIZE};
     use super::*;
 
     #[test]
@@ -185,16 +169,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "error message exceeds maximum size")]
+    #[should_panic(expected = "Vec<u8> length 65536 exceeds maximum size")]
     fn error_all_channels_too_long() {
         let long_msg = "x".repeat(MAX_MESSAGE_SIZE + 1);
-        let _ = Error::all_channels(&long_msg);
+        let err = Error::all_channels(&long_msg);
+        let _ = err.encode();
     }
 
     #[test]
-    #[should_panic(expected = "error message exceeds maximum size")]
+    #[should_panic(expected = "Vec<u8> length 65536 exceeds maximum size")]
     fn error_for_channel_too_long() {
         let long_msg = "x".repeat(MAX_MESSAGE_SIZE + 1);
-        let _ = Error::for_channel(ChannelId::ALL, &long_msg);
+        let err = Error::for_channel(ChannelId::ALL, &long_msg);
+        let _ = err.encode();
     }
 }

--- a/smite/src/bolt/shutdown.rs
+++ b/smite/src/bolt/shutdown.rs
@@ -1,7 +1,7 @@
 //! BOLT 2 shutdown message.
 
 use super::BoltError;
-use super::types::{ChannelId, MAX_MESSAGE_SIZE};
+use super::types::ChannelId;
 use super::wire::WireFormat;
 
 /// BOLT 2 shutdown message (type 38).
@@ -17,16 +17,8 @@ pub struct Shutdown {
 
 impl Shutdown {
     /// Creates a shutdown for a specific channel.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `scriptpubkey` exceeds `MAX_MESSAGE_SIZE` bytes.
     #[must_use]
     pub fn for_channel(channel_id: ChannelId, scriptpubkey: Vec<u8>) -> Self {
-        assert!(
-            scriptpubkey.len() <= MAX_MESSAGE_SIZE,
-            "shutdown scriptpubkey exceeds maximum size"
-        );
         Self {
             channel_id,
             scriptpubkey,

--- a/smite/src/bolt/tx_abort.rs
+++ b/smite/src/bolt/tx_abort.rs
@@ -1,7 +1,7 @@
 //! BOLT 2 `tx_abort` message.
 
 use super::BoltError;
-use super::types::{ChannelId, MAX_MESSAGE_SIZE};
+use super::types::ChannelId;
 use super::wire::WireFormat;
 
 /// BOLT 2 `tx_abort` message (type 74).
@@ -23,16 +23,8 @@ pub struct TxAbort {
 
 impl TxAbort {
     /// Creates a `tx_abort` for the given channel.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `msg` exceeds `MAX_MESSAGE_SIZE` bytes.
     #[must_use]
     pub fn new(channel_id: ChannelId, msg: &str) -> Self {
-        assert!(
-            msg.len() <= MAX_MESSAGE_SIZE,
-            "tx_abort message exceeds maximum size"
-        );
         Self {
             channel_id,
             data: msg.as_bytes().to_vec(),
@@ -70,7 +62,7 @@ impl TxAbort {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CHANNEL_ID_SIZE;
+    use super::super::{CHANNEL_ID_SIZE, MAX_MESSAGE_SIZE};
     use super::*;
 
     #[test]
@@ -166,9 +158,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "tx_abort message exceeds maximum size")]
+    #[should_panic(expected = "Vec<u8> length 65536 exceeds maximum size")]
     fn new_too_long() {
         let long_msg = "x".repeat(MAX_MESSAGE_SIZE + 1);
-        let _ = TxAbort::new(ChannelId::new([0x00; CHANNEL_ID_SIZE]), &long_msg);
+        let abort = TxAbort::new(ChannelId::new([0x00; CHANNEL_ID_SIZE]), &long_msg);
+        let _ = abort.encode();
     }
 }

--- a/smite/src/bolt/warning.rs
+++ b/smite/src/bolt/warning.rs
@@ -1,7 +1,7 @@
 //! BOLT 1 warning message.
 
 use super::BoltError;
-use super::types::{ChannelId, MAX_MESSAGE_SIZE};
+use super::types::ChannelId;
 use super::wire::WireFormat;
 
 /// BOLT 1 warning message (type 1).
@@ -21,16 +21,8 @@ pub struct Warning {
 
 impl Warning {
     /// Creates a warning for all channels.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `msg` exceeds `MAX_MESSAGE_SIZE` bytes.
     #[must_use]
     pub fn all_channels(msg: &str) -> Self {
-        assert!(
-            msg.len() <= MAX_MESSAGE_SIZE,
-            "warning message exceeds maximum size"
-        );
         Self {
             channel_id: ChannelId::ALL,
             data: msg.as_bytes().to_vec(),
@@ -38,16 +30,8 @@ impl Warning {
     }
 
     /// Creates a warning for a specific channel.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `msg` exceeds `MAX_MESSAGE_SIZE` bytes.
     #[must_use]
     pub fn for_channel(channel_id: ChannelId, msg: &str) -> Self {
-        assert!(
-            msg.len() <= MAX_MESSAGE_SIZE,
-            "warning message exceeds maximum size"
-        );
         Self {
             channel_id,
             data: msg.as_bytes().to_vec(),
@@ -85,7 +69,7 @@ impl Warning {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CHANNEL_ID_SIZE;
+    use super::super::{CHANNEL_ID_SIZE, MAX_MESSAGE_SIZE};
     use super::*;
 
     #[test]
@@ -185,16 +169,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "warning message exceeds maximum size")]
+    #[should_panic(expected = "Vec<u8> length 65536 exceeds maximum size")]
     fn warning_all_channels_too_long() {
         let long_msg = "x".repeat(MAX_MESSAGE_SIZE + 1);
-        let _ = Warning::all_channels(&long_msg);
+        let warn = Warning::all_channels(&long_msg);
+        let _ = warn.encode();
     }
 
     #[test]
-    #[should_panic(expected = "warning message exceeds maximum size")]
+    #[should_panic(expected = "Vec<u8> length 65536 exceeds maximum size")]
     fn warning_for_channel_too_long() {
         let long_msg = "x".repeat(MAX_MESSAGE_SIZE + 1);
-        let _ = Warning::for_channel(ChannelId::ALL, &long_msg);
+        let warn = Warning::for_channel(ChannelId::ALL, &long_msg);
+        let _ = warn.encode();
     }
 }

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -166,9 +166,14 @@ impl WireFormat for Vec<u8> {
     }
 
     /// Writes a `[u16:len][len*byte]` variable-length field.
-    #[allow(clippy::cast_possible_truncation)]
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.len()` exceeds `MAX_MESSAGE_SIZE`.
     fn write(&self, out: &mut Vec<u8>) {
-        (self.len() as u16).write(out);
+        u16::try_from(self.len())
+            .unwrap_or_else(|_| panic!("Vec<u8> length {} exceeds maximum size", self.len()))
+            .write(out);
         out.extend_from_slice(self);
     }
 }
@@ -609,6 +614,14 @@ mod tests {
         let decoded = Vec::<u8>::read(&mut cursor).unwrap();
         assert_eq!(decoded, original);
         assert!(cursor.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "Vec<u8> length 65536 exceeds maximum size")]
+    fn vec_u8_write_u16_overflow() {
+        let oversized = vec![0x00; 0xffff + 1];
+        let mut buf = Vec::new();
+        oversized.write(&mut buf);
     }
 
     // Test vectors from BOLT 1 Appendix A


### PR DESCRIPTION
This asserts that `self.len()` does not exceed `u16::MAX` in `Vec<u8>::write`, as suggested in https://github.com/morehouse/smite/pull/27#discussion_r3041066644.

I looked at all existing calls to `Vec<u8>::write`. All expect a u16 length prefix to be written. None expect to write more than 65535 bytes.

The assertion that was added in #27 could stay as a more specific error message.