### PR TITLE
smite-ir: Add `InstructionReorderMutator`

### DIFF
--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -30,7 +30,7 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use smite_ir::generators::OpenChannelGenerator;
-use smite_ir::mutators::{InputSwapMutator, OperationParamMutator};
+use smite_ir::mutators::{InputSwapMutator, InstructionReorderMutator, OperationParamMutator};
 use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
 
 /// Mutator state owned by AFL++ across calls. Allocated by [`afl_custom_init`],
@@ -77,12 +77,20 @@ impl MutatorState {
         let stack = 1u32 << self.rng.random_range(0..=4);
         for _ in 0..stack {
             // Uniform pick between the available mutators.
-            let name = if self.rng.random() {
-                OperationParamMutator.mutate(program, &mut self.rng);
-                "op-param"
-            } else {
-                InputSwapMutator.mutate(program, &mut self.rng);
-                "input-swap"
+            let name = match self.rng.random_range(0..3) {
+                0 => {
+                    OperationParamMutator.mutate(program, &mut self.rng);
+                    "op-param"
+                }
+                1 => {
+                    InputSwapMutator.mutate(program, &mut self.rng);
+                    "input-swap"
+                }
+                2 => {
+                    InstructionReorderMutator.mutate(program, &mut self.rng);
+                    "instr-reorder"
+                }
+                _ => unreachable!(),
             };
             self.last_sequence.push(name);
         }
@@ -369,7 +377,7 @@ mod tests {
             }
             for name in suffix.split(',') {
                 assert!(
-                    name == "op-param" || name == "input-swap",
+                    name == "op-param" || name == "input-swap" || name == "instr-reorder",
                     "unexpected mutator name in description: {name:?} (full: {s:?})",
                 );
             }

--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -44,7 +44,9 @@ use smite_ir::generators::{
     OpenChannelGenerator,
 };
 use smite_ir::minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
-use smite_ir::mutators::{InputSwapMutator, InstructionDeleteMutator, OperationParamMutator};
+use smite_ir::mutators::{
+    InputSwapMutator, InstructionDeleteMutator, InstructionReorderMutator, OperationParamMutator,
+};
 use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
 
 /// Mutator state owned by AFL++ across calls. Allocated by [`afl_custom_init`],
@@ -98,7 +100,7 @@ impl MutatorState {
         let stack = 1u32 << self.rng.random_range(0..=4);
         for _ in 0..stack {
             // Uniform pick between the available mutators.
-            let name = match self.rng.random_range(0..3) {
+            let name = match self.rng.random_range(0..4) {
                 0 => {
                     OperationParamMutator.mutate(program, &mut self.rng);
                     "op-param"
@@ -110,6 +112,10 @@ impl MutatorState {
                 2 => {
                     InstructionDeleteMutator.mutate(program, &mut self.rng);
                     "instr-delete"
+                }
+                3 => {
+                    InstructionReorderMutator.mutate(program, &mut self.rng);
+                    "instr-reorder"
                 }
                 _ => unreachable!("random_range() bound out of sync with match arms"),
             };
@@ -548,7 +554,10 @@ mod tests {
             }
             for name in suffix.split(',') {
                 assert!(
-                    name == "op-param" || name == "input-swap" || name == "instr-delete",
+                    name == "op-param"
+                        || name == "input-swap"
+                        || name == "instr-delete"
+                        || name == "instr-reorder",
                     "unexpected mutator name in description: {name:?} (full: {s:?})",
                 );
             }

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -4,9 +4,11 @@
 //! structural validity. Each mutator makes a small, targeted change.
 
 mod input_swap;
+mod instruction_reorder;
 mod operation_param;
 
 pub use input_swap::InputSwapMutator;
+pub use instruction_reorder::InstructionReorderMutator;
 pub use operation_param::OperationParamMutator;
 
 use rand::Rng;

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -5,10 +5,12 @@
 
 mod input_swap;
 mod instruction_delete;
+mod instruction_reorder;
 mod operation_param;
 
 pub use input_swap::InputSwapMutator;
 pub use instruction_delete::InstructionDeleteMutator;
+pub use instruction_reorder::InstructionReorderMutator;
 pub use operation_param::OperationParamMutator;
 
 use rand::Rng;

--- a/smite-ir/src/mutators/instruction_reorder.rs
+++ b/smite-ir/src/mutators/instruction_reorder.rs
@@ -1,0 +1,81 @@
+//! Mutator that swaps Act instructions.
+
+use rand::{Rng, RngExt, seq::IteratorRandom};
+
+use super::Mutator;
+use crate::Program;
+
+/// Swaps two `Act` instructions that have no data dependencies between them.
+/// This explores alternative execution orderings while preserving SSA invariants.
+pub struct InstructionReorderMutator;
+
+impl Mutator for InstructionReorderMutator {
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool {
+        // Select an Act instruction at random (say Act_1).
+        let Some(act1_idx) = program
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, instr)| {
+                if instr.operation.is_act() {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .choose(rng)
+        else {
+            return false;
+        };
+
+        // Find the first instruction that consumes Act_1. We cannot move
+        // Act_1 past this point without breaking def-before-use.
+        let mut usage_boundary = act1_idx;
+        for instr in &program.instructions[(act1_idx + 1)..] {
+            if instr.inputs.contains(&act1_idx) {
+                break;
+            }
+            usage_boundary += 1;
+        }
+
+        // Uniformly sample a valid Act_2 from the safe range.
+        let mut act2_idx = act1_idx;
+        let mut candidates_count = 0;
+        for i in (act1_idx + 1)..=usage_boundary {
+            // Ensure the candidate is an Act and does not depend on anything
+            // defined at or after Act_1, guaranteeing it can be safely moved up.
+            if !program.instructions[i].operation.is_act()
+                || program.instructions[i]
+                    .inputs
+                    .iter()
+                    .any(|&input| input >= act1_idx)
+            {
+                continue;
+            }
+            candidates_count += 1;
+            if rng.random_range(0..candidates_count) == 0 {
+                act2_idx = i;
+            }
+        }
+
+        // Abort if no valid independent Act instructions exist in the range.
+        if act2_idx == act1_idx {
+            return false;
+        }
+
+        // Swap Act_1 and Act_2.
+        program.instructions.swap(act1_idx, act2_idx);
+
+        // Healing: Update downstream references to Act_1 and Act_2.
+        for instr in &mut program.instructions[(act2_idx + 1)..] {
+            instr.inputs.iter_mut().for_each(|input| {
+                if *input == act1_idx {
+                    *input = act2_idx;
+                } else if *input == act2_idx {
+                    *input = act1_idx;
+                }
+            });
+        }
+        true
+    }
+}

--- a/smite-ir/src/mutators/instruction_reorder.rs
+++ b/smite-ir/src/mutators/instruction_reorder.rs
@@ -1,0 +1,67 @@
+//! Mutator that swaps Act instructions.
+
+use rand::{Rng, seq::IteratorRandom};
+
+use super::Mutator;
+use crate::Program;
+
+/// Swaps two `Act` instructions that have no data dependencies between them.
+/// This explores alternative execution orderings while preserving SSA invariants.
+pub struct InstructionReorderMutator;
+
+impl Mutator for InstructionReorderMutator {
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool {
+        // Select an Act instruction at random (say Act_1).
+        let Some(act1_idx) = program
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, instr)| instr.operation.has_side_effects().then_some(i))
+            .choose(rng)
+        else {
+            return false;
+        };
+
+        // Find the first instruction that consumes Act_1. We cannot move
+        // Act_1 past this point without breaking def-before-use.
+        let mut usage_boundary = act1_idx;
+        for instr in &program.instructions[(act1_idx + 1)..] {
+            if instr.inputs.contains(&act1_idx) {
+                break;
+            }
+            usage_boundary += 1;
+        }
+
+        // Uniformly sample a valid Act_2 from the safe range.
+        let Some(act2_idx) = ((act1_idx + 1)..=usage_boundary)
+            .filter(|&i| {
+                // Ensure the candidate is an Act and does not depend on anything
+                // defined at or after Act_1, guaranteeing it can be safely moved up.
+                program.instructions[i].operation.has_side_effects()
+                    && !program.instructions[i]
+                        .inputs
+                        .iter()
+                        .any(|&input| input >= act1_idx)
+            })
+            .choose(rng)
+        else {
+            // Abort if no valid independent Act instructions exist in the range.
+            return false;
+        };
+
+        // Swap Act_1 and Act_2.
+        program.instructions.swap(act1_idx, act2_idx);
+
+        // Healing: Update downstream references to Act_1 and Act_2.
+        for instr in &mut program.instructions[(act2_idx + 1)..] {
+            for input in &mut instr.inputs {
+                if *input == act1_idx {
+                    *input = act2_idx;
+                } else if *input == act2_idx {
+                    *input = act1_idx;
+                }
+            }
+        }
+        true
+    }
+}

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -304,4 +304,10 @@ impl Operation {
                 | Self::ExtractAcceptChannel(_)
         )
     }
+
+    /// Returns true for Act instructions.
+    #[must_use]
+    pub fn is_act(&self) -> bool {
+        matches!(self, Self::SendMessage | Self::RecvAcceptChannel)
+    }
 }

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -11,7 +11,9 @@ use generators::{
     OpenChannelGenerator,
 };
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
-use mutators::{InputSwapMutator, InstructionDeleteMutator, OperationParamMutator};
+use mutators::{
+    InputSwapMutator, InstructionDeleteMutator, InstructionReorderMutator, OperationParamMutator,
+};
 use operation::{AcceptChannelField, ChannelTypeVariant, ShutdownScriptVariant};
 
 /// Helper to build a private key with a single distinguishing byte.
@@ -1361,6 +1363,16 @@ fn assert_false_is_noop<M: Mutator>(mutator: &M, original: &Program) {
     }
 }
 
+fn assert_mutator_preserves_well_formedness<M: Mutator>(mutator: &M, original: &Program) {
+    let mut rng = SmallRng::seed_from_u64(0);
+    for _ in 0..100 {
+        let mut program = original.clone();
+        if mutator.mutate(&mut program, &mut rng) {
+            assert_well_formed(&program);
+        }
+    }
+}
+
 #[test]
 fn param_mutator_false_is_noop() {
     let original = Program {
@@ -1650,15 +1662,7 @@ fn input_swap_returns_false_when_no_alternatives() {
 #[test]
 fn input_swap_preserves_well_formedness() {
     let original = generate_open_channel_program(0);
-    let mutator = InputSwapMutator;
-    let mut rng = SmallRng::seed_from_u64(0);
-
-    for _ in 0..100 {
-        let mut program = original.clone();
-        if mutator.mutate(&mut program, &mut rng) {
-            assert_well_formed(&program);
-        }
-    }
+    assert_mutator_preserves_well_formedness(&InputSwapMutator, &original);
 }
 
 #[test]
@@ -1920,6 +1924,156 @@ fn instr_delete_maintains_validity() {
             assert_well_formed(&program);
         }
     }
+}
+
+// -- InstructionReorderMutator tests --
+
+#[test]
+fn instr_reorder_false_is_noop() {
+    let original = generate_open_channel_program(0);
+    assert_false_is_noop(&InstructionReorderMutator, &original);
+}
+
+#[test]
+fn instr_reorder_returns_false_on_empty() {
+    let mut program = Program {
+        instructions: vec![],
+    };
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mutator = InstructionReorderMutator;
+    assert!(!mutator.mutate(&mut program, &mut rng));
+}
+
+#[test]
+fn instr_reorder_returns_false_on_single_or_no_act() {
+    // ChannelAnnouncementGenerator produces a single Act instruction: SendMessage.
+    let mut program = generate_channel_announcement_program(0);
+    let mutator = InstructionReorderMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    assert!(!mutator.mutate(&mut program, &mut rng));
+    // Delete the SendMessage instruction at the end. The program is now
+    // non-empty with 0 Act instructions.
+    program.instructions.pop();
+    assert!(!mutator.mutate(&mut program, &mut rng));
+}
+
+#[test]
+fn instr_reorder_returns_false_if_act2_is_past_usage_boundary() {
+    // Invalid program, but mutators shouldn't care about program validity.
+    // Two of the three Act instructions are immediately consumed.
+    let mut program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::BuildOpenChannel,
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::SendOpenChannel,
+                inputs: vec![0],
+            },
+            Instruction {
+                operation: Operation::RecvAcceptChannel,
+                inputs: vec![1],
+            },
+            Instruction {
+                operation: Operation::ExtractAcceptChannel(AcceptChannelField::ChannelType),
+                inputs: vec![2],
+            },
+            Instruction {
+                operation: Operation::SendOpenChannel,
+                inputs: vec![0],
+            },
+        ],
+    };
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mutator = InstructionReorderMutator;
+    for _ in 0..100 {
+        assert!(!mutator.mutate(&mut program, &mut rng));
+    }
+}
+
+#[test]
+fn instr_reorder_swaps_and_heals() {
+    // The only swappable instructions are RecvAcceptChannel and SendMessage.
+    let mut program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::BuildOpenChannel,
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::SendOpenChannel,
+                inputs: vec![0],
+            },
+            Instruction {
+                operation: Operation::RecvAcceptChannel,
+                inputs: vec![1],
+            },
+            Instruction {
+                operation: Operation::LoadChainHashFromContext,
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::SendMessage,
+                inputs: vec![0],
+            },
+            Instruction {
+                operation: Operation::ExtractAcceptChannel(AcceptChannelField::ChannelType),
+                inputs: vec![2],
+            },
+        ],
+    };
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mutator = InstructionReorderMutator;
+    let mut mutated = false;
+    for _ in 0..100 {
+        if mutator.mutate(&mut program, &mut rng) {
+            mutated = true;
+            break;
+        }
+    }
+    assert!(
+        mutated,
+        "InstructionReorderMutator never mutated the program"
+    );
+
+    // RecvAcceptChannel and SendMessage should've been swapped.
+    assert_eq!(program.instructions[2].operation, Operation::SendMessage);
+    assert_eq!(
+        program.instructions[4].operation,
+        Operation::RecvAcceptChannel
+    );
+    // The inteleaved instruction shouldn't have been changed.
+    assert_eq!(
+        program.instructions[3].operation,
+        Operation::LoadChainHashFromContext
+    );
+    // Downstream instructions should be healed.
+    assert_eq!(program.instructions[5].inputs[0], 4);
+}
+
+#[test]
+fn instr_reorder_preserves_well_formedness() {
+    let mut original = generate_open_channel_program(0);
+    // The generic OpenChannelGenerator program doesn't have swappable Act
+    // instructions, so add some.
+    let open_channel_msg = original.instructions.len() - 3;
+    original.instructions.extend([
+        Instruction {
+            operation: Operation::MineBlocks(6),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::SendOpenChannel,
+            inputs: vec![open_channel_msg],
+        },
+        Instruction {
+            operation: Operation::MineBlocks(42),
+            inputs: vec![],
+        },
+    ]);
+    assert_mutator_preserves_well_formedness(&InstructionReorderMutator, &original);
 }
 
 // -- DeadCodeEliminator tests --


### PR DESCRIPTION
Add an `InstructionReorder` mutator for Smite IR. Mutates a given program by swapping two '"Act" instructions that have no data dependencies between them. This explores alternative execution orderings while preserving SSA invariants.