### PR TITLE
multi: add BitcoinCli support and MineBlock IR operation

### DIFF
--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -65,6 +65,16 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
             mutate_channel_type(variant, rng);
             true
         }
+        Operation::MineBlocks(v) => {
+            // Limit the number of mined blocks to keep execution times low.
+            // Reference execution timings:
+            // MineBlocks(10): 16ms
+            // MineBlocks(100): 157ms
+            // MineBlocks(200): 359ms
+            // MineBlocks(255): 468ms
+            *v = rng.random_range(1..=16);
+            true
+        }
         Operation::ExtractAcceptChannel(field) => mutate_extract_field(field, rng),
 
         // Non-mutable variants. Reaching here means `is_param_mutable` and this

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -97,6 +97,8 @@ pub enum Operation {
     /// Receive and parse an `accept_channel` response.
     /// Produces an `AcceptChannel` compound variable.
     RecvAcceptChannel,
+    /// Mines the given number of blocks on the Bitcoin network.
+    MineBlocks(u8),
 }
 
 /// A BOLT 2 compliant `upfront_shutdown_script` template.
@@ -539,6 +541,7 @@ impl fmt::Display for Operation {
             Self::LoadTargetPubkeyFromContext => write!(f, "LoadTargetPubkeyFromContext()"),
             Self::LoadChainHashFromContext => write!(f, "LoadChainHashFromContext()"),
             Self::RecvAcceptChannel => write!(f, "RecvAcceptChannel()"),
+            Self::MineBlocks(v) => write!(f, "MineBlocks({v})"),
             // Operations with inputs: parens added by Program::Display.
             Self::DerivePoint => write!(f, "DerivePoint"),
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
@@ -567,7 +570,7 @@ impl Operation {
             Self::LoadChainHashFromContext => Some(VariableType::ChainHash),
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::BuildOpenChannel => Some(VariableType::Message),
-            Self::SendMessage => None,
+            Self::SendMessage | Self::MineBlocks(_) => None,
             Self::RecvAcceptChannel => Some(VariableType::AcceptChannel),
         }
     }
@@ -589,6 +592,7 @@ impl Operation {
             | Self::LoadChannelType(_)
             | Self::LoadTargetPubkeyFromContext
             | Self::LoadChainHashFromContext
+            | Self::MineBlocks(_)
             | Self::RecvAcceptChannel => vec![],
 
             Self::DerivePoint => vec![VariableType::PrivateKey],
@@ -653,6 +657,7 @@ impl Operation {
                 | Self::LoadChannelId(_)
                 | Self::LoadShutdownScript(_)
                 | Self::LoadChannelType(_)
+                | Self::MineBlocks(_)
                 | Self::ExtractAcceptChannel(_)
         )
     }

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for IR types.
 
+use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 use smite::bolt::MAX_MESSAGE_SIZE;
@@ -229,12 +230,72 @@ fn postcard_roundtrip() {
                 operation: Operation::LoadFeatures(vec![0x01, 0x02]),
                 inputs: vec![],
             },
+            Instruction {
+                operation: Operation::MineBlocks(6),
+                inputs: vec![],
+            },
         ],
     };
 
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);
+}
+
+#[test]
+fn mine_blocks_operation() {
+    let op = Operation::MineBlocks(8);
+    assert_eq!(op.input_types(), vec![]);
+    assert_eq!(op.output_type(), None);
+    assert!(op.is_param_mutable());
+}
+
+#[test]
+fn displays_mine_blocks_program() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::MineBlocks(6),
+            inputs: vec![],
+        }],
+    };
+    let text = program.to_string();
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines, vec!["MineBlocks(6)"]);
+}
+
+#[test]
+fn validate_accepts_mine_blocks() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::MineBlocks(8),
+            inputs: vec![],
+        }],
+    };
+    program.validate().expect("MineBlocks should validate");
+}
+
+#[test]
+fn validate_rejects_mine_blocks_with_wrong_input() {
+    let program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::LoadAmount(100_000_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::MineBlocks(6),
+                inputs: vec![0],
+            },
+        ],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::WrongInputCount {
+            instr: 1,
+            expected: 0,
+            got: 1
+        }),
+    );
 }
 
 // Ensure AcceptChannelField and AcceptChannelField::ALL stay in sync. The
