### PR TITLE
smite-scenarios: implement `IrScenario`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "postcard",
  "secp256k1",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,37 @@ echo 'AAAA' > /tmp/smite-seeds/seed1
 ~/AFLplusplus/afl-fuzz -X -i /tmp/smite-seeds -o /tmp/smite-out -- /tmp/smite-nyx
 ```
 
+### IR Scenario
+
+The `ir` scenario uses structured IR programs instead of raw bytes. It requires
+a custom mutator library and different AFL++ flags:
+
+```bash
+TARGET=ldk
+SCENARIO=ir
+
+# Build the Docker image and Nyx sharedir as above
+docker build -t smite-$TARGET-$SCENARIO -f workloads/$TARGET/Dockerfile --build-arg SCENARIO=$SCENARIO .
+./scripts/setup-nyx.sh /tmp/smite-nyx smite-$TARGET-$SCENARIO ~/AFLplusplus
+
+# Build the custom mutator
+cargo build --release -p smite-ir-mutator
+
+# Create seed corpus (an empty file works -- the mutator generates fresh programs)
+mkdir -p /tmp/smite-seeds
+printf '\x00' > /tmp/smite-seeds/empty
+
+# Start fuzzing with the custom mutator
+AFL_CUSTOM_MUTATOR_LIBRARY=target/release/libsmite_ir_mutator.so \
+AFL_CUSTOM_MUTATOR_ONLY=1 \
+AFL_DISABLE_TRIM=1 \
+~/AFLplusplus/afl-fuzz -X -i /tmp/smite-seeds -o /tmp/smite-out -- /tmp/smite-nyx
+```
+
+`AFL_CUSTOM_MUTATOR_ONLY=1` disables AFL++'s built-in mutators (which would
+corrupt the postcard encoding). `AFL_DISABLE_TRIM=1` prevents AFL++ from
+trimming inputs (which would also corrupt the encoding).
+
 ## Running Modes
 
 ### Nyx Mode
@@ -87,7 +118,8 @@ firefox ./$TARGET-$SCENARIO-coverage-report/html/index.html
 
 ```
 smite/              # Core Rust library (runners, scenarios, noise protocol, BOLT messages)
-smite-ir/           # Library to build and mutate Intermediate Representation (IR) programs
+smite-ir/           # IR types, generators, and mutators for structured fuzzing programs
+smite-ir-mutator/   # AFL++ custom mutator cdylib for IR programs
 smite-nyx-sys/      # Nyx FFI bindings
 smite-scenarios/    # Scenario implementations and target binaries
 workloads/

--- a/smite-scenarios/Cargo.toml
+++ b/smite-scenarios/Cargo.toml
@@ -15,6 +15,7 @@ smite = { path = "../smite" }
 smite-ir = { path = "../smite-ir" }
 smite-nyx-sys = { path = "../smite-nyx-sys", optional = true }
 
+postcard.workspace = true
 log.workspace = true
 simple_logger.workspace = true
 secp256k1.workspace = true

--- a/smite-scenarios/src/bin/cln_ir.rs
+++ b/smite-scenarios/src/bin/cln_ir.rs
@@ -1,0 +1,9 @@
+//! CLN IR fuzzing scenario binary.
+
+use smite::scenarios::smite_run;
+use smite_scenarios::scenarios::{IrScenario, PostInitSetup};
+use smite_scenarios::targets::ClnTarget;
+
+fn main() -> std::process::ExitCode {
+    smite_run::<IrScenario<ClnTarget, PostInitSetup>>()
+}

--- a/smite-scenarios/src/bin/eclair_ir.rs
+++ b/smite-scenarios/src/bin/eclair_ir.rs
@@ -1,0 +1,9 @@
+//! Eclair IR fuzzing scenario binary.
+
+use smite::scenarios::smite_run;
+use smite_scenarios::scenarios::{IrScenario, PostInitSetup};
+use smite_scenarios::targets::EclairTarget;
+
+fn main() -> std::process::ExitCode {
+    smite_run::<IrScenario<EclairTarget, PostInitSetup>>()
+}

--- a/smite-scenarios/src/bin/ldk_ir.rs
+++ b/smite-scenarios/src/bin/ldk_ir.rs
@@ -1,0 +1,9 @@
+//! LDK IR fuzzing scenario binary.
+
+use smite::scenarios::smite_run;
+use smite_scenarios::scenarios::{IrScenario, PostInitSetup};
+use smite_scenarios::targets::LdkTarget;
+
+fn main() -> std::process::ExitCode {
+    smite_run::<IrScenario<LdkTarget, PostInitSetup>>()
+}

