### PR TITLE
smite-ir-mutator: add AFL++ custom mutator library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "smite",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smite-ir-mutator"
+version = "0.0.0"
+dependencies = [
+ "postcard",
+ "rand 0.10.0",
+ "smite-ir",
+]
+
+[[package]]
 name = "smite-nyx-sys"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ warnings = "deny"
 
 [workspace.dependencies]
 log = "0.4"
+rand = { version = "0.10", default-features = false }
 simple_logger = { version = "5", default-features = false }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.31", features = ["std", "hashes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "3"
-members = ["smite", "smite-ir", "smite-nyx-sys", "smite-scenarios"]
+members = [
+  "smite",
+  "smite-ir",
+  "smite-ir-mutator",
+  "smite-nyx-sys",
+  "smite-scenarios",
+]
 exclude = ["workloads/ldk"]
 
 [workspace.package]

--- a/smite-ir-mutator/Cargo.toml
+++ b/smite-ir-mutator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "smite-ir-mutator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+smite-ir = { path = "../smite-ir" }
+rand.workspace = true
+postcard.workspace = true

--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -1,0 +1,400 @@
+//! AFL++ custom mutator C ABI shim.
+//!
+//! This crate exports the `afl_custom_*` symbols that AFL++ looks up via
+//! `dlsym` when a shared library is supplied through
+//! `AFL_CUSTOM_MUTATOR_LIBRARY`. The resulting `.so` (built via
+//! `crate-type = ["cdylib"]`) is the *only* way AFL++ produces inputs for the
+//! IR fuzzer.
+//!
+//! # AFL++ environment contract
+//!
+//! Set the following when launching `afl-fuzz`:
+//! - `AFL_CUSTOM_MUTATOR_LIBRARY=/path/to/libsmite_ir_mutator.so`
+//! - `AFL_CUSTOM_MUTATOR_ONLY=1` -- disable AFL++'s byte mutators. This also
+//!   disables the havoc stage entirely, so we deliberately do not implement
+//!   `afl_custom_havoc_mutation`.
+//! - `AFL_DISABLE_TRIM=1` -- this library does not implement custom trim and
+//!   AFL++'s default byte-level trim would corrupt our structured programs.
+//!
+//! # Buffer ownership
+//!
+//! `MutatorState` owns a `Vec<u8>` (`out_buf`) that holds the serialized
+//! mutated program. When AFL++ requests a new input from us, we hand it a
+//! pointer to that `Vec<u8>` along with its length. AFL++ never saves the
+//! pointer across calls, so we're safe to reuse the buffer for the next input.
+
+use std::os::raw::{c_char, c_uint, c_void};
+use std::slice;
+
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+use smite_ir::generators::OpenChannelGenerator;
+use smite_ir::mutators::{InputSwapMutator, OperationParamMutator};
+use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
+
+/// Mutator state owned by AFL++ across calls. Allocated by [`afl_custom_init`],
+/// destroyed by [`afl_custom_deinit`].
+struct MutatorState {
+    rng: SmallRng,
+    /// Reusable buffer for serialized mutated programs. The pointer to its
+    /// contents is what we hand back to AFL++ when it requests an input.
+    out_buf: Vec<u8>,
+    /// Reusable null-terminated description string returned by
+    /// [`afl_custom_describe`].
+    description: Vec<u8>,
+    /// Sequence of actions taken in the last [`afl_custom_fuzz`] call, used by
+    /// [`afl_custom_describe`] to name queue entries.
+    last_sequence: Vec<&'static str>,
+}
+
+impl MutatorState {
+    fn new(seed: u32) -> Self {
+        Self {
+            rng: SmallRng::seed_from_u64(u64::from(seed)),
+            out_buf: Vec::new(),
+            description: Vec::new(),
+            last_sequence: vec!["init"],
+        }
+    }
+
+    /// Generates a fresh program from scratch using `OpenChannelGenerator`.
+    fn generate_fresh(&mut self) -> Program {
+        let mut builder = ProgramBuilder::new();
+        OpenChannelGenerator.generate(&mut builder, &mut self.rng);
+        self.last_sequence.clear();
+        self.last_sequence.push("fresh");
+        builder.build()
+    }
+
+    /// Applies a random number of stacked mutations to `program`. The stack
+    /// count is a power of two in `[1, 16]` to give a mix of small tweaks and
+    /// larger leaps per execution, similar in spirit to AFL++'s havoc stage.
+    /// Records the ordered list of mutator names in `last_sequence`.
+    fn mutate_stacked(&mut self, program: &mut Program) {
+        self.last_sequence.clear();
+        // Power-of-two stack count: 1, 2, 4, 8, or 16 mutations.
+        let stack = 1u32 << self.rng.random_range(0..=4);
+        for _ in 0..stack {
+            // Uniform pick between the available mutators.
+            let name = if self.rng.random() {
+                OperationParamMutator.mutate(program, &mut self.rng);
+                "op-param"
+            } else {
+                InputSwapMutator.mutate(program, &mut self.rng);
+                "input-swap"
+            };
+            self.last_sequence.push(name);
+        }
+    }
+
+    /// Postcard-encodes `program` into `self.out_buf`, reusing the existing
+    /// allocation. Returns `true` if the encoded length fits within `max_size`.
+    fn serialize(&mut self, program: &Program, max_size: usize) -> bool {
+        let mut buf = std::mem::take(&mut self.out_buf);
+        buf.clear();
+        match postcard::to_extend(program, buf) {
+            Ok(buf) => {
+                self.out_buf = buf;
+                self.out_buf.len() <= max_size
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+/// Decodes `bytes` as a postcard-encoded `Program` and validates it. Returns
+/// `Some(program)` only if both decoding and validation succeed.
+fn decode_and_validate(bytes: &[u8]) -> Option<Program> {
+    let program: Program = postcard::from_bytes(bytes).ok()?;
+    program.validate().ok()?;
+    Some(program)
+}
+
+// -- AFL++ custom mutator ABI -------------------------------------------------
+
+/// Allocates a new [`MutatorState`] and returns an opaque pointer to it. AFL++
+/// passes this pointer back on every function call as the `data` argument.
+///
+/// # Safety
+///
+/// The returned pointer is heap-allocated via `Box::into_raw` and must be freed
+/// by a matching call to [`afl_custom_deinit`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn afl_custom_init(_afl: *const c_void, seed: c_uint) -> *mut c_void {
+    Box::into_raw(Box::new(MutatorState::new(seed))).cast::<c_void>()
+}
+
+/// Frees the [`MutatorState`] previously returned by [`afl_custom_init`].
+///
+/// # Safety
+///
+/// `data` must be a pointer previously returned by [`afl_custom_init`] and
+/// not yet freed. After this call, `data` must not be used again.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn afl_custom_deinit(data: *mut c_void) {
+    drop(unsafe { Box::from_raw(data.cast::<MutatorState>()) });
+}
+
+/// Generates one mutated input from the seed at `buf`.
+///
+/// If `buf_size == 0` or postcard decoding/validation fails, falls back to
+/// generating a fresh program. Otherwise applies a stack of mutations (see
+/// [`MutatorState::mutate_stacked`]) to the decoded program; with 5%
+/// probability of regenerating from scratch anyway to avoid getting stuck on a
+/// single seed.
+///
+/// `*out_buf` is always set to a valid, non-null pointer before returning (even
+/// on failure, where we return 0 and point at our empty buffer). The buffer at
+/// `*out_buf` remains valid until the next call to `afl_custom_fuzz`.
+///
+/// # Safety
+///
+/// - `data` must be a pointer returned by [`afl_custom_init`].
+/// - `buf` must point to `buf_size` readable bytes.
+/// - `out_buf` must be a valid, writable pointer to a `*const u8` slot.
+/// - `_add_buf` is unused; we export `afl_custom_splice_optout` so AFL++ never
+///   populates it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn afl_custom_fuzz(
+    data: *mut c_void,
+    buf: *mut u8,
+    buf_size: usize,
+    out_buf: *mut *const u8,
+    _add_buf: *mut u8,
+    _add_buf_size: usize,
+    max_size: usize,
+) -> usize {
+    let state = unsafe { &mut *data.cast::<MutatorState>() };
+
+    let generate_fresh = buf_size == 0 || state.rng.random_range(0..20) == 0;
+    let program = if generate_fresh {
+        state.generate_fresh()
+    } else {
+        let input = unsafe { slice::from_raw_parts(buf, buf_size) };
+        match decode_and_validate(input) {
+            Some(mut p) => {
+                state.mutate_stacked(&mut p);
+                p
+            }
+            None => state.generate_fresh(),
+        }
+    };
+
+    let len = if state.serialize(&program, max_size) {
+        state.out_buf.len()
+    } else {
+        0
+    };
+    unsafe { *out_buf = state.out_buf.as_ptr() };
+    len
+}
+
+/// Marker symbol that tells AFL++ not to populate `add_buf` for
+/// [`afl_custom_fuzz`]. AFL++ never actually calls this function -- it only
+/// checks for the symbol's presence via `dlsym` and, if found, skips picking a
+/// splice input before each fuzz call.
+///
+/// # Safety
+///
+/// Never invoked; the signature exists only so the symbol has the correct
+/// linkage.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn afl_custom_splice_optout(_data: *mut c_void) {}
+
+/// Returns a null-terminated description of the most recently applied mutation.
+/// AFL++ uses this when naming queue entries.
+///
+/// The description is trimmed to fit within `max_description_len` bytes
+/// (excluding the trailing null).
+///
+/// # Safety
+///
+/// - `data` must be a pointer returned by [`afl_custom_init`].
+/// - The returned pointer is owned by the [`MutatorState`] and remains valid
+///   only until the next call into this library.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn afl_custom_describe(
+    data: *mut c_void,
+    max_description_len: usize,
+) -> *const c_char {
+    let state = unsafe { &mut *data.cast::<MutatorState>() };
+    state.description.clear();
+    state.description.extend_from_slice(b"smite-ir:");
+    for (i, name) in state.last_sequence.iter().enumerate() {
+        if i > 0 {
+            state.description.push(b',');
+        }
+        state.description.extend_from_slice(name.as_bytes());
+    }
+    // Leave room for the trailing null terminator.
+    if state.description.len() > max_description_len {
+        state.description.truncate(max_description_len);
+    }
+    state.description.push(0);
+    state.description.as_ptr().cast::<c_char>()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+    use std::ptr;
+
+    use super::*;
+
+    /// RAII wrapper that calls `afl_custom_init` on construction and
+    /// `afl_custom_deinit` on drop.
+    struct State(*mut c_void);
+
+    impl State {
+        fn new(seed: u32) -> Self {
+            Self(unsafe { afl_custom_init(ptr::null(), seed) })
+        }
+    }
+
+    impl Drop for State {
+        fn drop(&mut self) {
+            unsafe { afl_custom_deinit(self.0) };
+        }
+    }
+
+    /// Calls `afl_custom_fuzz` and returns `(out, len)`. The returned pointer
+    /// is borrowed from the state's internal buffer and is only valid until the
+    /// next call into the library.
+    fn fuzz_via_ffi(state: &State, mut input: Vec<u8>, max_size: usize) -> (*const u8, usize) {
+        let mut out: *const u8 = ptr::null();
+        let len = unsafe {
+            afl_custom_fuzz(
+                state.0,
+                input.as_mut_ptr(),
+                input.len(),
+                &raw mut out,
+                ptr::null_mut(),
+                0,
+                max_size,
+            )
+        };
+        (out, len)
+    }
+
+    fn decode_and_validate(out: *const u8, len: usize) -> Program {
+        let bytes = unsafe { slice::from_raw_parts(out, len) };
+        let program: Program = postcard::from_bytes(bytes).expect("decode");
+        program.validate().expect("valid program");
+        program
+    }
+
+    fn verify_fresh_generation(state: &State) {
+        let ptr = unsafe { afl_custom_describe(state.0, 64) };
+        assert!(!ptr.is_null());
+        let s = unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .expect("valid utf-8");
+        assert_eq!(s, "smite-ir:fresh", "fresh generation did not occur");
+    }
+
+    fn seed_program_bytes() -> Vec<u8> {
+        let mut rng = SmallRng::seed_from_u64(0);
+        let mut builder = ProgramBuilder::new();
+        OpenChannelGenerator.generate(&mut builder, &mut rng);
+        postcard::to_allocvec(&builder.build()).expect("postcard serialization")
+    }
+
+    #[test]
+    fn init_returns_nonnull() {
+        let state = State::new(0);
+        assert!(!state.0.is_null());
+    }
+
+    #[test]
+    fn fuzz_with_empty_input_generates_fresh() {
+        let state = State::new(1);
+        let (out, len) = fuzz_via_ffi(&state, Vec::new(), 1 << 16);
+        assert!(len > 0);
+        decode_and_validate(out, len);
+        verify_fresh_generation(&state);
+    }
+
+    #[test]
+    fn fuzz_valid_input_produces_valid_output() {
+        let state = State::new(2);
+        let mut current = seed_program_bytes();
+        for _ in 0..50 {
+            let (out, len) = fuzz_via_ffi(&state, current, 1 << 16);
+            assert!(len > 0);
+            // Copy before the next call, which will overwrite the state's
+            // out_buf.
+            let bytes = unsafe { slice::from_raw_parts(out, len) }.to_vec();
+            decode_and_validate(bytes.as_ptr(), bytes.len());
+            current = bytes;
+        }
+    }
+
+    #[test]
+    fn fuzz_with_garbage_input_generates_fresh() {
+        let state = State::new(3);
+        let (out, len) = fuzz_via_ffi(&state, vec![0xFFu8; 16], 1 << 16);
+        assert!(len > 0);
+        decode_and_validate(out, len);
+        verify_fresh_generation(&state);
+    }
+
+    #[test]
+    fn fuzz_returns_zero_on_oversize_with_non_null_out_buf() {
+        // max_size = 4 is smaller than any encoded program; expect the fuzz
+        // path to return 0 and still leave *out_buf pointing at something
+        // non-null.
+        let state = State::new(4);
+        let (out, len) = fuzz_via_ffi(&state, Vec::new(), 4);
+        assert_eq!(len, 0);
+        assert!(!out.is_null());
+    }
+
+    #[test]
+    fn describe_lists_stacked_mutator_sequence() {
+        let state = State::new(6);
+        // Loop until we hit the stacked-mutation branch (5% of calls generate
+        // fresh instead).
+        for _ in 0..10 {
+            let _ = fuzz_via_ffi(&state, seed_program_bytes(), 1 << 16);
+            let ptr = unsafe { afl_custom_describe(state.0, 256) };
+            let s = unsafe { CStr::from_ptr(ptr) }
+                .to_str()
+                .expect("valid utf-8");
+            let suffix = s
+                .strip_prefix("smite-ir:")
+                .expect("smite-ir: prefix on description");
+            if suffix == "fresh" {
+                continue;
+            }
+            for name in suffix.split(',') {
+                assert!(
+                    name == "op-param" || name == "input-swap",
+                    "unexpected mutator name in description: {name:?} (full: {s:?})",
+                );
+            }
+            return;
+        }
+        panic!("no stacked mutations of existing input after 10 attempts");
+    }
+
+    #[test]
+    fn describe_respects_max_description_len() {
+        let state = State::new(7);
+        let _ = fuzz_via_ffi(&state, Vec::new(), 1 << 16);
+        // Cap the description at 5 bytes.
+        let ptr = unsafe { afl_custom_describe(state.0, 5) };
+        let bytes = unsafe { CStr::from_ptr(ptr) }.to_bytes();
+        assert!(
+            bytes.len() <= 5,
+            "description must leave room for the null terminator within max_description_len",
+        );
+    }
+
+    #[test]
+    fn splice_optout_symbol_exists() {
+        // AFL++ should never call this function, but invoking it should not
+        // crash either.
+        unsafe { afl_custom_splice_optout(ptr::null_mut()) };
+    }
+}

