### PR TITLE
multi: drop direct secp256k1 and use re-exported from bitcoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,10 +19,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bitcoin"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+dependencies = [
+ "base58ck",
+ "bech32",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -217,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,15 +375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,40 +400,11 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "rand_core 0.10.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
+ "rand_core",
 ]
 
 [[package]]
@@ -412,20 +428,19 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.31.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.11.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -504,12 +519,12 @@ dependencies = [
 name = "smite"
 version = "0.0.0"
 dependencies = [
+ "bitcoin",
  "chacha20poly1305",
  "hex",
  "hkdf",
  "log",
  "nix",
- "secp256k1",
  "sha2",
  "simple_logger",
  "smite-nyx-sys",
@@ -521,9 +536,9 @@ dependencies = [
 name = "smite-ir"
 version = "0.0.0"
 dependencies = [
+ "bitcoin",
  "postcard",
- "rand 0.10.0",
- "secp256k1",
+ "rand",
  "serde",
  "smite",
  "thiserror",
@@ -534,7 +549,7 @@ name = "smite-ir-mutator"
 version = "0.0.0"
 dependencies = [
  "postcard",
- "rand 0.10.0",
+ "rand",
  "smite-ir",
 ]
 
@@ -549,11 +564,11 @@ dependencies = [
 name = "smite-scenarios"
 version = "0.0.0"
 dependencies = [
+ "bitcoin",
  "hex",
  "libc",
  "log",
  "postcard",
- "secp256k1",
  "serde",
  "serde_json",
  "simple_logger",
@@ -671,26 +686,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ log = "0.4"
 rand = { version = "0.10", default-features = false }
 simple_logger = { version = "5", default-features = false }
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
-secp256k1 = { version = "0.31", features = ["std", "hashes"] }
+bitcoin = "0.32"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"

--- a/smite-ir/Cargo.toml
+++ b/smite-ir/Cargo.toml
@@ -12,5 +12,5 @@ smite = { path = "../smite" }
 rand.workspace = true
 serde.workspace = true
 postcard.workspace = true
-secp256k1.workspace = true
+bitcoin.workspace = true
 thiserror.workspace = true

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -3,7 +3,7 @@
 //! Variables exist only during program execution -- they are never serialized.
 //! The serialized program stores data only in [`Operation`] literals.
 
-use secp256k1::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 use smite::bolt::{AcceptChannel, ChannelId};
 
 const CHAIN_HASH_SIZE: usize = 32;

--- a/smite-scenarios/Cargo.toml
+++ b/smite-scenarios/Cargo.toml
@@ -18,8 +18,8 @@ smite-nyx-sys = { path = "../smite-nyx-sys", optional = true }
 postcard.workspace = true
 log.workspace = true
 simple_logger.workspace = true
-secp256k1.workspace = true
 thiserror.workspace = true
+bitcoin.workspace = true
 
 hex = "0.4"
 libc = "0.2"

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -3,7 +3,7 @@
 //! Executes an IR program against a target node over an established connection,
 //! producing side effects (sending/receiving messages).
 
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use smite::bolt::{
     AcceptChannel, ChannelId, Message, OpenChannel, OpenChannelTlvs, Pong, msg_type,
 };
@@ -136,7 +136,7 @@ pub fn execute(
             // -- Compute operations --
             Operation::DerivePoint => {
                 let key_bytes = resolve_private_key(&variables, instr.inputs[0])?;
-                let sk = SecretKey::from_byte_array(key_bytes)
+                let sk = SecretKey::from_slice(&key_bytes)
                     .map_err(|_| ExecuteError::InvalidPrivateKey)?;
                 let pk = PublicKey::from_secret_key(&secp, &sk);
                 Some(Variable::Point(pk))
@@ -425,7 +425,7 @@ mod tests {
     use std::collections::VecDeque;
 
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
     use smite::bolt::{AcceptChannelTlvs, Init, Ping};
     use smite_ir::Instruction;
 
@@ -468,7 +468,7 @@ mod tests {
         let secp = Secp256k1::new();
         let mut key_bytes = [0u8; 32];
         key_bytes[31] = byte;
-        let sk = SecretKey::from_byte_array(key_bytes).expect("valid secret key");
+        let sk = SecretKey::from_slice(&key_bytes).expect("valid secret key");
         PublicKey::from_secret_key(&secp, &sk)
     }
 
@@ -732,7 +732,7 @@ mod tests {
         let oc = decode_open_channel(&conn.sent[0]);
         let secp = Secp256k1::new();
         let expected =
-            PublicKey::from_secret_key(&secp, &SecretKey::from_byte_array([0x11; 32]).unwrap());
+            PublicKey::from_secret_key(&secp, &SecretKey::from_slice(&[0x11; 32]).unwrap());
         assert_eq!(oc.funding_pubkey, expected);
     }
 

--- a/smite-scenarios/src/scenarios.rs
+++ b/smite-scenarios/src/scenarios.rs
@@ -15,7 +15,7 @@ use smite::scenarios::ScenarioError;
 
 use std::time::Duration;
 
-use secp256k1::SecretKey;
+use bitcoin::secp256k1::SecretKey;
 use smite::bolt::{Init, Message, Ping};
 use smite::noise::NoiseConnection;
 
@@ -45,8 +45,8 @@ pub fn handshake_with_target<T: Target>(
     target: &T,
     timeout: Duration,
 ) -> Result<(NoiseConnection, Init), ScenarioError> {
-    let local_static = SecretKey::from_byte_array(STATIC_KEY).expect("valid static key");
-    let local_ephemeral = SecretKey::from_byte_array(EPHEMERAL_KEY).expect("valid ephemeral key");
+    let local_static = SecretKey::from_slice(&STATIC_KEY).expect("valid static key");
+    let local_ephemeral = SecretKey::from_slice(&EPHEMERAL_KEY).expect("valid ephemeral key");
 
     let mut conn = NoiseConnection::connect(
         target.addr(),

--- a/smite-scenarios/src/scenarios/noise.rs
+++ b/smite-scenarios/src/scenarios/noise.rs
@@ -4,7 +4,7 @@ use std::io::{ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::time::Duration;
 
-use secp256k1::SecretKey;
+use bitcoin::secp256k1::SecretKey;
 use smite::bolt::{Init, Message};
 use smite::noise::{
     ACT_TWO_SIZE, ENCRYPTED_LENGTH_SIZE, MAC_SIZE, NoiseCipher, NoiseConnection, NoiseHandshake,
@@ -53,9 +53,8 @@ pub struct NoiseScenario<T: Target> {
 impl<T: Target> NoiseScenario<T> {
     /// Create a fresh initiator handshake using fixed keys.
     fn new_handshake(&self) -> NoiseHandshake {
-        let local_static = SecretKey::from_byte_array(FUZZ_STATIC_KEY).expect("valid static key");
-        let local_ephemeral =
-            SecretKey::from_byte_array(EPHEMERAL_KEY).expect("valid ephemeral key");
+        let local_static = SecretKey::from_slice(&FUZZ_STATIC_KEY).expect("valid static key");
+        let local_ephemeral = SecretKey::from_slice(&EPHEMERAL_KEY).expect("valid ephemeral key");
         NoiseHandshake::new_initiator(local_static, local_ephemeral, *self.target.pubkey())
     }
 

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -13,6 +13,7 @@ pub use ldk::{LdkConfig, LdkTarget};
 pub use lnd::{LndConfig, LndTarget};
 use smite::scenarios::TargetError;
 
+use bitcoin::secp256k1;
 use std::net::SocketAddr;
 
 /// Path where the crash handler writes crash data in local (non-Nyx) mode.

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use bitcoin::secp256k1;
 use serde::Deserialize;
 use smite::process::ManagedProcess;
 

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use bitcoin::secp256k1;
 use serde::Deserialize;
 use smite::process::ManagedProcess;
 

--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use bitcoin::secp256k1;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;

--- a/smite-scenarios/src/targets/lnd.rs
+++ b/smite-scenarios/src/targets/lnd.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use bitcoin::secp256k1;
 use serde::Deserialize;
 use smite::process::ManagedProcess;
 

--- a/smite/Cargo.toml
+++ b/smite/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 log.workspace = true
 simple_logger.workspace = true
-secp256k1.workspace = true
+bitcoin.workspace = true
 thiserror.workspace = true
 
 # Noise protocol crypto dependencies (BOLT 8)

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -357,8 +357,8 @@ pub fn message_with_type(msg_type: u16, payload: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use secp256k1::hashes::{Hash, sha256};
-    use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use bitcoin::hashes::{Hash, sha256};
+    use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
     use types::CHAIN_HASH_SIZE;
 
     // Tests ordered by message type number: Warning(1), Init(16), Error(17), Ping(18), Pong(19)
@@ -411,7 +411,7 @@ mod tests {
     /// Valid `OpenChannel` message for testing.
     fn sample_open_channel() -> OpenChannel {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         OpenChannel {
@@ -449,7 +449,7 @@ mod tests {
     /// Valid `AcceptChannel` message for testing.
     fn sample_accept_channel() -> AcceptChannel {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         AcceptChannel {
@@ -483,9 +483,9 @@ mod tests {
     /// Valid `FundingCreated` message for testing.
     fn sample_funding_created() -> FundingCreated {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let msg = secp256k1::Message::from_digest([0xaa; 32]);
-        let sig = secp.sign_ecdsa(msg, &sk);
+        let sig = secp.sign_ecdsa(&msg, &sk);
 
         FundingCreated {
             temporary_channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
@@ -507,9 +507,9 @@ mod tests {
     /// Valid `FundingSigned` message for testing.
     fn sample_funding_signed() -> FundingSigned {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let msg = secp256k1::Message::from_digest([0xaa; 32]);
-        let sig = secp.sign_ecdsa(msg, &sk);
+        let sig = secp.sign_ecdsa(&msg, &sk);
 
         FundingSigned {
             channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
@@ -529,7 +529,7 @@ mod tests {
     /// Valid `ChannelReady` message for testing.
     fn sample_channel_ready() -> ChannelReady {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         ChannelReady {
@@ -560,7 +560,7 @@ mod tests {
     /// Valid `OpenChannel2` message for testing.
     fn sample_open_channel2() -> OpenChannel2 {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         OpenChannel2 {
@@ -605,7 +605,7 @@ mod tests {
         let keys: Vec<PublicKey> = secrets
             .iter()
             .map(|s| {
-                let sk = SecretKey::from_byte_array(*s).expect("valid secret");
+                let sk = SecretKey::from_slice(s).expect("valid secret");
                 PublicKey::from_secret_key(&secp, &sk)
             })
             .collect();

--- a/smite/src/bolt/accept_channel.rs
+++ b/smite/src/bolt/accept_channel.rs
@@ -4,7 +4,7 @@ use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::ChannelId;
 use super::wire::WireFormat;
-use secp256k1::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for upfront shutdown script.
 const TLV_UPFRONT_SHUTDOWN_SCRIPT: u64 = 0;
@@ -159,7 +159,7 @@ impl AcceptChannelTlvs {
 mod tests {
     use super::super::PUBLIC_KEY_SIZE;
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
 
     /// Valid `AcceptChannel` message for testing.
     fn sample_accept_channel(tlvs: Option<AcceptChannelTlvs>) -> AcceptChannel {
@@ -170,7 +170,7 @@ mod tests {
         let keys: Vec<PublicKey> = secrets
             .iter()
             .map(|s| {
-                let sk = SecretKey::from_byte_array(*s).expect("valid secret");
+                let sk = SecretKey::from_slice(s).expect("valid secret");
                 PublicKey::from_secret_key(&secp, &sk)
             })
             .collect();

--- a/smite/src/bolt/accept_channel2.rs
+++ b/smite/src/bolt/accept_channel2.rs
@@ -4,7 +4,7 @@ use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::ChannelId;
 use super::wire::WireFormat;
-use secp256k1::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for upfront shutdown script.
 const TLV_UPFRONT_SHUTDOWN_SCRIPT: u64 = 0;
@@ -178,7 +178,7 @@ mod tests {
     use super::super::CHANNEL_ID_SIZE;
     use super::super::PUBLIC_KEY_SIZE;
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
 
     /// Offset of the first public key field (`funding_pubkey`) in the wire encoding:
     /// 32 + 8 + 8 + 8 + 8 + 4 + 2 + 2 = 72 bytes.
@@ -193,7 +193,7 @@ mod tests {
         let keys: Vec<PublicKey> = secrets
             .iter()
             .map(|s| {
-                let sk = SecretKey::from_byte_array(*s).expect("valid secret");
+                let sk = SecretKey::from_slice(s).expect("valid secret");
                 PublicKey::from_secret_key(&secp, &sk)
             })
             .collect();

--- a/smite/src/bolt/channel_ready.rs
+++ b/smite/src/bolt/channel_ready.rs
@@ -4,7 +4,7 @@ use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::ChannelId;
 use super::wire::WireFormat;
-use secp256k1::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for short channel ID alias.
 const TLV_SHORT_CHANNEL_ID: u64 = 1;
@@ -98,12 +98,12 @@ impl ChannelReadyTlvs {
 mod tests {
     use super::super::{CHANNEL_ID_SIZE, PUBLIC_KEY_SIZE};
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
 
     /// Valid `ChannelReady` message for testing.
     fn sample_channel_ready(tlvs: Option<ChannelReadyTlvs>) -> ChannelReady {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         ChannelReady {

--- a/smite/src/bolt/funding_created.rs
+++ b/smite/src/bolt/funding_created.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::types::{ChannelId, Txid};
 use super::wire::WireFormat;
-use secp256k1::ecdsa::Signature;
+use bitcoin::secp256k1::ecdsa::Signature;
 
 /// BOLT 2 `funding_created` message (type 34).
 ///
@@ -61,15 +61,15 @@ impl FundingCreated {
 mod tests {
     use super::super::{CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, TXID_SIZE};
     use super::*;
-    use secp256k1::hashes::Hash;
-    use secp256k1::{Message, Secp256k1, SecretKey};
+    use bitcoin::hashes::Hash;
+    use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
 
     /// Valid `FundingCreated` message for testing.
     fn sample_funding_created() -> FundingCreated {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let msg = Message::from_digest([0xaa; 32]);
-        let sig = secp.sign_ecdsa(msg, &sk);
+        let sig = secp.sign_ecdsa(&msg, &sk);
 
         FundingCreated {
             temporary_channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),

--- a/smite/src/bolt/funding_signed.rs
+++ b/smite/src/bolt/funding_signed.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::types::ChannelId;
 use super::wire::WireFormat;
-use secp256k1::ecdsa::Signature;
+use bitcoin::secp256k1::ecdsa::Signature;
 
 /// BOLT 2 `funding_signed` message (type 35).
 ///
@@ -50,14 +50,14 @@ impl FundingSigned {
 mod tests {
     use super::super::{CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE};
     use super::*;
-    use secp256k1::{Message, Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
 
     /// Valid `FundingSigned` message for testing.
     fn sample_funding_signed() -> FundingSigned {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).expect("valid secret");
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
         let msg = Message::from_digest([0xaa; 32]);
-        let sig = secp.sign_ecdsa(msg, &sk);
+        let sig = secp.sign_ecdsa(&msg, &sk);
 
         FundingSigned {
             channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),

--- a/smite/src/bolt/open_channel.rs
+++ b/smite/src/bolt/open_channel.rs
@@ -4,7 +4,7 @@ use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::{CHAIN_HASH_SIZE, ChannelId};
 use super::wire::WireFormat;
-use secp256k1::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for upfront shutdown script.
 const TLV_UPFRONT_SHUTDOWN_SCRIPT: u64 = 0;
@@ -178,7 +178,7 @@ impl OpenChannelTlvs {
 mod tests {
     use super::super::PUBLIC_KEY_SIZE;
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
 
     /// Valid `OpenChannel` message for testing.
     fn sample_open_channel(tlvs: Option<OpenChannelTlvs>) -> OpenChannel {
@@ -189,7 +189,7 @@ mod tests {
         let keys: Vec<PublicKey> = secrets
             .iter()
             .map(|s| {
-                let sk = SecretKey::from_byte_array(*s).expect("valid secret");
+                let sk = SecretKey::from_slice(s).expect("valid secret");
                 PublicKey::from_secret_key(&secp, &sk)
             })
             .collect();

--- a/smite/src/bolt/open_channel2.rs
+++ b/smite/src/bolt/open_channel2.rs
@@ -4,7 +4,7 @@ use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::{CHAIN_HASH_SIZE, ChannelId};
 use super::wire::WireFormat;
-use secp256k1::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for upfront shutdown script.
 const TLV_UPFRONT_SHUTDOWN_SCRIPT: u64 = 0;
@@ -197,7 +197,7 @@ impl OpenChannel2Tlvs {
 mod tests {
     use super::super::PUBLIC_KEY_SIZE;
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
 
     /// Valid `OpenChannel2` message for testing.
     fn sample_open_channel2(tlvs: Option<OpenChannel2Tlvs>) -> OpenChannel2 {
@@ -208,7 +208,7 @@ mod tests {
         let keys: Vec<PublicKey> = secrets
             .iter()
             .map(|s| {
-                let sk = SecretKey::from_byte_array(*s).expect("valid secret");
+                let sk = SecretKey::from_slice(s).expect("valid secret");
                 PublicKey::from_secret_key(&secp, &sk)
             })
             .collect();

--- a/smite/src/bolt/tx_add_input.rs
+++ b/smite/src/bolt/tx_add_input.rs
@@ -1,6 +1,6 @@
 //! BOLT 2 `tx_add_input` message.
 
-use secp256k1::hashes::Hash;
+use bitcoin::secp256k1::hashes::Hash;
 
 use super::BoltError;
 use super::tlv::TlvStream;

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -1,6 +1,6 @@
 //! Fundamental types for BOLT message encoding.
 
-use secp256k1::hashes::{self, sha256d};
+use bitcoin::hashes::{self, sha256d};
 
 /// Maximum Lightning message size (2-byte length prefix limit).
 pub const MAX_MESSAGE_SIZE: usize = 65535;

--- a/smite/src/bolt/update_fail_malformed_htlc.rs
+++ b/smite/src/bolt/update_fail_malformed_htlc.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::types::ChannelId;
 use super::wire::WireFormat;
-use secp256k1::hashes::sha256;
+use bitcoin::secp256k1::hashes::sha256;
 
 /// BOLT 2 `update_fail_malformed_htlc` message (type 135). Sent
 /// when a node cannot parse an incoming HTLC's onion packet.
@@ -57,7 +57,7 @@ mod tests {
     use super::super::CHANNEL_ID_SIZE;
     use super::*;
     use crate::bolt::SHA256_HASH_SIZE;
-    use secp256k1::hashes::Hash;
+    use bitcoin::secp256k1::hashes::Hash;
 
     /// Valid `UpdateFailMalformedHtlc` message for testing.
     fn sample_msg() -> UpdateFailMalformedHtlc {

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -5,9 +5,9 @@ use crate::bolt::types::{
     BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, PUBLIC_KEY_SIZE, SHA256_HASH_SIZE,
     TXID_SIZE, Txid,
 };
-use secp256k1::PublicKey;
-use secp256k1::ecdsa::Signature;
-use secp256k1::hashes::{Hash, sha256};
+use bitcoin::hashes::{Hash, sha256};
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::ecdsa::Signature;
 
 /// A type that can be read from and written to the Lightning wire format.
 pub trait WireFormat: Sized {
@@ -215,7 +215,7 @@ impl WireFormat for sha256::Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{self, Secp256k1, SecretKey};
 
     #[test]
     fn u8_read_valid() {
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn pubkey_write_roundtrip() {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x22; 32]).unwrap();
+        let sk = SecretKey::from_slice(&[0x22; 32]).unwrap();
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         let mut buf = Vec::new();
@@ -876,9 +876,9 @@ mod tests {
     #[test]
     fn signature_write_roundtrip() {
         let secp = Secp256k1::new();
-        let sk = SecretKey::from_byte_array([0x11; 32]).unwrap();
+        let sk = SecretKey::from_slice(&[0x11; 32]).unwrap();
         let msg = secp256k1::Message::from_digest([0xaa; 32]);
-        let sig = secp.sign_ecdsa(msg, &sk);
+        let sig = secp.sign_ecdsa(&msg, &sk);
 
         let mut buf = Vec::new();
         sig.write(&mut buf);

--- a/smite/src/noise/connection.rs
+++ b/smite/src/noise/connection.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
-use secp256k1::{PublicKey, SecretKey};
+use bitcoin::secp256k1::{PublicKey, SecretKey};
 
 use super::cipher::{ENCRYPTED_LENGTH_SIZE, MAC_SIZE, MAX_MESSAGE_SIZE, NoiseCipher};
 use super::error::NoiseError;

--- a/smite/src/noise/handshake.rs
+++ b/smite/src/noise/handshake.rs
@@ -4,7 +4,7 @@
 // guarantee the value is set.
 #![allow(clippy::missing_panics_doc)]
 
-use secp256k1::{PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret};
+use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret};
 use sha2::{Digest, Sha256};
 
 use super::cipher::{NoiseCipher, decrypt_with_ad, encrypt_with_ad, hkdf_two_keys};

--- a/smite/src/noise/tests.rs
+++ b/smite/src/noise/tests.rs
@@ -1,6 +1,6 @@
 //! BOLT 8 test vectors for Noise protocol implementation.
 
-use secp256k1::{PublicKey, SecretKey};
+use bitcoin::secp256k1::{self, PublicKey, SecretKey};
 
 use super::cipher::{ENCRYPTED_LENGTH_SIZE, NoiseCipher};
 use super::handshake::{ACT_ONE_SIZE, ACT_THREE_SIZE, ACT_TWO_SIZE, NoiseHandshake};
@@ -23,7 +23,7 @@ fn hex_to_vec(s: &str) -> Vec<u8> {
 
 /// Helper to create a `SecretKey` from hex.
 fn secret_key(hex: &str) -> SecretKey {
-    SecretKey::from_byte_array(hex_to_array(hex)).expect("valid secret key")
+    SecretKey::from_slice(&hex_to_vec(hex)).expect("valid secret key")
 }
 
 /// Helper to create a `PublicKey` from hex.


### PR DESCRIPTION
Add bitcoin as a dependency for constructing signed commitment transactions. This significantly reduces boilerplate compared to doing it manually.

Since bitcoin re-exports secp256k1, drop the direct dependency to avoid duplicate versions and use the re-exported one throughout.