--- a/smite-scenarios/src/bin/lnd_ir.rs
+++ b/smite-scenarios/src/bin/lnd_ir.rs
@@ -1,0 +1,9 @@
+//! LND IR fuzzing scenario binary.
+
+use smite::scenarios::smite_run;
+use smite_scenarios::scenarios::{IrScenario, PostInitSetup};
+use smite_scenarios::targets::LndTarget;
+
+fn main() -> std::process::ExitCode {
+    smite_run::<IrScenario<LndTarget, PostInitSetup>>()
+}

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -102,6 +102,7 @@ pub fn execute(
     program: &Program,
     context: &ProgramContext,
     conn: &mut impl Connection,
+    start: std::time::Instant,
 ) -> Result<(), ExecuteError> {
     let secp = Secp256k1::new();
     let mut variables: Vec<Option<Variable>> = Vec::with_capacity(program.instructions.len());
@@ -156,12 +157,20 @@ pub fn execute(
             // -- Act operations --
             Operation::SendMessage => {
                 let bytes = resolve_message(&variables, instr.inputs[0])?;
+                let msg_type = bytes.get(..2).map(|b| u16::from_be_bytes([b[0], b[1]]));
+                log::debug!(
+                    "[{:?}] SendMessage: type {msg_type:?}, {} bytes",
+                    start.elapsed(),
+                    bytes.len(),
+                );
                 conn.send_message(bytes)?;
                 None
             }
 
             Operation::RecvAcceptChannel => {
+                log::debug!("[{:?}] RecvAcceptChannel: waiting", start.elapsed());
                 let ac = recv_accept_channel(conn)?;
+                log::debug!("[{:?}] RecvAcceptChannel: received", start.elapsed());
                 Some(Variable::AcceptChannel(ac))
             }
         };
@@ -607,7 +616,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        execute(&program, &sample_context(), &mut conn).unwrap();
+        execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap();
 
         assert_eq!(conn.sent.len(), 1);
         let oc = decode_open_channel(&conn.sent[0]);
@@ -657,7 +672,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        execute(&program, &sample_context(), &mut conn).unwrap();
+        execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap();
 
         let oc = decode_open_channel(&conn.sent[0]);
         assert_eq!(
@@ -700,7 +721,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        execute(&program, &sample_context(), &mut conn).unwrap();
+        execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap();
 
         let oc = decode_open_channel(&conn.sent[0]);
         let secp = Secp256k1::new();
@@ -754,7 +781,13 @@ mod tests {
         };
         let mut conn = MockConnection::new();
         conn.queue_recv(ac_bytes);
-        execute(&program, &sample_context(), &mut conn).unwrap();
+        execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -771,7 +804,13 @@ mod tests {
         };
         let mut conn = MockConnection::new();
         conn.queue_recv(init_bytes);
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             ExecuteError::UnexpectedMessage {
@@ -802,7 +841,13 @@ mod tests {
         let mut conn = MockConnection::new();
         conn.queue_recv(ping_bytes);
         conn.queue_recv(ac_bytes);
-        execute(&program, &sample_context(), &mut conn).unwrap();
+        execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap();
 
         // Verify a correctly-sized pong was sent.
         assert_eq!(conn.sent.len(), 1);
@@ -825,7 +870,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             ExecuteError::WrongInputCount {
@@ -851,7 +902,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             ExecuteError::TypeMismatch {
@@ -871,7 +928,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ExecuteError::VariableIndexOutOfBounds { .. }));
     }
 
@@ -892,7 +955,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ExecuteError::VariableIndexOutOfBounds { .. }));
     }
 
@@ -920,7 +989,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ExecuteError::VoidVariable { index: 21 }));
     }
 
@@ -940,7 +1015,13 @@ mod tests {
             instructions: instrs,
         };
         let mut conn = MockConnection::new();
-        let err = execute(&program, &sample_context(), &mut conn).unwrap_err();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ExecuteError::InvalidPrivateKey));
     }
 

--- a/smite-scenarios/src/scenarios.rs
+++ b/smite-scenarios/src/scenarios.rs
@@ -3,10 +3,12 @@
 mod encrypted_bytes;
 mod init;
 mod noise;
+mod setup;
 
 pub use encrypted_bytes::EncryptedBytesScenario;
 pub use init::InitScenario;
 pub use noise::NoiseScenario;
+pub use setup::{PostInitSetup, REGTEST_CHAIN_HASH, SnapshotSetup};
 use smite::scenarios::ScenarioError;
 
 use std::time::Duration;

--- a/smite-scenarios/src/scenarios.rs
+++ b/smite-scenarios/src/scenarios.rs
@@ -2,11 +2,13 @@
 
 mod encrypted_bytes;
 mod init;
+mod ir;
 mod noise;
 mod setup;
 
 pub use encrypted_bytes::EncryptedBytesScenario;
 pub use init::InitScenario;
