### PR TITLE
smite-ir: generate compliant shutdown scripts

### DIFF
--- a/smite-ir/src/generators/open_channel.rs
+++ b/smite-ir/src/generators/open_channel.rs
@@ -4,6 +4,7 @@ use rand::Rng;
 
 use super::Generator;
 use crate::builder::ProgramBuilder;
+use crate::operation::ShutdownScriptVariant;
 use crate::{Operation, VariableType};
 
 /// Generates an `open_channel` -> `accept_channel` flow.
@@ -37,7 +38,9 @@ impl Generator for OpenChannelGenerator {
         let to_self_delay = builder.pick_variable(VariableType::U16, rng);
         let max_accepted_htlcs = builder.pick_variable(VariableType::U16, rng);
         let channel_flags = builder.pick_variable(VariableType::U8, rng);
-        let upfront_shutdown_script = builder.pick_variable(VariableType::Bytes, rng);
+        let shutdown_script_variant = ShutdownScriptVariant::random(rng);
+        let upfront_shutdown_script =
+            builder.append(Operation::LoadShutdownScript(shutdown_script_variant), &[]);
         let channel_type = builder.pick_variable(VariableType::Features, rng);
 
         // Build and send open_channel.

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -5,7 +5,7 @@ use rand::{Rng, RngExt};
 use smite::bolt::MAX_MESSAGE_SIZE;
 
 use super::Mutator;
-use crate::operation::AcceptChannelField;
+use crate::operation::{AcceptChannelField, ShutdownScriptVariant};
 use crate::{Operation, Program};
 
 /// Mutates the embedded parameter of a randomly chosen `is_param_mutable`
@@ -55,6 +55,10 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         }
         Operation::LoadPrivateKey(bytes) | Operation::LoadChannelId(bytes) => {
             mutate_fixed_bytes(bytes, rng);
+            true
+        }
+        Operation::LoadShutdownScript(variant) => {
+            mutate_shutdown_script(variant, rng);
             true
         }
         Operation::ExtractAcceptChannel(field) => mutate_extract_field(field, rng),
@@ -237,6 +241,40 @@ fn mutate_fixed_bytes(bytes: &mut [u8], rng: &mut impl Rng) {
 }
 
 // -- Extract field mutation --
+
+/// Mutates a `ShutdownScriptVariant`. Half the time, mutates the variant's
+/// embedded bytes in place; otherwise replaces with a random different variant.
+/// Falls through to a variant swap if the current variant has no embedded
+/// bytes.
+fn mutate_shutdown_script(variant: &mut ShutdownScriptVariant, rng: &mut impl Rng) {
+    if rng.random() && mutate_shutdown_script_bytes(variant, rng) {
+        return;
+    }
+    let current = std::mem::discriminant(variant);
+    for _ in 0..8 {
+        let candidate = ShutdownScriptVariant::random(rng);
+        if std::mem::discriminant(&candidate) != current {
+            *variant = candidate;
+            return;
+        }
+    }
+}
+
+/// Mutates the variant's embedded bytes via `mutate_fixed_bytes`. Returns
+/// `false` if the variant carries no bytes to mutate.
+fn mutate_shutdown_script_bytes(variant: &mut ShutdownScriptVariant, rng: &mut impl Rng) -> bool {
+    let bytes: &mut [u8] = match variant {
+        ShutdownScriptVariant::Empty => return false,
+        ShutdownScriptVariant::P2pkh(h)
+        | ShutdownScriptVariant::P2sh(h)
+        | ShutdownScriptVariant::P2wpkh(h) => h,
+        ShutdownScriptVariant::P2wsh(h) => h,
+        ShutdownScriptVariant::AnySegwit { program, .. } => program,
+        ShutdownScriptVariant::OpReturn(data) => data,
+    };
+    mutate_fixed_bytes(bytes, rng);
+    true
+}
 
 /// Returns `true` if the field was swapped, `false` if no same-type alternative
 /// field exists.

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -194,23 +194,28 @@ fn mutate_bytes(bytes: &mut Vec<u8>, rng: &mut impl Rng) {
     }
 }
 