@@ -572,6 +633,20 @@ fn generate_fresh_produces_distinct_indices() {
 }
 
 #[test]
+fn generate_mine_blocks_program() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    let mb = builder.append(Operation::MineBlocks(rng.random_range(1..=16)), &[]);
+    let program = builder.build();
+    program.validate().expect("MineBlocks should validate");
+
+    assert!(matches!(
+        program.instructions[mb].operation,
+        Operation::MineBlocks(_),
+    ),);
+}
+
+#[test]
 fn pick_variable_reuses_existing() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
@@ -875,6 +950,37 @@ fn param_mutator_changes_values() {
     assert_ne!(
         program, original,
         "OperationParamMutator never changed the program"
+    );
+}
+
+#[test]
+fn param_mutator_changes_mined_num_blocks() {
+    let original = Program {
+        instructions: vec![Instruction {
+            operation: Operation::MineBlocks(42),
+            inputs: vec![],
+        }],
+    };
+    let mut program = original.clone();
+    let mutator = OperationParamMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    let mut diff_count = 0;
+    for _ in 0..100 {
+        mutator.mutate(&mut program, &mut rng);
+        // Make sure that MineBlocks contains a value within the clamped range of
+        // blocks to be mined.
+        let Operation::MineBlocks(num_blocks) = program.instructions[0].operation else {
+            panic!("OperationParamMutator changed the operation type");
+        };
+        assert!((1..=16).contains(&num_blocks));
+        if program != original {
+            diff_count += 1;
+        }
+    }
+    assert!(
+        diff_count > 90,
+        "OperationParamMutator has an unexpected bias"
     );
 }
 

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -13,9 +13,16 @@ use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable, VariableType};
 
 /// Abstraction over bitcoin-cli operations, allowing mock implementations in tests.
-pub trait BitcoinRpc {}
+pub trait BitcoinRpc {
+    /// Mines the given number of blocks.
+    fn mine_blocks(&mut self, num_blocks: u8);
+}
 
-impl BitcoinRpc for BitcoinCli {}
+impl BitcoinRpc for BitcoinCli {
+    fn mine_blocks(&mut self, num_blocks: u8) {
+        BitcoinCli::mine_blocks(self, num_blocks);
+    }
+}
 
 /// State captured during snapshot setup, available to IR programs at execution
 /// time via `LoadContext*` operations.
@@ -108,7 +115,7 @@ pub fn execute(
     program: &Program,
     context: &ProgramContext,
     conn: &mut impl Connection,
-    _bitcoin_cli: &mut impl BitcoinRpc,
+    bitcoin_cli: &mut impl BitcoinRpc,
     start: std::time::Instant,
 ) -> Result<(), ExecuteError> {
     let secp = Secp256k1::new();
@@ -179,6 +186,12 @@ pub fn execute(
                 let ac = recv_accept_channel(conn)?;
                 log::debug!("[{:?}] RecvAcceptChannel: received", start.elapsed());
                 Some(Variable::AcceptChannel(ac))
+            }
+
+            Operation::MineBlocks(v) => {
+                bitcoin_cli.mine_blocks(*v);
+                log::debug!("[{:?}] MineBlocks: mined {} block(s)", start.elapsed(), v);
+                None
             }
         };
 
