### PR TITLE
smite: replace hkdf/sha2 with bitcoin hash-based derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,15 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,17 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,24 +249,6 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "inout"
@@ -489,17 +451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,10 +473,8 @@ dependencies = [
  "bitcoin",
  "chacha20poly1305",
  "hex",
- "hkdf",
  "log",
  "nix",
- "sha2",
  "simple_logger",
  "smite-nyx-sys",
  "tempfile",

--- a/smite/Cargo.toml
+++ b/smite/Cargo.toml
@@ -20,8 +20,6 @@ thiserror.workspace = true
 chacha20poly1305 = { version = "0.10", default-features = false, features = [
   "alloc",
 ] }
-hkdf = "0.12"
-sha2 = "0.10"
 
 smite-nyx-sys = { path = "../smite-nyx-sys", optional = true }
 

--- a/smite/src/noise/cipher.rs
+++ b/smite/src/noise/cipher.rs
@@ -1,9 +1,10 @@
+use bitcoin::hashes::hmac::{Hmac, HmacEngine};
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::{Hash, HashEngine};
 use chacha20poly1305::{
     ChaCha20Poly1305, Nonce,
     aead::{Aead, KeyInit, Payload},
 };
-use hkdf::Hkdf;
-use sha2::Sha256;
 
 use super::error::NoiseError;
 
@@ -215,13 +216,18 @@ pub fn decrypt_with_ad(
 
 /// HKDF extract-and-expand to derive two 32-byte keys.
 pub fn hkdf_two_keys(salt: &[u8; 32], ikm: &[u8]) -> ([u8; 32], [u8; 32]) {
-    let hk = Hkdf::<Sha256>::new(Some(salt), ikm);
-    let mut output = [0u8; 64];
-    hk.expand(&[], &mut output).expect("valid HKDF length");
-    let mut key1 = [0u8; 32];
-    let mut key2 = [0u8; 32];
-    key1.copy_from_slice(&output[..32]);
-    key2.copy_from_slice(&output[32..]);
+    // Implement RFC 5869 with zero-length info and L=2.
+    let mut hmac = HmacEngine::<Sha256>::new(salt);
+    hmac.input(ikm);
+    let prk = Hmac::from_engine(hmac).to_byte_array();
+    let mut hmac = HmacEngine::<Sha256>::new(&prk);
+    hmac.input(&[1]);
+    let key1 = Hmac::from_engine(hmac).to_byte_array();
+    let mut hmac = HmacEngine::<Sha256>::new(&prk);
+    hmac.input(&key1);
+    hmac.input(&[2]);
+    let key2 = Hmac::from_engine(hmac).to_byte_array();
+
     (key1, key2)
 }
 

--- a/smite/src/noise/handshake.rs
+++ b/smite/src/noise/handshake.rs
@@ -4,8 +4,9 @@
 // guarantee the value is set.
 #![allow(clippy::missing_panics_doc)]
 
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey, ecdh::SharedSecret};
-use sha2::{Digest, Sha256};
 
 use super::cipher::{NoiseCipher, decrypt_with_ad, encrypt_with_ad, hkdf_two_keys};
 use super::error::NoiseError;
@@ -136,22 +137,22 @@ impl NoiseHandshake {
     fn initialize_state(responder_static: &PublicKey) -> ([u8; 32], [u8; 32]) {
         // h = SHA256(protocolName)
         // ck = h
-        let ck: [u8; 32] = Sha256::digest(PROTOCOL_NAME).into();
+        let ck = Sha256::hash(PROTOCOL_NAME).to_byte_array();
 
         // h = SHA256(h || prologue)
-        let h: [u8; 32] = {
-            let mut hasher = Sha256::new();
-            hasher.update(ck);
-            hasher.update(PROLOGUE);
-            hasher.finalize().into()
+        let h = {
+            let mut sha = Sha256::engine();
+            sha.input(&ck);
+            sha.input(PROLOGUE);
+            Sha256::from_engine(sha).to_byte_array()
         };
 
         // h = SHA256(h || rs.pub.serializeCompressed())
-        let h: [u8; 32] = {
-            let mut hasher = Sha256::new();
-            hasher.update(h);
-            hasher.update(responder_static.serialize());
-            hasher.finalize().into()
+        let h = {
+            let mut sha = Sha256::engine();
+            sha.input(&h);
+            sha.input(&responder_static.serialize());
+            Sha256::from_engine(sha).to_byte_array()
         };
 
         (ck, h)
@@ -465,10 +466,10 @@ impl NoiseHandshake {
 
     /// Mix data into the handshake hash.
     fn mix_hash(&mut self, data: &[u8]) {
-        let mut hasher = Sha256::new();
-        hasher.update(self.h);
-        hasher.update(data);
-        self.h = hasher.finalize().into();
+        let mut sha = Sha256::engine();
+        sha.input(&self.h);
+        sha.input(data);
+        self.h = Sha256::from_engine(sha).to_byte_array();
     }
 }
 


### PR DESCRIPTION
ref: https://github.com/morehouse/smite/pull/68#issuecomment-4400056232

Removed the `hkdf` and `sha2` dependencies and implemented the same behavior using hash-based derivation from the `bitcoin` crate. Going forward, we will standardize on the `bitcoin` library wherever possible

I also verified the derivation by comparing it against LDK: https://github.com/lightningdevkit/rust-lightning/blob/a1d4e2f26eea696a0a1ebc2fe56abd884905bd5f/lightning/src/crypto/utils.rs#L8-L24
