### PR TITLE
Remove cargo afl installation

### DIFF
--- a/workloads/ldk/Dockerfile
+++ b/workloads/ldk/Dockerfile
@@ -51,7 +51,6 @@ WORKDIR /ldk-wrapper
 COPY workloads/ldk/Cargo.toml workloads/ldk/Cargo.lock ./
 COPY workloads/ldk/src/ src/
 ENV AFL_NO_CFG_FUZZING=1
-RUN cargo afl build --release
 
 # Copy smite workspace files and build the Rust ldk-scenario binary
 WORKDIR /smite


### PR DESCRIPTION
If I understand the Dockerfile correctly, smite is not really instrumenting any Rust code. (and neither is it using `cargo afl` subcommands)

so I think we can delete it from the `Dockerfile`

fwiw; it was [removed from fuzzamoto](https://github.com/dergoegge/fuzzamoto/commit/98dc4d223e46f9470360cf4b69ef8b51d0aa0f1e) too 