@@ -471,10 +484,16 @@ mod tests {
 
     // Mocking BitcoinCli via MockBitcoinCli
 
-    #[derive(Debug, Default)]
-    struct MockBitcoinCli {}
+    #[derive(Default)]
+    struct MockBitcoinCli {
+        mine_blocks_calls: Vec<u8>,
+    }
 
-    impl BitcoinRpc for MockBitcoinCli {}
+    impl BitcoinRpc for MockBitcoinCli {
+        fn mine_blocks(&mut self, num_blocks: u8) {
+            self.mine_blocks_calls.push(num_blocks);
+        }
+    }
 
     // -- Helpers --
 
@@ -1022,6 +1041,65 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, ExecuteError::VoidVariable { index: 21 }));
+    }
+
+    // MineBlocks should track calls to mine_blocks
+    #[test]
+    fn execute_mine_blocks_invokes_cli() {
+        let instrs = vec![Instruction {
+            operation: Operation::MineBlocks(6),
+            inputs: vec![],
+        }];
+        let program = Program {
+            instructions: instrs,
+        };
+        let mut conn = MockConnection::new();
+        let mut mock_cli = MockBitcoinCli::default();
+        let context = sample_context();
+        execute(
+            &program,
+            &context,
+            &mut conn,
+            &mut mock_cli,
+            std::time::Instant::now(),
+        )
+        .unwrap();
+
+        // Verify that mine_blocks was called with the correct number
+        assert_eq!(mock_cli.mine_blocks_calls, vec![6]);
+    }
+
+    #[test]
+    fn execute_mine_blocks_wrong_input() {
+        let instrs = vec![
+            Instruction {
+                operation: Operation::LoadAmount(1),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::MineBlocks(6),
+                inputs: vec![0],
+            },
+        ];
+        let program = Program {
+            instructions: instrs,
+        };
+        let mut conn = MockConnection::new();
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            &mut MockBitcoinCli::default(),
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ExecuteError::WrongInputCount {
+                expected: 0,
+                got: 1,
+            }
+        ));
     }
 
     #[test]

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -4,12 +4,18 @@
 //! producing side effects (sending/receiving messages).
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use smite::bitcoin::BitcoinCli;
 use smite::bolt::{
     AcceptChannel, ChannelId, Message, OpenChannel, OpenChannelTlvs, Pong, msg_type,
 };
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable, VariableType};
+
+/// Abstraction over bitcoin-cli operations, allowing mock implementations in tests.
+pub trait BitcoinRpc {}
+
+impl BitcoinRpc for BitcoinCli {}
 
 /// State captured during snapshot setup, available to IR programs at execution
 /// time via `LoadContext*` operations.
@@ -102,6 +108,7 @@ pub fn execute(
     program: &Program,
     context: &ProgramContext,
     conn: &mut impl Connection,
+    _bitcoin_cli: &mut impl BitcoinRpc,
     start: std::time::Instant,
 ) -> Result<(), ExecuteError> {
     let secp = Secp256k1::new();
@@ -462,6 +469,13 @@ mod tests {
         }
     }
 
+    // Mocking BitcoinCli via MockBitcoinCli
+
+    #[derive(Debug, Default)]
+    struct MockBitcoinCli {}
+
+    impl BitcoinRpc for MockBitcoinCli {}
+
     // -- Helpers --
 
     fn sample_pubkey(byte: u8) -> PublicKey {
@@ -620,6 +634,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap();
@@ -676,6 +691,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap();
@@ -725,6 +741,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap();
@@ -785,6 +802,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap();
@@ -808,6 +826,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();
@@ -845,6 +864,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap();
@@ -874,6 +894,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();
@@ -906,6 +927,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();
@@ -932,6 +954,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();
@@ -959,6 +982,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();
@@ -993,6 +1017,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();
@@ -1019,6 +1044,7 @@ mod tests {
             &program,
             &sample_context(),
             &mut conn,
+            &mut MockBitcoinCli::default(),
             std::time::Instant::now(),
         )
         .unwrap_err();

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -48,7 +48,13 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
             input.len(),
         );
 
