### PR TITLE
ci: Build every target image with all scenarios

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Docker
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [lnd, ldk, cln, eclair]
+      # don't skip other targets if one fails
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: workloads/${{ matrix.target }}/Dockerfile
+          build-args: SCENARIO=ir
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
       # don't skip other targets if one fails
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -4,7 +4,6 @@ FROM debian:bookworm AS builder
 ARG LLVM_V=19
 ARG CLN_VERSION=v25.12.1
 ARG BITCOIN_VERSION=29.2
-ARG SCENARIO
 
 ENV LLVM_V=${LLVM_V}
 
@@ -81,7 +80,7 @@ RUN CC=afl-clang-lto ./configure --prefix=/usr/local --disable-rust \
 COPY workloads/cln/build-cln-lto.sh /tmp/
 RUN chmod +x /tmp/build-cln-lto.sh && /tmp/build-cln-lto.sh
 
-# Copy smite workspace files and build the Rust cln-scenario binary
+# Copy smite workspace files and build all scenario binaries
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
@@ -89,8 +88,10 @@ COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
 COPY smite-scenarios/ smite-scenarios/
-RUN TARGET_MAP_SIZE=$(cat /tmp/total-map-size) \
-    cargo build -p smite-scenarios --bin cln_${SCENARIO} --release --features nyx
+RUN set -eu; for f in smite-scenarios/src/bin/cln_*.rs; do \
+        TARGET_MAP_SIZE=$(cat /tmp/total-map-size) \
+            cargo build -p smite-scenarios --bin "$(basename $f .rs)" --release --features nyx; \
+    done
 
 # Build crash handler shared libraries, LD_PRELOADed into CLN to bypass its
 # blocking crashdump signal handler. Two variants:

--- a/workloads/eclair/Dockerfile
+++ b/workloads/eclair/Dockerfile
@@ -4,7 +4,6 @@ FROM eclipse-temurin:21 AS builder
 # Build arguments
 ARG ECLAIR_VERSION=v0.13.1
 ARG BITCOIN_VERSION=29.2
-ARG SCENARIO
 
 # Install build dependencies.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -61,7 +60,7 @@ RUN java -cp target/eclair-sancov-0.0.0.jar EclairEdgeCounter \
     > /tmp/eclair-edge-count.txt && \
     echo "Eclair edge count: $(cat /tmp/eclair-edge-count.txt)"
 
-# Copy smite workspace and build the eclair scenario binary.
+# Copy smite workspace files and build all scenario binaries
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
@@ -69,8 +68,10 @@ COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
 COPY smite-scenarios/ smite-scenarios/
-RUN TARGET_MAP_SIZE=$(cat /tmp/eclair-edge-count.txt) \
-    cargo build -p smite-scenarios --bin eclair_${SCENARIO} --release --features nyx
+RUN set -eu; for f in smite-scenarios/src/bin/eclair_*.rs; do \
+        TARGET_MAP_SIZE=$(cat /tmp/eclair-edge-count.txt) \
+            cargo build -p smite-scenarios --bin "$(basename $f .rs)" --release --features nyx; \
+    done
 
 # Build JVM crash handler shared libraries, LD_PRELOADed into the JVM to
 # report crashes before atexit handlers close TCP sockets. Two variants:

--- a/workloads/ldk/Dockerfile
+++ b/workloads/ldk/Dockerfile
@@ -3,7 +3,6 @@ FROM debian:bookworm AS builder
 # Build arguments
 ARG LLVM_V=19
 ARG BITCOIN_VERSION=29.2
-ARG SCENARIO
 
 ENV LLVM_V=${LLVM_V}
 
@@ -61,7 +60,7 @@ ENV AFL_NO_CFG_FUZZING=1
 ENV RUSTFLAGS="-C target-cpu=x86-64-v3"
 RUN cargo afl build --release
 
-# Copy smite workspace files and build the Rust ldk-scenario binary
+# Copy smite workspace files and build all scenario binaries
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
@@ -69,8 +68,10 @@ COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
 COPY smite-scenarios/ smite-scenarios/
-RUN TARGET_PATH=/ldk-wrapper/target/release/ldk-node-wrapper \
-    cargo build -p smite-scenarios --bin ldk_${SCENARIO} --release --features nyx
+RUN set -eu; for f in smite-scenarios/src/bin/ldk_*.rs; do \
+        TARGET_PATH=/ldk-wrapper/target/release/ldk-node-wrapper \
+            cargo build -p smite-scenarios --bin "$(basename $f .rs)" --release --features nyx; \
+    done
 
 # Build crash handler shared libraries, LD_PRELOADed into ldk-node-wrapper to
 # report crashes immediately (before process teardown closes TCP sockets).

--- a/workloads/lnd/Dockerfile
+++ b/workloads/lnd/Dockerfile
@@ -5,7 +5,6 @@ ARG LLVM_V=19
 ARG GO_VERSION=1.24.11
 ARG LND_VERSION=v0.20.0-beta
 ARG BITCOIN_VERSION=29.2
-ARG SCENARIO
 
 ENV LLVM_V=${LLVM_V}
 
@@ -62,7 +61,7 @@ RUN cd cmd/lncli && go build
 COPY ./workloads/lnd/sancov.go /lnd/sancov.go
 RUN cd cmd/lnd && CGO_ENABLED=1 go build -v -tags=libfuzzer -gcflags=all=-d=libfuzzer
 
-# Copy smite workspace files and build the Rust lnd-scenario binary
+# Copy smite workspace files and build all scenario binaries
 WORKDIR /smite
 COPY Cargo.toml Cargo.lock ./
 COPY smite/ smite/
@@ -70,7 +69,10 @@ COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
 COPY smite-scenarios/ smite-scenarios/
-RUN TARGET_PATH=/lnd/cmd/lnd/lnd cargo build -p smite-scenarios --bin lnd_${SCENARIO} --release --features nyx
+RUN set -eu; for f in smite-scenarios/src/bin/lnd_*.rs; do \
+        TARGET_PATH=/lnd/cmd/lnd/lnd \
+            cargo build -p smite-scenarios --bin "$(basename $f .rs)" --release --features nyx; \
+    done
 
 # Runtime image
 FROM debian:bookworm-slim


### PR DESCRIPTION
This should catch if a PR breaks building a target image.

#64 did, but I didn't run `docker build` before approving.