### PR TITLE
feat(smitebot): scaffold CLI crate and command surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +196,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +243,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -230,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +360,12 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -306,6 +414,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -529,6 +643,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "smitebot"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "thiserror",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +727,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
   "smite",
+  "smitebot",
   "smite-ir",
   "smite-ir-mutator",
   "smite-nyx-sys",
@@ -29,3 +30,4 @@ postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 bitcoin = "0.32"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+clap = { version = "4.5", features = ["derive"] }

--- a/smitebot/Cargo.toml
+++ b/smitebot/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "smitebot"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+clap.workspace = true
+thiserror.workspace = true

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -1,0 +1,138 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "smitebot", version, about = "Smite fuzzing campaign manager")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Validate host prerequisites.
+    Doctor(DoctorArgs),
+    /// Build workload Docker images.
+    Build(BuildArgs),
+    /// Start a fuzzing campaign.
+    Start(StartArgs),
+    /// Stop a fuzzing campaign.
+    Stop(StopArgs),
+    /// Show campaign status.
+    Status(StatusArgs),
+    /// Manage corpus artifacts.
+    Corpus {
+        #[command(subcommand)]
+        command: CorpusCommand,
+    },
+    /// Triage crash artifacts.
+    Crashes(CrashesArgs),
+    /// Reproduce a single crash input.
+    Reproduce(ReproduceArgs),
+    /// Generate and diff coverage artifacts.
+    Coverage(CoverageArgs),
+}
+
+#[derive(Debug, Subcommand)]
+enum CorpusCommand {
+    /// Merge AFL++ queue directories into a single corpus.
+    Merge(CorpusMergeArgs),
+    /// Minimize a merged corpus with afl-cmin.
+    Minimize(CorpusMinimizeArgs),
+}
+
+#[derive(Debug, Args)]
+struct DoctorArgs {}
+
+#[derive(Debug, Args)]
+struct BuildArgs {}
+
+#[derive(Debug, Args)]
+struct StartArgs {
+    /// Maximum time to wait for AFL++ runner readiness.
+    #[arg(long, default_value_t = 300)]
+    startup_timeout_secs: u64,
+    /// Build Docker image before launching campaign.
+    #[arg(long, default_value_t = true)]
+    auto_build: bool,
+}
+
+#[derive(Debug, Args)]
+struct StopArgs {}
+
+#[derive(Debug, Args)]
+struct StatusArgs {}
+
+#[derive(Debug, Args)]
+struct CorpusMergeArgs {}
+
+#[derive(Debug, Args)]
+struct CorpusMinimizeArgs {
+    /// One or more corpus input directories. If multiple are provided, they are
+    /// merged before minimization.
+    #[arg(long = "input-dir", required = true, num_args = 1..)]
+    input_dirs: Vec<PathBuf>,
+    /// Output directory for minimized corpus.
+    #[arg(long)]
+    out_dir: PathBuf,
+    /// Nyx sharedir passed to afl-cmin target command.
+    #[arg(long)]
+    sharedir: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct CrashesArgs {}
+
+#[derive(Debug, Args)]
+struct ReproduceArgs {
+    /// Crash input file to reproduce.
+    #[arg(long)]
+    input: PathBuf,
+    /// Number of reproduction attempts before declaring flaky.
+    #[arg(long, default_value_t = 3)]
+    retries: u32,
+}
+
+#[derive(Debug, Args)]
+struct CoverageArgs {}
+
+#[derive(Debug, thiserror::Error)]
+enum SmitebotError {
+    #[error("command not implemented yet: {command}")]
+    NotImplemented { command: &'static str },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("smitebot: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<(), SmitebotError> {
+    match cli.command {
+        Command::Doctor(_args) => Err(not_implemented("doctor")),
+        Command::Build(_args) => Err(not_implemented("build")),
+        Command::Start(_args) => Err(not_implemented("start")),
+        Command::Stop(_args) => Err(not_implemented("stop")),
+        Command::Status(_args) => Err(not_implemented("status")),
+        Command::Corpus { command } => match command {
+            CorpusCommand::Merge(_args) => Err(not_implemented("corpus merge")),
+            CorpusCommand::Minimize(_args) => Err(not_implemented("corpus minimize")),
+        },
+        Command::Crashes(_args) => Err(not_implemented("crashes")),
+        Command::Reproduce(_args) => Err(not_implemented("reproduce")),
+        Command::Coverage(_args) => Err(not_implemented("coverage")),
+    }
+}
+
+fn not_implemented(command: &'static str) -> SmitebotError {
+    SmitebotError::NotImplemented { command }
+}


### PR DESCRIPTION
## Summary
This PR introduces the foundation for `smitebot` as a new workspace crate.

### Included
- Add `smitebot` crate to workspace members.
- Add shared `clap` workspace dependency.
- Add `smitebot` CLI skeleton with command dispatch and typed errors.
- Add command tree:
  - `doctor`
  - `build`
  - `start`
  - `stop`
  - `status`
  - `corpus merge`
  - `corpus minimize`
  - `crashes`
  - `reproduce`
  - `coverage`
- Add CLI options (skeleton):
  - `start --startup-timeout-secs --auto-build`
  - `reproduce --input --retries`
  - `corpus minimize --input-dir... --out-dir --sharedir`

### Not included
- No runtime implementation yet (all handlers intentionally return `NotImplemented`).
- No behavior changes to existing crates.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p smitebot --verbose`
- `cargo run -p smitebot -- --help`
- `cargo run -p smitebot -- reproduce --help`
- `cargo run -p smitebot -- corpus minimize --help`