-        match executor::execute(&program, &self.context, &mut self.conn, start) {
+        match executor::execute(
+            &program,
+            &self.context,
+            &mut self.conn,
+            &mut self.target.bitcoin_cli().clone(),
+            start,
+        ) {
             Ok(()) => {
                 log::debug!("[{:?}] Program executed successfully", start.elapsed());
             }

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -11,6 +11,7 @@ pub use cln::{ClnConfig, ClnTarget};
 pub use eclair::{EclairConfig, EclairTarget};
 pub use ldk::{LdkConfig, LdkTarget};
 pub use lnd::{LndConfig, LndTarget};
+use smite::bitcoin::BitcoinCli;
 use smite::scenarios::TargetError;
 
 use bitcoin::secp256k1;
@@ -61,6 +62,9 @@ pub trait Target: Sized {
 
     /// Target's P2P listen address.
     fn addr(&self) -> SocketAddr;
+
+    /// `bitcoin-cli` wrapper for the regtest `bitcoind` instance.
+    fn bitcoin_cli(&self) -> &BitcoinCli;
 
     /// Check if target is still alive. Returns `Err(Crashed)` if dead.
     ///

--- a/smite-scenarios/src/targets/bitcoind.rs
+++ b/smite-scenarios/src/targets/bitcoind.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::TargetError;
@@ -59,7 +60,10 @@ pub fn resolve_data_dir() -> Result<(PathBuf, Option<tempfile::TempDir>), Target
 }
 
 /// Starts bitcoind and waits for it to be ready.
-pub fn start(config: &BitcoindConfig, data_dir: &Path) -> Result<ManagedProcess, TargetError> {
+pub fn start(
+    config: &BitcoindConfig,
+    data_dir: &Path,
+) -> Result<(ManagedProcess, BitcoinCli), TargetError> {
     log::info!("Starting bitcoind...");
 
     let bitcoind_dir = data_dir.join("bitcoind");
@@ -97,16 +101,16 @@ pub fn start(config: &BitcoindConfig, data_dir: &Path) -> Result<ManagedProcess,
     }
 
     let bitcoind = ManagedProcess::spawn(&mut cmd, "bitcoind")?;
+    let cli = BitcoinCli {
+        rpc_port: config.rpc_port,
+        bitcoind_dir,
+    };
 
     // Wait for bitcoind to be ready
     log::info!("Waiting for bitcoind to be ready...");
     for _ in 0..30 {
-        let status = Command::new("bitcoin-cli")
-            .arg("-regtest")
-            .arg(format!("-datadir={}", bitcoind_dir.display()))
-            .arg(format!("-rpcport={}", config.rpc_port))
-            .arg("-rpcuser=rpcuser")
-            .arg("-rpcpassword=rpcpass")
+        let status = cli
+            .run()
             .arg("getblockchaininfo")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -114,7 +118,8 @@ pub fn start(config: &BitcoindConfig, data_dir: &Path) -> Result<ManagedProcess,
 
         if status.is_ok_and(|s| s.success()) {
             log::info!("bitcoind is ready");
-            return setup_wallet(config, &bitcoind_dir, bitcoind);
+            setup_wallet(&cli)?;
+            return Ok((bitcoind, cli));
         }
 
         std::thread::sleep(Duration::from_secs(1));
@@ -126,18 +131,10 @@ pub fn start(config: &BitcoindConfig, data_dir: &Path) -> Result<ManagedProcess,
 }
 
 /// Creates wallet and generates initial blocks.
-fn setup_wallet(
-    config: &BitcoindConfig,
-    bitcoind_dir: &Path,
-    bitcoind: ManagedProcess,
-) -> Result<ManagedProcess, TargetError> {
+fn setup_wallet(cli: &BitcoinCli) -> Result<(), TargetError> {
     // Create wallet
-    let _ = Command::new("bitcoin-cli")
-        .arg("-regtest")
-        .arg(format!("-datadir={}", bitcoind_dir.display()))
-        .arg(format!("-rpcport={}", config.rpc_port))
-        .arg("-rpcuser=rpcuser")
-        .arg("-rpcpassword=rpcpass")
+    let _ = cli
+        .run()
         .arg("createwallet")
         .arg("default")
         .stdout(Stdio::null())
@@ -145,12 +142,8 @@ fn setup_wallet(
         .status();
 
     // Generate initial blocks
-    let status = Command::new("bitcoin-cli")
-        .arg("-regtest")
-        .arg(format!("-datadir={}", bitcoind_dir.display()))
-        .arg(format!("-rpcport={}", config.rpc_port))
-        .arg("-rpcuser=rpcuser")
-        .arg("-rpcpassword=rpcpass")
+    let status = cli
+        .run()
         .arg("-generate")
         .arg(INITIAL_BLOCKS.to_string())
         .stdout(Stdio::null())
@@ -163,5 +156,5 @@ fn setup_wallet(
         ));
     }
 
-    Ok(bitcoind)
+    Ok(())
 }

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
+use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -62,6 +63,7 @@ pub struct ClnTarget {
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
     cln_dir: PathBuf,
+    bitcoin_cli: BitcoinCli,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -205,7 +207,7 @@ impl Target for ClnTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let bitcoind = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (cln, pubkey, cln_dir) = Self::start_cln(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.cln_p2p_port));
 
@@ -217,6 +219,7 @@ impl Target for ClnTarget {
             pubkey,
             addr,
             cln_dir,
+            bitcoin_cli,
             temp_dir,
         })
     }
@@ -227,6 +230,10 @@ impl Target for ClnTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn bitcoin_cli(&self) -> &BitcoinCli {
+        &self.bitcoin_cli
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
+use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -73,6 +74,7 @@ pub struct EclairTarget {
     bitcoind: ManagedProcess,
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
+    bitcoin_cli: BitcoinCli,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -196,7 +198,7 @@ impl Target for EclairTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let bitcoind = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (eclair, pubkey) = Self::start_eclair(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.eclair_p2p_port));
 
@@ -207,6 +209,7 @@ impl Target for EclairTarget {
             bitcoind,
             pubkey,
             addr,
+            bitcoin_cli,
             temp_dir,
         })
     }