+pub use ir::IrScenario;
 pub use noise::NoiseScenario;
 pub use setup::{PostInitSetup, REGTEST_CHAIN_HASH, SnapshotSetup};
 use smite::scenarios::ScenarioError;

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -1,0 +1,101 @@
+//! IR program scenario: deserialize a postcard `Program` from the fuzz input
+//! and execute it against the target over an established encrypted connection.
+
+use std::marker::PhantomData;
+
+use smite::noise::NoiseConnection;
+use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
+use smite_ir::Program;
+
+use super::{SnapshotSetup, ping_pong};
+use crate::executor::{self, ExecuteError, ProgramContext};
+use crate::targets::Target;
+
+/// Scenario that executes IR programs against a target over an encrypted
+/// connection established by `S`.
+pub struct IrScenario<T: Target, S: SnapshotSetup<T>> {
+    target: T,
+    conn: NoiseConnection,
+    context: ProgramContext,
+    // S is only used for static dispatch on S::setup(), not stored.
+    _phantom: PhantomData<S>,
+}
+
+impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
+    fn new(_args: &[String]) -> Result<Self, ScenarioError> {
+        let target = T::start(T::Config::default())?;
+        let (conn, context) = S::setup(&target)?;
+        Ok(Self {
+            target,
+            conn,
+            context,
+            _phantom: PhantomData,
+        })
+    }
+
+    fn run(&mut self, input: &[u8]) -> ScenarioResult {
+        let start = std::time::Instant::now();
+
+        let Ok(program) = postcard::from_bytes::<Program>(input) else {
+            log::debug!("Input did not deserialize properly, skipping");
+            return ScenarioResult::Skip;
+        };
+
+        log::debug!(
+            "[{:?}] Executing IR program ({} instructions, {} input bytes)",
+            start.elapsed(),
+            program.instructions.len(),
+            input.len(),
+        );
+
+        match executor::execute(&program, &self.context, &mut self.conn, start) {
+            Ok(()) => {
+                log::debug!("[{:?}] Program executed successfully", start.elapsed());
+            }
+            Err(ExecuteError::Connection(e)) => {
+                // Target may have closed the connection in response to bad
+                // input. check_alive below is the authority on whether that's a
+                // crash.
+                log::debug!("[{:?}] execute connection error: {e}", start.elapsed());
+            }
+            Err(ExecuteError::UnexpectedMessage { expected, got }) => {
+                // Target replied with an unexpected message type (often
+                // Error/Warning when rejecting our input). Usually normal
+                // protocol behavior.
+                log::debug!(
+                    "[{:?}] unexpected message: expected {expected}, got {got}",
+                    start.elapsed(),
+                );
+            }
+            Err(ExecuteError::Decode(e)) => {
+                // Either our decoder is incomplete or the target sent something
+                // the spec doesn't allow.
+                return ScenarioResult::Fail(format!("decode error: {e}"));
+            }
+            Err(e) => {
+                // Ill-formed IR program. This could happen if an input was
+                // constructed manually or using non-Smite mutators.
+                log::debug!("[{:?}] invalid IR program: {e}", start.elapsed());
+                return ScenarioResult::Skip;
+            }
+        }
+
+        // Ping-pong sync to ensure the target has at least done the initial
+        // processing of all previous messages. Timeouts here signal a hang.
+        if let Err(e) = ping_pong(&mut self.conn) {
+            log::debug!("[{:?}] ping_pong: {e}", start.elapsed());
+            if e.is_timeout() {
+                return ScenarioResult::Fail("target hung (ping timeout)".into());
+            }
+        } else {
+            log::debug!("[{:?}] Target responded with pong", start.elapsed());
+        }
+
+        if let Err(e) = self.target.check_alive() {
+            log::debug!("[{:?}] check_alive: {e}", start.elapsed());
+            return ScenarioResult::Fail("target crashed".into());
+        }
+
+        ScenarioResult::Ok
+    }
+}