-fn mutate_fixed_bytes(bytes: &mut [u8; 32], rng: &mut impl Rng) {
+/// In-place byte tweaks that preserve the slice's length.
+fn mutate_fixed_bytes(bytes: &mut [u8], rng: &mut impl Rng) {
+    if bytes.is_empty() {
+        return;
+    }
+    let n = bytes.len();
     match rng.random_range(0..6) {
         // Flip a random bit.
         0 => {
-            let idx = rng.random_range(0..32);
+            let idx = rng.random_range(0..n);
             bytes[idx] ^= 1 << rng.random_range(0..8u8);
         }
         // Change a random byte.
         1 => {
-            let idx = rng.random_range(0..32);
+            let idx = rng.random_range(0..n);
             bytes[idx] = rng.random();
         }
         // Shuffle a random subrange.
         2 => shuffle_subrange(bytes, rng),
         // Add or subtract a small delta from a random byte.
         3 => {
-            let idx = rng.random_range(0..32);
+            let idx = rng.random_range(0..n);
             let delta = rng.random_range(1..=35);
             if rng.random() {
                 bytes[idx] = bytes[idx].wrapping_add(delta);
@@ -219,14 +224,15 @@ fn mutate_fixed_bytes(bytes: &mut [u8; 32], rng: &mut impl Rng) {
             }
         }
         // Copy a chunk from one position to another.
-        4 => {
-            let len = rng.random_range(1..=31);
-            let src = rng.random_range(0..=32 - len);
-            let dst = rng.random_range(0..=32 - len);
+        4 if n >= 2 => {
+            let max_len = (n - 1).min(32);
+            let len = rng.random_range(1..=max_len);
+            let src = rng.random_range(0..=n - len);
+            let dst = rng.random_range(0..=n - len);
             bytes.copy_within(src..src + len, dst);
         }
         // Randomize entirely.
-        _ => rng.fill(&mut bytes[..]),
+        _ => rng.fill(bytes),
     }
 }
 

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::fmt::Write;
 
+use rand::{Rng, RngExt};
 use serde::{Deserialize, Serialize};
 
 use super::VariableType;
@@ -38,6 +39,11 @@ pub enum Operation {
     LoadPrivateKey([u8; 32]),
     /// Load a 32-byte channel identifier.
     LoadChannelId([u8; 32]),
+    /// Load a BOLT 2 compliant `upfront_shutdown_script`.
+    ///
+    /// Produces a [`VariableType::Bytes`] value whose contents match one of the
+    /// standard script templates required by BOLT 2.
+    LoadShutdownScript(ShutdownScriptVariant),
     /// Load the target node's public key from the program context.
     LoadTargetPubkeyFromContext,
     /// Load the chain hash from the program context.
@@ -86,6 +92,184 @@ pub enum Operation {
     /// Receive and parse an `accept_channel` response.
     /// Produces an `AcceptChannel` compound variable.
     RecvAcceptChannel,
+}
+
+/// A BOLT 2 compliant `upfront_shutdown_script` template.
+///
+/// Each variant encodes to a script matching one of the formats required by
+/// BOLT 2 for the upfront shutdown TLV. `Empty` opts out of upfront shutdown
+/// entirely and is accepted regardless of feature negotiation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ShutdownScriptVariant {
+    /// Zero-length script. Opts out of upfront shutdown.
+    Empty,
+    /// `OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG`.
+    P2pkh([u8; 20]),
+    /// `OP_HASH160 <20-byte hash> OP_EQUAL`.
+    P2sh([u8; 20]),
+    /// `OP_0 <20-byte hash>`.
+    P2wpkh([u8; 20]),
+    /// `OP_0 <32-byte hash>`.
+    P2wsh([u8; 32]),
+    /// `OP_<version> <program>` for witness program versions 1..=16 with a
+    /// 2..=40 byte program. Requires the counterparty to signal
+    /// `option_shutdown_anysegwit`.
+    AnySegwit {
+        /// Witness program version, in `1..=16`.
+        version: u8,
+        /// Witness program bytes, length in `2..=40`.
+        program: Vec<u8>,
+    },
+    /// `OP_RETURN <data>` where `data` is 6..=80 bytes. Requires the
+    /// counterparty to signal `option_simple_close`.
+    OpReturn(Vec<u8>),
+}
+
+impl ShutdownScriptVariant {
+    /// Number of variants, used for uniform random sampling. Keep in sync with
+    /// `random` and the enum definition.
+    pub const VARIANT_COUNT: usize = 7;
+
+    /// `AnySegwit` witness program version bounds (BOLT 2 / BIP 141).
+    pub const ANYSEGWIT_MIN_VERSION: u8 = 1;
+    pub const ANYSEGWIT_MAX_VERSION: u8 = 16;
+
+    /// `AnySegwit` witness program length bounds (BOLT 2 / BIP 141).
+    pub const ANYSEGWIT_MIN_PROGRAM_LEN: usize = 2;
+    pub const ANYSEGWIT_MAX_PROGRAM_LEN: usize = 40;
+
+    /// `OP_RETURN` payload length bounds (BOLT 2 `option_simple_close`).
+    pub const OP_RETURN_MIN_DATA_LEN: usize = 6;
+    pub const OP_RETURN_MAX_DATA_LEN: usize = 80;
+
+    /// Generates a random variant with random embedded data. Variants are
+    /// chosen uniformly. Embedded hashes / programs are filled with random
+    /// bytes; lengths are drawn uniformly from the BOLT-permitted range for
+    /// variable-length variants.
+    pub fn random(rng: &mut impl Rng) -> Self {
+        match rng.random_range(0..Self::VARIANT_COUNT) {
+            0 => Self::Empty,
+            1 => Self::P2pkh(rng.random()),
+            2 => Self::P2sh(rng.random()),
+            3 => Self::P2wpkh(rng.random()),
+            4 => Self::P2wsh(rng.random()),
+            5 => {
+                let version =
+                    rng.random_range(Self::ANYSEGWIT_MIN_VERSION..=Self::ANYSEGWIT_MAX_VERSION);
+                let len = rng.random_range(
+                    Self::ANYSEGWIT_MIN_PROGRAM_LEN..=Self::ANYSEGWIT_MAX_PROGRAM_LEN,
+                );
+                let mut program = vec![0u8; len];
+                rng.fill(&mut program[..]);
+                Self::AnySegwit { version, program }
+            }
+            6 => {
+                let len =
+                    rng.random_range(Self::OP_RETURN_MIN_DATA_LEN..=Self::OP_RETURN_MAX_DATA_LEN);
+                let mut data = vec![0u8; len];
+                rng.fill(&mut data[..]);
+                Self::OpReturn(data)
+            }
+            _ => unreachable!("ShutdownScriptVariant::random doesn't generate all variants"),
+        }
+    }
+
+    /// Encodes the variant as raw scriptpubkey bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `AnySegwit.version` is outside
+    /// `ANYSEGWIT_MIN_VERSION..=ANYSEGWIT_MAX_VERSION`, if the program is
+    /// outside `ANYSEGWIT_MIN_PROGRAM_LEN..=ANYSEGWIT_MAX_PROGRAM_LEN` bytes,
+    /// or if `OpReturn` data is outside
+    /// `OP_RETURN_MIN_DATA_LEN..=OP_RETURN_MAX_DATA_LEN` bytes.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            Self::Empty => Vec::new(),
+            Self::P2pkh(h) => {
+                let mut out = Vec::with_capacity(25);
+                out.extend_from_slice(&[0x76, 0xa9, 0x14]);
+                out.extend_from_slice(h);
+                out.extend_from_slice(&[0x88, 0xac]);
+                out
+            }
+            Self::P2sh(h) => {
+                let mut out = Vec::with_capacity(23);
+                out.extend_from_slice(&[0xa9, 0x14]);
+                out.extend_from_slice(h);
+                out.push(0x87);
+                out
+            }
+            Self::P2wpkh(h) => {
+                let mut out = Vec::with_capacity(22);
+                out.extend_from_slice(&[0x00, 0x14]);
+                out.extend_from_slice(h);
+                out
+            }
+            Self::P2wsh(h) => {
+                let mut out = Vec::with_capacity(34);
+                out.extend_from_slice(&[0x00, 0x20]);
+                out.extend_from_slice(h);
+                out
+            }
+            Self::AnySegwit { version, program } => {
+                assert!(
+                    (Self::ANYSEGWIT_MIN_VERSION..=Self::ANYSEGWIT_MAX_VERSION).contains(version),
+                    "AnySegwit version {version} out of range",
+                );
+                assert!(
+                    (Self::ANYSEGWIT_MIN_PROGRAM_LEN..=Self::ANYSEGWIT_MAX_PROGRAM_LEN)
+                        .contains(&program.len()),
+                    "AnySegwit program length {} out of range",
+                    program.len(),
+                );
+                // OP_1..OP_16 = 0x51..=0x60 (i.e., 0x50 + version).
+                let opcode = 0x50 + version;
+                let mut out = Vec::with_capacity(2 + program.len());
+                #[allow(clippy::cast_possible_truncation)] // program.len() is at most 40.
+                out.extend_from_slice(&[opcode, program.len() as u8]);
+                out.extend_from_slice(program);
+                out
+            }
+            Self::OpReturn(data) => {
+                assert!(
+                    (Self::OP_RETURN_MIN_DATA_LEN..=Self::OP_RETURN_MAX_DATA_LEN)
+                        .contains(&data.len()),
+                    "OpReturn data length {} out of range",
+                    data.len(),
+                );
+                let mut out = Vec::with_capacity(3 + data.len());
+                out.push(0x6a); // OP_RETURN
+                if data.len() <= 75 {
+                    #[allow(clippy::cast_possible_truncation)] // data.len() <= 75 here.
+                    out.push(data.len() as u8);
+                } else {
+                    // OP_PUSHDATA1 followed by length (76..=80).
+                    #[allow(clippy::cast_possible_truncation)] // data.len() <= 80 here.
+                    out.extend_from_slice(&[0x4c, data.len() as u8]);
+                }
+                out.extend_from_slice(data);
+                out
+            }
+        }
+    }
+}
+
+impl fmt::Display for ShutdownScriptVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "Empty"),
+            Self::P2pkh(h) => write!(f, "P2pkh({})", format_hex(h)),
+            Self::P2sh(h) => write!(f, "P2sh({})", format_hex(h)),
+            Self::P2wpkh(h) => write!(f, "P2wpkh({})", format_hex(h)),
+            Self::P2wsh(h) => write!(f, "P2wsh({})", format_hex(h)),
+            Self::AnySegwit { version, program } => {
+                write!(f, "AnySegwit(v{version}, {})", format_hex(program))
+            }
+            Self::OpReturn(data) => write!(f, "OpReturn({})", format_hex(data)),
+        }
+    }
 }
 
 /// Fields that can be extracted from an `AcceptChannel` compound variable.