@@ -217,6 +220,10 @@ impl Target for EclairTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn bitcoin_cli(&self) -> &BitcoinCli {
+        &self.bitcoin_cli
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use bitcoin::secp256k1;
+use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -55,6 +56,7 @@ pub struct LdkTarget {
     bitcoind: ManagedProcess,
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
+    bitcoin_cli: BitcoinCli,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -127,7 +129,7 @@ impl Target for LdkTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let bitcoind = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (ldk, pubkey) = Self::start_ldk(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.ldk_p2p_port));
 
@@ -138,6 +140,7 @@ impl Target for LdkTarget {
             bitcoind,
             pubkey,
             addr,
+            bitcoin_cli,
             temp_dir,
         })
     }
@@ -148,6 +151,10 @@ impl Target for LdkTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn bitcoin_cli(&self) -> &BitcoinCli {
+        &self.bitcoin_cli
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite-scenarios/src/targets/lnd.rs
+++ b/smite-scenarios/src/targets/lnd.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
+use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -91,6 +92,7 @@ pub struct LndTarget {
     coverage_pipes: Option<CoveragePipes>,
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
+    bitcoin_cli: BitcoinCli,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -273,7 +275,7 @@ impl Target for LndTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let bitcoind = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (lnd, coverage_pipes, pubkey) = Self::start_lnd(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.lnd_p2p_port));
 
@@ -285,6 +287,7 @@ impl Target for LndTarget {
             coverage_pipes,
             pubkey,
             addr,
+            bitcoin_cli,
             temp_dir,
         })
     }