--- a/smite-ir/Cargo.toml
+++ b/smite-ir/Cargo.toml
@@ -13,3 +13,4 @@ rand = { version = "0.10", default-features = false }
 serde.workspace = true
 postcard.workspace = true
 secp256k1.workspace = true
+thiserror.workspace = true

--- a/smite-ir/Cargo.toml
+++ b/smite-ir/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 smite = { path = "../smite" }
-rand = { version = "0.10", default-features = false }
+rand.workspace = true
 serde.workspace = true
 postcard.workspace = true
 secp256k1.workspace = true

--- a/smite-ir/src/program.rs
+++ b/smite-ir/src/program.rs
@@ -7,8 +7,12 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use smite::bolt::MAX_MESSAGE_SIZE;
+use thiserror::Error;
 
+use super::VariableType;
 use super::instruction::Instruction;
+use super::operation::Operation;
 
 /// An IR program: an ordered list of instructions.
 ///
@@ -16,13 +20,133 @@ use super::instruction::Instruction;
 /// mutator and the scenario executor. Execution context (target pubkey, chain
 /// hash, etc.) is supplied separately by the executor at run time and is not
 /// part of the serialized program.
-// TODO: add `validate` method for mutators to check deserialized programs
-// before mutation. Invalid programs should be rejected so that we don't panic
-// when modifying and rebuilding them via `ProgramBuilder`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Program {
     /// Instructions in SSA order.
     pub instructions: Vec<Instruction>,
