### PR TITLE
smite: use `bitcoin::Txid` instead of local newtype

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -61,7 +61,7 @@ pub use tx_remove_input::TxRemoveInput;
 pub use tx_remove_output::TxRemoveOutput;
 pub use types::{
     BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, MAX_MESSAGE_SIZE, PUBLIC_KEY_SIZE,
-    SHA256_HASH_SIZE, TXID_SIZE, Txid,
+    SHA256_HASH_SIZE, TXID_SIZE,
 };
 pub use update_fail_htlc::{UpdateFailHtlc, UpdateFailHtlcTlvs};
 pub use update_fail_malformed_htlc::UpdateFailMalformedHtlc;
@@ -362,6 +362,7 @@ pub fn message_with_type(msg_type: u16, payload: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::Txid;
     use bitcoin::hashes::{Hash, sha256};
     use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
     use types::CHAIN_HASH_SIZE;

--- a/smite/src/bolt/funding_created.rs
+++ b/smite/src/bolt/funding_created.rs
@@ -1,8 +1,9 @@
 //! BOLT 2 funding created message.
 
 use super::BoltError;
-use super::types::{ChannelId, Txid};
+use super::types::ChannelId;
 use super::wire::WireFormat;
+use bitcoin::Txid;
 use bitcoin::secp256k1::ecdsa::Signature;
 
 /// BOLT 2 `funding_created` message (type 34).

--- a/smite/src/bolt/tx_add_input.rs
+++ b/smite/src/bolt/tx_add_input.rs
@@ -1,10 +1,11 @@
 //! BOLT 2 `tx_add_input` message.
 
+use bitcoin::Txid;
 use bitcoin::secp256k1::hashes::Hash;
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::{ChannelId, Txid};
+use super::types::ChannelId;
 use super::wire::WireFormat;
 
 /// BOLT 2 `tx_add_input` message (type 66).

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -1,7 +1,5 @@
 //! Fundamental types for BOLT message encoding.
 
-use bitcoin::hashes::{self, sha256d};
-
 /// Maximum Lightning message size (2-byte length prefix limit).
 pub const MAX_MESSAGE_SIZE: usize = 65535;
 
@@ -77,11 +75,6 @@ impl BigSize {
             9
         }
     }
-}
-
-hashes::hash_newtype! {
-    /// A bitcoin transaction hash/transaction ID.
-    pub struct Txid(sha256d::Hash);
 }
 
 #[cfg(test)]

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -3,8 +3,9 @@
 use crate::bolt::BoltError;
 use crate::bolt::types::{
     BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, PUBLIC_KEY_SIZE, SHA256_HASH_SIZE,
-    TXID_SIZE, Txid,
+    TXID_SIZE,
 };
+use bitcoin::Txid;
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::ecdsa::Signature;


### PR DESCRIPTION
Drop the local `Txid` `hash_newtype` and import `bitcoin::Txid` directly at the call sites.