@@ -295,6 +298,10 @@ impl Target for LndTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn bitcoin_cli(&self) -> &BitcoinCli {
+        &self.bitcoin_cli
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -27,4 +27,25 @@ impl BitcoinCli {
             .arg("-rpcpassword=rpcpass");
         cmd
     }
+
+    /// Mines the given number of blocks.
+    ///
+    /// # Panics
+    ///
+    /// If the `bitcoin-cli -generate` command fails to execute or returns
+    /// a non-success exit status.
+    pub fn mine_blocks(&self, num_blocks: u8) {
+        let mine_out = self
+            .run()
+            .arg("-generate")
+            .arg(num_blocks.to_string())
+            .output()
+            .expect("bitcoin-cli -generate should not fail");
+        assert!(
+            mine_out.status.success(),
+            "bitcoin-cli -generate {} failed: {}",
+            num_blocks,
+            String::from_utf8_lossy(&mine_out.stderr)
+        );
+    }
 }

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -1,0 +1,30 @@
+//! This module implements utilities for interacting with regtest
+//! `bitcoind` instances via `bitcoin-cli`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Connection info for invoking `bitcoin-cli` against the regtest `bitcoind`
+/// started by a target.
+#[derive(Debug, Clone)]
+pub struct BitcoinCli {
+    /// RPC port exposed by the regtest `bitcoind` instance.
+    pub rpc_port: u16,
+    /// Path passed to `bitcoin-cli -datadir`.
+    pub bitcoind_dir: PathBuf,
+}
+
+impl BitcoinCli {
+    /// Creates a `bitcoin-cli` command preconfigured with the connection
+    /// arguments for this regtest node.
+    #[must_use]
+    pub fn run(&self) -> Command {
+        let mut cmd = Command::new("bitcoin-cli");
+        cmd.arg("-regtest")
+            .arg(format!("-datadir={}", self.bitcoind_dir.display()))
+            .arg(format!("-rpcport={}", self.rpc_port))
+            .arg("-rpcuser=rpcuser")
+            .arg("-rpcpassword=rpcpass");
+        cmd
+    }
+}

--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -6,6 +6,7 @@
 //! provides the building blocks that scenarios and targets are built on.
 //!
 //! # Modules
+//! - [`bitcoin`] - Utilities for interacting with `bitcoind` instances via `bitcoin-cli`.
 //! - [`bolt`] - BOLT message encoding and decoding.
 //! - [`noise`] - BOLT 8 `Noise_XK` encrypted transport.
 //! - [`oracles`] - Post-scenario invariant checks.
@@ -13,6 +14,7 @@
 //! - [`runners`] - Fuzz input delivery (Nyx and local modes).
 //! - [`scenarios`] - Scenario trait and the [`scenarios::smite_run`] entry point.
 
+pub mod bitcoin;
 pub mod bolt;
 pub mod noise;
 pub mod oracles;


### PR DESCRIPTION
Added a `BitcoinCli` struct that contains the connection information required to invoke bitcoin-cli against the regtest bitcoind started by a target, and added it to the program context. This will be useful for future IR funding flow support, where the IR executor may need a bitcoin-cli reference to mine blocks, broadcast tx etc. The executor can access this `BitcoinCli` reference through `ProgramContext`.

Added a `BitcoinCli` variable type and `LoadBitcoinCliFromContext` so IR programs can access the bitcoin-cli connection handle from the program context and make Bitcoin RPC calls.

Added a `MineBlock` IR operation that takes a `BitcoinCli` input and invokes `bitcoin-cli -generate 1` to mine a block on regtest. This will be required once we add the funding flow scenario, where the funding tx is broadcast and then mined into a block to confirm it on-chain, since peers can exchange the `channel_ready` message only after the funding tx is confirmed.

I also verified the working of `MineBlock` using the diff below:
<details>
<summary>smite diff</summary>

```diff
diff --git a/smite-ir/src/generators/open_channel.rs b/smite-ir/src/generators/open_channel.rs
index f58f1bf..bf94823 100644
--- a/smite-ir/src/generators/open_channel.rs
+++ b/smite-ir/src/generators/open_channel.rs
@@ -25,6 +25,7 @@ impl Generator for OpenChannelGenerator {
         let delayed_payment_basepoint = builder.generate_fresh(VariableType::Point, rng);
         let htlc_basepoint = builder.generate_fresh(VariableType::Point, rng);
         let first_per_commitment_point = builder.generate_fresh(VariableType::Point, rng);
+        let bitcoin_cli = builder.generate_fresh(VariableType::BitcoinCli, rng);
 
         // Channel parameters.
         let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
@@ -77,5 +78,7 @@ impl Generator for OpenChannelGenerator {
 
         // Receive accept_channel.
         builder.append(Operation::RecvAcceptChannel, &[]);
+
+        builder.append(Operation::MineBlock,&[bitcoin_cli]);
     }
 }
 ```