+}
+
+/// Reasons a program can fail [`Program::validate`].
+///
+/// Mirrors the assertions in `ProgramBuilder::append`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ValidateError {
+    /// An instruction has the wrong number of inputs for its operation.
+    #[error("instruction {instr}: expected {expected} inputs, got {got}")]
+    WrongInputCount {
+        /// Index of the offending instruction.
+        instr: usize,
+        /// Number of inputs the operation expects.
+        expected: usize,
+        /// Number of inputs actually present.
+        got: usize,
+    },
+    /// An input references an instruction index that does not exist or is not
+    /// strictly less than the referencing instruction's own index (SSA
+    /// violation).
+    #[error("instruction {instr} input {input}: index {index} out of bounds")]
+    InputOutOfBounds {
+        /// Index of the offending instruction.
+        instr: usize,
+        /// Position of the input within the instruction's input list.
+        input: usize,
+        /// The out-of-range index that was referenced.
+        index: usize,
+    },
+    /// An input references an instruction whose operation produces no output
+    /// (e.g., `SendMessage`).
+    #[error("instruction {instr} input {input}: index {index} refers to a void instruction")]
+    VoidInput {
+        /// Index of the offending instruction.
+        instr: usize,
+        /// Position of the input within the instruction's input list.
+        input: usize,
+        /// The referenced instruction index.
+        index: usize,
+    },
+    /// An input has the wrong variable type for its position in the operation.
+    #[error("instruction {instr} input {input}: expected {expected:?}, got {got:?}")]
+    TypeMismatch {
+        /// Index of the offending instruction.
+        instr: usize,
+        /// Position of the input within the instruction's input list.
+        input: usize,
+        /// The variable type the operation expects.
+        expected: VariableType,
+        /// The variable type actually produced by the referenced instruction.
+        got: VariableType,
+    },
+    /// A `LoadBytes` or `LoadFeatures` operation contains more bytes than
+    /// `MAX_MESSAGE_SIZE`, which would panic in the BOLT encoder.
+    #[error("instruction {instr}: byte field length {len} exceeds MAX_MESSAGE_SIZE")]
+    OversizedBytes {
+        /// Index of the offending instruction.
+        instr: usize,
+        /// Actual byte length.
+        len: usize,
+    },
+}
+
+impl Program {
+    /// Validates that the program is well-formed: every instruction has the
+    /// right number of inputs, every input references a prior non-void
+    /// instruction, and every input's type matches what its operation expects.
+    ///
+    /// `ProgramBuilder` enforces most of these properties during construction;
+    /// this method exists so mutators can check programs that arrived from an
+    /// untrusted source (e.g., a corpus file decoded by the AFL++ custom
+    /// mutator) before attempting to mutate them.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first violation encountered.
+    pub fn validate(&self) -> Result<(), ValidateError> {
+        for (instr_idx, instr) in self.instructions.iter().enumerate() {
+            let expected = instr.operation.input_types();
+            if instr.inputs.len() != expected.len() {
+                return Err(ValidateError::WrongInputCount {
+                    instr: instr_idx,
+                    expected: expected.len(),
+                    got: instr.inputs.len(),
+                });
+            }
+            for (input_pos, (&input_idx, &expected_type)) in
+                instr.inputs.iter().zip(expected.iter()).enumerate()
+            {
+                if input_idx >= instr_idx {
+                    return Err(ValidateError::InputOutOfBounds {
+                        instr: instr_idx,
+                        input: input_pos,
+                        index: input_idx,
+                    });
+                }
+                let Some(actual_type) = self.instructions[input_idx].operation.output_type() else {
+                    return Err(ValidateError::VoidInput {
+                        instr: instr_idx,
+                        input: input_pos,
+                        index: input_idx,
+                    });
+                };
+                if actual_type != expected_type {
+                    return Err(ValidateError::TypeMismatch {
+                        instr: instr_idx,
+                        input: input_pos,
+                        expected: expected_type,
+                        got: actual_type,
+                    });
+                }
+            }
+            if let Operation::LoadBytes(b) | Operation::LoadFeatures(b) = &instr.operation
+                && b.len() > MAX_MESSAGE_SIZE
+            {
+                return Err(ValidateError::OversizedBytes {
+                    instr: instr_idx,
+                    len: b.len(),
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for Program {

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -8,6 +8,7 @@ use super::*;
 use generators::OpenChannelGenerator;
 use mutators::{InputSwapMutator, OperationParamMutator};
 use operation::AcceptChannelField;
+use program::ValidateError;
 
 /// Helper to build a private key with a single distinguishing byte.
 fn key(byte: u8) -> [u8; 32] {
@@ -418,6 +419,210 @@ fn append_type_mismatch_panics() {
     let mut builder = ProgramBuilder::new();
     let amount = builder.generate_fresh(VariableType::Amount, &mut rng);
     builder.append(Operation::DerivePoint, &[amount]);
+}
+
+// -- Program::validate tests --
+
+#[test]
+fn validate_accepts_generated_program() {
+    for seed in 0..100 {
+        let program = generate_program(seed);
+        program
+            .validate()
+            .expect("generated program should validate");
+    }
+}
+
+#[test]
+fn validate_accepts_empty_program() {
+    let program = Program {
+        instructions: vec![],
+    };
+    program.validate().expect("empty program should validate");
+}
+
+#[test]
+fn validate_rejects_wrong_input_count() {
+    // DerivePoint expects 1 input; supply 0.
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::WrongInputCount {
+            instr: 0,
+            expected: 1,
+            got: 0,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_input_out_of_bounds() {
+    // DerivePoint references instruction index 99, which doesn't exist.
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![99],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::InputOutOfBounds {
+            instr: 0,
+            input: 0,
+            index: 99,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_forward_reference() {
+    // Instruction 0 references instruction 1 -- SSA violation, even though the
+    // index is in bounds for the program as a whole.
+    let program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![1],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey(key(1)),
+                inputs: vec![],
+            },
+        ],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::InputOutOfBounds {
+            instr: 0,
+            input: 0,
+            index: 1,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_self_reference() {
+    // Instruction 0 references itself -- SSA violation.
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![0],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::InputOutOfBounds {
+            instr: 0,
+            input: 0,
+            index: 0,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_void_input() {
+    // Build a valid program, then append a DerivePoint that references the void
+    // SendMessage instruction emitted by the generator.
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    let mut program = builder.build();
+    let send_idx = program
+        .instructions
+        .iter()
+        .position(|i| matches!(i.operation, Operation::SendMessage))
+        .expect("generator emits SendMessage");
+    program.instructions.push(Instruction {
+        operation: Operation::DerivePoint,
+        inputs: vec![send_idx],
+    });
+    let bad_idx = program.instructions.len() - 1;
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::VoidInput {
+            instr: bad_idx,
+            input: 0,
+            index: send_idx,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_type_mismatch() {
+    // DerivePoint expects a PrivateKey input, but we feed it an Amount.
+    let program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::LoadAmount(1000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![0],
+            },
+        ],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::TypeMismatch {
+            instr: 1,
+            input: 0,
+            expected: VariableType::PrivateKey,
+            got: VariableType::Amount,
+        }),
+    );
+}
+
+#[test]
+fn validate_accepts_max_message_size_bytes() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::LoadBytes(vec![0; MAX_MESSAGE_SIZE]),
+            inputs: vec![],
+        }],
+    };
+    program
+        .validate()
+        .expect("bytes at exactly MAX_MESSAGE_SIZE should be valid");
+}
+
+#[test]
+fn validate_rejects_oversized_bytes() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::LoadBytes(vec![0; MAX_MESSAGE_SIZE + 1]),
+            inputs: vec![],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::OversizedBytes {
+            instr: 0,
+            len: MAX_MESSAGE_SIZE + 1,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_oversized_features() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::LoadFeatures(vec![0; MAX_MESSAGE_SIZE + 1]),
+            inputs: vec![],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::OversizedBytes {
+            instr: 0,
+            len: MAX_MESSAGE_SIZE + 1,
+        }),
+    );
 }
 
 // -- OperationParamMutator tests --

--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -85,9 +85,10 @@ RUN chmod +x /tmp/build-cln-lto.sh && /tmp/build-cln-lto.sh
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN TARGET_MAP_SIZE=$(cat /tmp/total-map-size) \
     cargo build -p smite-scenarios --bin cln_${SCENARIO} --release --features nyx
 

--- a/workloads/cln/Dockerfile.coverage
+++ b/workloads/cln/Dockerfile.coverage
@@ -81,9 +81,10 @@ RUN make -j$(nproc) install
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN cargo build -p smite-scenarios --bin cln_${SCENARIO} --release
 
 # Runtime image

--- a/workloads/eclair/Dockerfile
+++ b/workloads/eclair/Dockerfile
@@ -65,9 +65,10 @@ RUN java -cp target/eclair-sancov-0.0.0.jar EclairEdgeCounter \
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN TARGET_MAP_SIZE=$(cat /tmp/eclair-edge-count.txt) \
     cargo build -p smite-scenarios --bin eclair_${SCENARIO} --release --features nyx
 

--- a/workloads/eclair/Dockerfile.coverage
+++ b/workloads/eclair/Dockerfile.coverage
@@ -51,9 +51,10 @@ RUN find eclair-node/target -name "eclair-node-*-bin.zip" \
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN cargo build -p smite-scenarios --bin eclair_${SCENARIO} --release
 
 # Runtime image.

--- a/workloads/ldk/Dockerfile
+++ b/workloads/ldk/Dockerfile
@@ -57,9 +57,10 @@ RUN cargo afl build --release
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN TARGET_PATH=/ldk-wrapper/target/release/ldk-node-wrapper \
     cargo build -p smite-scenarios --bin ldk_${SCENARIO} --release --features nyx
 

--- a/workloads/ldk/Dockerfile.coverage
+++ b/workloads/ldk/Dockerfile.coverage
@@ -52,9 +52,10 @@ RUN cargo build --release
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 ENV RUSTFLAGS=""
 RUN cargo build -p smite-scenarios --bin ldk_${SCENARIO} --release
 

--- a/workloads/lnd/Dockerfile
+++ b/workloads/lnd/Dockerfile
@@ -66,9 +66,10 @@ RUN cd cmd/lnd && CGO_ENABLED=1 go build -v -tags=libfuzzer -gcflags=all=-d=libf
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN TARGET_PATH=/lnd/cmd/lnd/lnd cargo build -p smite-scenarios --bin lnd_${SCENARIO} --release --features nyx
 
 # Runtime image

--- a/workloads/lnd/Dockerfile.coverage
+++ b/workloads/lnd/Dockerfile.coverage
@@ -51,9 +51,10 @@ RUN cd cmd/lncli && go build
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
-COPY smite-scenarios/ smite-scenarios/
 COPY smite-ir/ smite-ir/
+COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smite-scenarios/ smite-scenarios/
 RUN cargo build -p smite-scenarios --bin lnd_${SCENARIO} --release
 
 # Runtime image


### PR DESCRIPTION
Implement the AFL++ custom mutator C ABI as a new crate. The resulting cdylib should be used with `AFL_CUSTOM_MUTATOR_LIBRARY`, along with `AFL_CUSTOM_MUTATOR_ONLY=1` and `AFL_DISABLE_TRIM=1`.

The library exports five functions for use by AFL++:
- `afl_custom_init` and `afl_custom_deinit` create and destroy a boxed `MutatorState` for use by the other functions.
- `afl_custom_fuzz` decodes and validates a provided input as a `Program`,  then mutates the `Program` or generates a new one from scratch.
- `afl_custom_splice_optout` tells AFL++ not to provide inputs for a splice mutator.
- `afl_custom_describe` returns the sequence of mutators that produced the latest mutated input.

The AFL++ custom mutator [documentation](https://aflplus.plus/docs/custom_mutators/) and [examples](https://github.com/AFLplusplus/AFLplusplus/tree/stable/custom_mutators/examples) will be helpful for review.

Ref: #5 (Milestone 1)