--- a/smite-scenarios/src/scenarios/setup.rs
+++ b/smite-scenarios/src/scenarios/setup.rs
@@ -1,0 +1,109 @@
+//! Snapshot setup: procedural pre-snapshot state preparation for IR fuzzing.
+
+use std::time::Duration;
+
+use smite::bolt::{Init, InitTlvs, Message};
+use smite::noise::NoiseConnection;
+use smite::scenarios::ScenarioError;
+
+use super::{handshake_with_target, ping_pong};
+use crate::executor::ProgramContext;
+use crate::targets::{INITIAL_BLOCKS, Target};
+
+/// Bitcoin regtest genesis hash (in BOLT 2 network byte order).
+pub const REGTEST_CHAIN_HASH: [u8; 32] = [
+    0x06, 0x22, 0x6e, 0x46, 0x11, 0x1a, 0x0b, 0x59, 0xca, 0xaf, 0x12, 0x60, 0x43, 0xeb, 0x5b, 0xbf,
+    0x28, 0xc3, 0x4f, 0x3a, 0x5e, 0x33, 0x2a, 0x1f, 0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88, 0x91, 0x0f,
+];
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Pre-snapshot setup that establishes a ready-to-use connection and produces
+/// the [`ProgramContext`] an IR program will read at execution time. Called
+/// once from `IrScenario::new()` before the Nyx snapshot is taken.
+pub trait SnapshotSetup<T: Target> {
+    /// Execute the setup and return the connection and context.
+    ///
+    /// # Errors
+    ///
+    /// Setup-specific; propagated to the scenario's `new()`.
+    fn setup(target: &T) -> Result<(NoiseConnection, ProgramContext), ScenarioError>;
+}
+
+/// Clears a feature bit from a feature vector.
+///
+/// Feature vectors are encoded as big-endian byte arrays where bit N lives in
+/// byte `features[len - 1 - N/8]` at position `N % 8`.
+fn clear_feature_bit(features: &mut [u8], bit: usize) {
+    let byte_index = features.len().checked_sub(1 + bit / 8);
+    if let Some(i) = byte_index {
+        features[i] &= !(1 << (bit % 8));
+    }
+}
+
+/// Gossip-related feature bits (BOLT 9): `gossip_queries` (6/7),
+/// `gossip_queries_ex` (10/11). Stripped so the target doesn't send
+/// `gossip_timestamp_filter` or other gossip noise during execution.
+const GOSSIP_FEATURE_BITS: &[usize] = &[6, 7, 10, 11];
+
+/// Feature bits that force a dual-funded flow when both peers support them:
+/// `option_dual_fund` (28/29). Eclair in particular will not allow
+/// single-funded flows if either of these feature bits is set, so we strip them
+/// when fuzzing the single-funded flow.
+const DUAL_FUNDING_FEATURE_BITS: &[usize] = &[28, 29];
+
+/// Peer storage feature bits: `option_provide_storage` (42/43). When enabled,
+/// peers may send `peer_storage` and `peer_storage_retrieval` messages at
+/// arbitrary times. Disabling these bits eliminates peer storage noise.
+const PEER_STORAGE_FEATURE_BITS: &[usize] = &[42, 43];
+
+/// Creates an `init` that echoes the received features with bits stripped that
+/// would steer the target away from the single-funded `open_channel` flow.
+fn init_for_single_funded(received: &Init) -> Init {
+    let mut globalfeatures = received.globalfeatures.clone();
+    let mut features = received.features.clone();
+    for &bit in GOSSIP_FEATURE_BITS
+        .iter()
+        .chain(DUAL_FUNDING_FEATURE_BITS)
+        .chain(PEER_STORAGE_FEATURE_BITS)
+    {
+        clear_feature_bit(&mut globalfeatures, bit);
+        clear_feature_bit(&mut features, bit);
+    }
+    Init {
+        globalfeatures,
+        features,
+        tlvs: InitTlvs::default(),
+    }
+}
+
+/// Setup that snapshots just after the Noise handshake and init exchange are
+/// complete.
+pub struct PostInitSetup;
+
+impl<T: Target> SnapshotSetup<T> for PostInitSetup {
+    fn setup(target: &T) -> Result<(NoiseConnection, ProgramContext), ScenarioError> {
+        let (mut conn, target_init) = handshake_with_target(target, TIMEOUT)?;
+
+        // Echo features but strip the bits that would take us off the
+        // single-funded `open_channel` path this setup is built for.
+        let our_init = init_for_single_funded(&target_init);
+        conn.send_message(&Message::Init(our_init).encode())?;
+
+        // Drain any remaining post-init noise so the snapshot starts with a
+        // clean connection.
+        ping_pong(&mut conn)?;
+
+        let context = ProgramContext {
+            target_pubkey: *target.pubkey(),
+            chain_hash: REGTEST_CHAIN_HASH,
+            // All targets gate startup on `INITIAL_BLOCKS` being mined, so
+            // this is the floor. Dynamic per-target queries can replace it
+            // later.
+            block_height: u32::try_from(INITIAL_BLOCKS).expect("fits in u32"),
+            target_features: target_init.features,
+        };
+
+        Ok((conn, context))
+    }
+}

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -6,6 +6,7 @@ mod eclair;
 mod ldk;
 mod lnd;
 
+pub use bitcoind::INITIAL_BLOCKS;
 pub use cln::{ClnConfig, ClnTarget};
 pub use eclair::{EclairConfig, EclairTarget};
 pub use ldk::{LdkConfig, LdkTarget};


### PR DESCRIPTION
Enables end-to-end IR fuzzing of all 4 targets.

`IrScenario` is parameterized by a `SnapshotSetup` that determines the snapshot restore point.  Currently we only implement a `PostInitSetup` tailored towards the `open_channel` funding flow, but we can add more snapshot setups as needed.

Ref: #5 (Milestone 1)