### PR TITLE
smite-ir: add `LoadTimestamp` operation

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -140,6 +140,7 @@ impl ProgramBuilder {
                 self.append(Operation::LoadFeeratePerKw(rng.random()), &[])
             }
             VariableType::BlockHeight => self.append(Operation::LoadBlockHeight(rng.random()), &[]),
+            VariableType::Timestamp => self.append(Operation::LoadTimestamp(rng.random()), &[]),
             VariableType::U16 => self.append(Operation::LoadU16(rng.random()), &[]),
             VariableType::U8 => self.append(Operation::LoadU8(rng.random()), &[]),
             VariableType::Bytes => {

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -37,7 +37,9 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
             *v = tweak_u64(*v, rng);
             true
         }
-        Operation::LoadFeeratePerKw(v) | Operation::LoadBlockHeight(v) => {
+        Operation::LoadFeeratePerKw(v)
+        | Operation::LoadBlockHeight(v)
+        | Operation::LoadTimestamp(v) => {
             *v = tweak_u32(*v, rng);
             true
         }

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -27,6 +27,8 @@ pub enum Operation {
     LoadFeeratePerKw(u32),
     /// Load a block height or count.
     LoadBlockHeight(u32),
+    /// Load a Unix timestamp in seconds.
+    LoadTimestamp(u32),
     /// Load a u16 protocol parameter (e.g., `to_self_delay`).
     LoadU16(u16),
     /// Load a u8 protocol parameter (e.g., `channel_flags`).
@@ -530,6 +532,7 @@ impl fmt::Display for Operation {
             Self::LoadAmount(v) => write!(f, "LoadAmount({v})"),
             Self::LoadFeeratePerKw(v) => write!(f, "LoadFeeratePerKw({v})"),
             Self::LoadBlockHeight(v) => write!(f, "LoadBlockHeight({v})"),
+            Self::LoadTimestamp(v) => write!(f, "LoadTimestamp({v})"),
             Self::LoadU16(v) => write!(f, "LoadU16({v})"),
             Self::LoadU8(v) => write!(f, "LoadU8({v})"),
             Self::LoadBytes(b) => write!(f, "LoadBytes({})", format_hex(b)),
@@ -560,6 +563,7 @@ impl Operation {
             Self::LoadAmount(_) => Some(VariableType::Amount),
             Self::LoadFeeratePerKw(_) => Some(VariableType::FeeratePerKw),
             Self::LoadBlockHeight(_) => Some(VariableType::BlockHeight),
+            Self::LoadTimestamp(_) => Some(VariableType::Timestamp),
             Self::LoadU16(_) => Some(VariableType::U16),
             Self::LoadU8(_) => Some(VariableType::U8),
             Self::LoadBytes(_) | Self::LoadShutdownScript(_) => Some(VariableType::Bytes),
@@ -582,6 +586,7 @@ impl Operation {
             Self::LoadAmount(_)
             | Self::LoadFeeratePerKw(_)
             | Self::LoadBlockHeight(_)
+            | Self::LoadTimestamp(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)
@@ -635,6 +640,7 @@ impl Operation {
             Self::LoadAmount(_)
             | Self::LoadFeeratePerKw(_)
             | Self::LoadBlockHeight(_)
+            | Self::LoadTimestamp(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)
@@ -666,6 +672,7 @@ impl Operation {
             Self::LoadAmount(_)
             | Self::LoadFeeratePerKw(_)
             | Self::LoadBlockHeight(_)
+            | Self::LoadTimestamp(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -632,11 +632,29 @@ impl Operation {
     #[must_use]
     pub fn extractable_fields(&self) -> Vec<(Operation, VariableType)> {
         match self {
+            Self::LoadAmount(_)
+            | Self::LoadFeeratePerKw(_)
+            | Self::LoadBlockHeight(_)
+            | Self::LoadU16(_)
+            | Self::LoadU8(_)
+            | Self::LoadBytes(_)
+            | Self::LoadFeatures(_)
+            | Self::LoadPrivateKey(_)
+            | Self::LoadChannelId(_)
+            | Self::LoadShutdownScript(_)
+            | Self::LoadChannelType(_)
+            | Self::LoadTargetPubkeyFromContext
+            | Self::LoadChainHashFromContext
+            | Self::DerivePoint
+            | Self::ExtractAcceptChannel(_)
+            | Self::BuildOpenChannel
+            | Self::SendMessage
+            | Self::MineBlocks(_) => vec![],
+
             Self::RecvAcceptChannel => AcceptChannelField::ALL
                 .iter()
                 .map(|&f| (Self::ExtractAcceptChannel(f), f.output_type()))
                 .collect(),
-            _ => vec![],
         }
     }
 
@@ -644,21 +662,27 @@ impl Operation {
     /// by `OperationParamMutator`.
     #[must_use]
     pub fn is_param_mutable(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::LoadAmount(_)
-                | Self::LoadFeeratePerKw(_)
-                | Self::LoadBlockHeight(_)
-                | Self::LoadU16(_)
-                | Self::LoadU8(_)
-                | Self::LoadBytes(_)
-                | Self::LoadFeatures(_)
-                | Self::LoadPrivateKey(_)
-                | Self::LoadChannelId(_)
-                | Self::LoadShutdownScript(_)
-                | Self::LoadChannelType(_)
-                | Self::MineBlocks(_)
-                | Self::ExtractAcceptChannel(_)
-        )
+            | Self::LoadFeeratePerKw(_)
+            | Self::LoadBlockHeight(_)
+            | Self::LoadU16(_)
+            | Self::LoadU8(_)
+            | Self::LoadBytes(_)
+            | Self::LoadFeatures(_)
+            | Self::LoadPrivateKey(_)
+            | Self::LoadChannelId(_)
+            | Self::LoadShutdownScript(_)
+            | Self::LoadChannelType(_)
+            | Self::MineBlocks(_)
+            | Self::ExtractAcceptChannel(_) => true,
+
+            Self::LoadTargetPubkeyFromContext
+            | Self::LoadChainHashFromContext
+            | Self::DerivePoint
+            | Self::BuildOpenChannel
+            | Self::SendMessage
+            | Self::RecvAcceptChannel => false,
+        }
     }
 }

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -29,6 +29,8 @@ pub enum Variable {
     FeeratePerKw(u32),
     /// Block height or count (`minimum_depth`, `cltv_expiry`, `locktime`).
     BlockHeight(u32),
+    /// Unix timestamp in seconds.
+    Timestamp(u32),
     /// Generic u16 protocol parameter (`to_self_delay`, `max_accepted_htlcs`,
     /// `cltv_expiry_delta`, etc.).
     U16(u16),
@@ -55,6 +57,7 @@ impl Variable {
             Self::Amount(_) => VariableType::Amount,
             Self::FeeratePerKw(_) => VariableType::FeeratePerKw,
             Self::BlockHeight(_) => VariableType::BlockHeight,
+            Self::Timestamp(_) => VariableType::Timestamp,
             Self::U16(_) => VariableType::U16,
             Self::U8(_) => VariableType::U8,
             Self::Features(_) => VariableType::Features,
@@ -76,6 +79,7 @@ pub enum VariableType {
     Amount,
     FeeratePerKw,
     BlockHeight,
+    Timestamp,
     U16,
     U8,
     Features,

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -136,6 +136,7 @@ pub fn execute(
             Operation::LoadAmount(v) => Some(Variable::Amount(*v)),
             Operation::LoadFeeratePerKw(v) => Some(Variable::FeeratePerKw(*v)),
             Operation::LoadBlockHeight(v) => Some(Variable::BlockHeight(*v)),
+            Operation::LoadTimestamp(v) => Some(Variable::Timestamp(*v)),
             Operation::LoadU16(v) => Some(Variable::U16(*v)),
             Operation::LoadU8(v) => Some(Variable::U8(*v)),
             Operation::LoadBytes(b) => Some(Variable::Bytes(b.clone())),


### PR DESCRIPTION
The timestamp type will be used when generating `node_announcement` and `channel_update` messages.

Tests are omitted for now since `LoadTimestamp` will be adequately tested by `BuildNodeAnnouncement` tests in the next PR.

Ref: #71 