</details>

<details>
<summary>smite and bitcoind logs</summary>

```bash
INFO  [smite_scenarios::targets::bitcoind] Preserving data directory: /data
INFO  [smite_scenarios::targets::bitcoind] Starting bitcoind...
INFO  [smite_scenarios::targets::bitcoind] Waiting for bitcoind to be ready...
INFO  [smite_scenarios::targets::bitcoind] bitcoind is ready
INFO  [smite_scenarios::targets::ldk] Starting ldk-node-wrapper...
INFO  [smite_scenarios::targets::ldk] LDK identity pubkey: 03a74fcad0445473559e6a047f3b8b3b9ae758809fdd41ebe14e11b8c63342a1fc
INFO  [smite_scenarios::targets::ldk] ldk-node-wrapper is ready and synced
INFO  [smite_scenarios::targets::ldk] Both daemons are running, ready to fuzz
DEBUG [smite_scenarios::scenarios] Handshake complete, received target init
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [4.55µs] Executing IR program (27 instructions, 344 input bytes)
DEBUG [smite_scenarios::executor] [223.133µs] SendMessage: type Some(32), 356 bytes
DEBUG [smite_scenarios::executor] [236.478µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [5.226548ms] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [5.231948ms] MineBlock: mining a block
DEBUG [smite_scenarios::scenarios::ir] [9.390277ms] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [9.589365ms] Target responded with pong
INFO  [smite::scenarios] Test case ran successfully!
DEBUG [smite::process] ldk-node-wrapper: dropping running process, attempting shutdown
DEBUG [smite::process] ldk-node-wrapper: sending SIGTERM to process group 53
DEBUG [smite::process] ldk-node-wrapper: exited with exit status: 0
DEBUG [smite::process] bitcoind: dropping running process, attempting shutdown
DEBUG [smite::process] bitcoind: sending SIGTERM to process group 7
DEBUG [smite::process] bitcoind: exited with exit status: 0

.......

2026-05-11T07:44:55Z UpdateTip: new best=754887284a582ef44b1875e9b9cfb1202812910f3bfb92ea6fca60b1a529910b height=101 version=0x20000000 log2_work=7.672425 tx=102 date='2026-05-11T07:45:13Z' progress=1.000000 cache=0.3MiB(101txo)
2026-05-11T07:44:55Z [default] AddToWallet ceabfb8fe0347dda0084f4a18752d1a15b7090a5ef45218c86c8e43826da8d71  new Confirmed (block=754887284a582ef44b1875e9b9cfb1202812910f3bfb92ea6fca60b1a529910b, height=101, index=0)
2026-05-11T07:44:55Z CreateNewBlock(): block weight: 888 txs: 0 fees: 0 sigops 400
2026-05-11T07:44:55Z Saw new header hash=29bf472f68bcc88a1a3e02c67331cfa4d2f956618777d1bbbcf281c5876d202b height=102
2026-05-11T07:44:55Z UpdateTip: new best=29bf472f68bcc88a1a3e02c67331cfa4d2f956618777d1bbbcf281c5876d202b height=102 version=0x20000000 log2_work=7.686501 tx=103 date='2026-05-11T07:45:13Z' progress=1.000000 cache=0.3MiB(102txo)
2026-05-11T07:44:55Z [default] AddToWallet 3325f6b56380693832efb8cacfaac961c60f0bbd983b2bf52006dad9d0b9c765  new Confirmed (block=29bf472f68bcc88a1a3e02c67331cfa4d2f956618777d1bbbcf281c5876d202b, height=102, index=0)
2026-05-11T07:44:55Z tor: Thread interrupt
```

</details>