@@ -188,6 +372,7 @@ impl fmt::Display for Operation {
             Self::LoadFeatures(b) => write!(f, "LoadFeatures({})", format_hex(b)),
             Self::LoadPrivateKey(b) => write!(f, "LoadPrivateKey({})", format_hex(b)),
             Self::LoadChannelId(b) => write!(f, "LoadChannelId({})", format_hex(b)),
+            Self::LoadShutdownScript(v) => write!(f, "LoadShutdownScript({v})"),
             Self::LoadTargetPubkeyFromContext => write!(f, "LoadTargetPubkeyFromContext()"),
             Self::LoadChainHashFromContext => write!(f, "LoadChainHashFromContext()"),
             Self::RecvAcceptChannel => write!(f, "RecvAcceptChannel()"),
@@ -211,7 +396,7 @@ impl Operation {
             Self::LoadBlockHeight(_) => Some(VariableType::BlockHeight),
             Self::LoadU16(_) => Some(VariableType::U16),
             Self::LoadU8(_) => Some(VariableType::U8),
-            Self::LoadBytes(_) => Some(VariableType::Bytes),
+            Self::LoadBytes(_) | Self::LoadShutdownScript(_) => Some(VariableType::Bytes),
             Self::LoadFeatures(_) => Some(VariableType::Features),
             Self::LoadPrivateKey(_) => Some(VariableType::PrivateKey),
             Self::LoadChannelId(_) => Some(VariableType::ChannelId),
@@ -237,6 +422,7 @@ impl Operation {
             | Self::LoadFeatures(_)
             | Self::LoadPrivateKey(_)
             | Self::LoadChannelId(_)
+            | Self::LoadShutdownScript(_)
             | Self::LoadTargetPubkeyFromContext
             | Self::LoadChainHashFromContext
             | Self::RecvAcceptChannel => vec![],
@@ -301,6 +487,7 @@ impl Operation {
                 | Self::LoadFeatures(_)
                 | Self::LoadPrivateKey(_)
                 | Self::LoadChannelId(_)
+                | Self::LoadShutdownScript(_)
                 | Self::ExtractAcceptChannel(_)
         )
     }

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -7,7 +7,7 @@ use smite::bolt::MAX_MESSAGE_SIZE;
 use super::*;
 use generators::OpenChannelGenerator;
 use mutators::{InputSwapMutator, OperationParamMutator};
-use operation::AcceptChannelField;
+use operation::{AcceptChannelField, ShutdownScriptVariant};
 use program::ValidateError;
 
 /// Helper to build a private key with a single distinguishing byte.
@@ -120,7 +120,7 @@ fn display_open_channel_program() {
             inputs: vec![],
         },
         Instruction {
-            operation: Operation::LoadBytes(vec![]),
+            operation: Operation::LoadShutdownScript(ShutdownScriptVariant::Empty),
             inputs: vec![],
         },
         Instruction {
@@ -186,7 +186,7 @@ fn display_open_channel_program() {
         "v21 = LoadU16(144)".into(),
         "v22 = LoadU16(483)".into(),
         "v23 = LoadU8(1)".into(),
-        "v24 = LoadBytes()".into(),
+        "v24 = LoadShutdownScript(Empty)".into(),
         "v25 = LoadFeatures()".into(),
         "v26 = BuildOpenChannel(v13, v12, v14, v15, v16, v17, v18, v19, v20, v21, v22, v1, v3, v5, v7, v9, v11, v23, v24, v25)".into(),
         "SendMessage(v26)".into(),
@@ -267,6 +267,164 @@ fn accept_channel_field_all_is_complete() {
         AcceptChannelField::ALL.len(),
         variant_count(AcceptChannelField::ALL[0]),
     );
+}
+
+// -- ShutdownScriptVariant tests --
+
+// Ensure ShutdownScriptVariant and ShutdownScriptVariant::VARIANT_COUNT stay in
+// sync. The exhaustive match below fails to compile if a variant is added
+// without updating it, and the assertion fails if the match is updated without
+// bumping VARIANT_COUNT.
+#[test]
+fn shutdown_script_variant_count_is_complete() {
+    let variant_count = |v: &ShutdownScriptVariant| -> usize {
+        match v {
+            ShutdownScriptVariant::Empty
+            | ShutdownScriptVariant::P2pkh(_)
+            | ShutdownScriptVariant::P2sh(_)
+            | ShutdownScriptVariant::P2wpkh(_)
+            | ShutdownScriptVariant::P2wsh(_)
+            | ShutdownScriptVariant::AnySegwit { .. }
+            | ShutdownScriptVariant::OpReturn(_) => 7,
+        }
+    };
+    assert_eq!(
+        ShutdownScriptVariant::VARIANT_COUNT,
+        variant_count(&ShutdownScriptVariant::Empty),
+    );
+}
+
+#[test]
+fn shutdown_script_empty_encodes_to_zero_bytes() {
+    assert_eq!(ShutdownScriptVariant::Empty.encode(), Vec::<u8>::new());
+}
+
+#[test]
+fn shutdown_script_p2pkh_encoding() {
+    let h = [0x42u8; 20];
+    let bytes = ShutdownScriptVariant::P2pkh(h).encode();
+    assert_eq!(bytes.len(), 25);
+    assert_eq!(&bytes[..3], &[0x76, 0xa9, 0x14]);
+    assert_eq!(&bytes[3..23], &h);
+    assert_eq!(&bytes[23..], &[0x88, 0xac]);
+}
+
+#[test]
+fn shutdown_script_p2sh_encoding() {
+    let h = [0x33u8; 20];
+    let bytes = ShutdownScriptVariant::P2sh(h).encode();
+    assert_eq!(bytes.len(), 23);
+    assert_eq!(&bytes[..2], &[0xa9, 0x14]);
+    assert_eq!(&bytes[2..22], &h);
+    assert_eq!(bytes[22], 0x87);
+}
+
+#[test]
+fn shutdown_script_p2wpkh_encoding() {
+    let h = [0x55u8; 20];
+    let bytes = ShutdownScriptVariant::P2wpkh(h).encode();
+    assert_eq!(bytes.len(), 22);
+    assert_eq!(&bytes[..2], &[0x00, 0x14]);
+    assert_eq!(&bytes[2..], &h);
+}
+
+#[test]
+fn shutdown_script_p2wsh_encoding() {
+    let h = [0x77u8; 32];
+    let bytes = ShutdownScriptVariant::P2wsh(h).encode();
+    assert_eq!(bytes.len(), 34);
+    assert_eq!(&bytes[..2], &[0x00, 0x20]);
+    assert_eq!(&bytes[2..], &h);
+}
+
+#[test]
+fn shutdown_script_anysegwit_p2tr() {
+    let prog = [0x99u8; 32];
+    let v = ShutdownScriptVariant::AnySegwit {
+        version: 1,
+        program: prog.to_vec(),
+    };
+    let bytes = v.encode();
+    assert_eq!(bytes.len(), 34);
+    assert_eq!(bytes[0], 0x51); // OP_1
+    assert_eq!(bytes[1], 32);
+    assert_eq!(&bytes[2..], &prog);
+}
+
+#[test]
+fn shutdown_script_anysegwit_v16_min_program() {
+    let v = ShutdownScriptVariant::AnySegwit {
+        version: ShutdownScriptVariant::ANYSEGWIT_MAX_VERSION,
+        program: vec![0xab, 0xcd],
+    };
+    let bytes = v.encode();
+    assert_eq!(bytes, vec![0x60, 0x02, 0xab, 0xcd]);
+}
+
+#[test]
+fn shutdown_script_op_return_short_push() {
+    // 6..=75 bytes: raw length opcode.
+    let data = vec![0x11u8; 75];
+    let bytes = ShutdownScriptVariant::OpReturn(data.clone()).encode();
+    assert_eq!(bytes.len(), 1 + 1 + 75);
+    assert_eq!(bytes[0], 0x6a); // OP_RETURN
+    assert_eq!(bytes[1], 75);
+    assert_eq!(&bytes[2..], &data[..]);
+}
+
+#[test]
+fn shutdown_script_op_return_pushdata1() {
+    // 76..=80 bytes: OP_PUSHDATA1 + length byte.
+    let data = vec![0x22u8; ShutdownScriptVariant::OP_RETURN_MAX_DATA_LEN];
+    let bytes = ShutdownScriptVariant::OpReturn(data.clone()).encode();
+    assert_eq!(
+        bytes.len(),
+        1 + 2 + ShutdownScriptVariant::OP_RETURN_MAX_DATA_LEN,
+    );
+    assert_eq!(bytes[0], 0x6a);
+    assert_eq!(bytes[1], 0x4c); // OP_PUSHDATA1
+    assert_eq!(
+        usize::from(bytes[2]),
+        ShutdownScriptVariant::OP_RETURN_MAX_DATA_LEN,
+    );
+    assert_eq!(&bytes[3..], &data[..]);
+}
+
+#[test]
+fn shutdown_script_random_respects_bounds() {
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..200 {
+        let v = ShutdownScriptVariant::random(&mut rng);
+        match &v {
+            ShutdownScriptVariant::AnySegwit { version, program } => {
+                assert!(
+                    (ShutdownScriptVariant::ANYSEGWIT_MIN_VERSION
+                        ..=ShutdownScriptVariant::ANYSEGWIT_MAX_VERSION)
+                        .contains(version),
+                    "version out of range: {version}",
+                );
+                assert!(
+                    (ShutdownScriptVariant::ANYSEGWIT_MIN_PROGRAM_LEN
+                        ..=ShutdownScriptVariant::ANYSEGWIT_MAX_PROGRAM_LEN)
+                        .contains(&program.len()),
+                    "program length out of range: {}",
+                    program.len(),
+                );
+            }
+            ShutdownScriptVariant::OpReturn(data) => {
+                assert!(
+                    (ShutdownScriptVariant::OP_RETURN_MIN_DATA_LEN
+                        ..=ShutdownScriptVariant::OP_RETURN_MAX_DATA_LEN)
+                        .contains(&data.len()),
+                    "OpReturn length out of range: {}",
+                    data.len(),
+                );
+            }
+            _ => {}
+        }
+        // encode() must not panic for any randomly produced variant.
+        let _ = v.encode();
+    }
 }
 
 fn generate_program(seed: u64) -> Program {

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -127,6 +127,7 @@ pub fn execute(
             Operation::LoadFeatures(b) => Some(Variable::Features(b.clone())),
             Operation::LoadPrivateKey(k) => Some(Variable::PrivateKey(*k)),
             Operation::LoadChannelId(id) => Some(Variable::ChannelId(ChannelId::new(*id))),
+            Operation::LoadShutdownScript(variant) => Some(Variable::Bytes(variant.encode())),
             Operation::LoadTargetPubkeyFromContext => Some(Variable::Point(context.target_pubkey)),
             Operation::LoadChainHashFromContext => Some(Variable::ChainHash(context.chain_hash)),
 
@@ -327,7 +328,11 @@ fn build_open_channel(
         first_per_commitment_point: resolve_pubkey(variables, inputs[16])?,
         channel_flags: resolve_u8(variables, inputs[17])?,
         tlvs: OpenChannelTlvs {
-            upfront_shutdown_script: nonempty_or_none(resolve_bytes(variables, inputs[18])?),
+            // Always send the TLV: a zero-length value is the BOLT 2 opt-out
+            // signal when option_upfront_shutdown_script is negotiated.
+            // Omitting it is a protocol violation in that case. Including if
+            // not negotiated is not.
+            upfront_shutdown_script: Some(resolve_bytes(variables, inputs[18])?.to_vec()),
             channel_type: nonempty_or_none(resolve_features(variables, inputs[19])?),
         },
     })
@@ -623,7 +628,7 @@ mod tests {
         assert_eq!(oc.htlc_basepoint, pk);
         assert_eq!(oc.first_per_commitment_point, pk);
         assert_eq!(oc.channel_flags, 1);
-        assert!(oc.tlvs.upfront_shutdown_script.is_none());
+        assert_eq!(oc.tlvs.upfront_shutdown_script, Some(vec![]));
         assert!(oc.tlvs.channel_type.is_none());
     }
 


### PR DESCRIPTION
Helps the fuzzer choose BOLT 2 compliant shutdown scripts so that deeper paths can be reached in the `open_channel->accept_channel` flow.

This change in combination with #57 are required to get past `open_channel` message validation in LDK.

Ref: #5 (Milestone 1)