### PR TITLE
scripts: force 'fork' multiprocessing when creating sharedir

### DIFF
--- a/scripts/setup-nyx.sh
+++ b/scripts/setup-nyx.sh
@@ -60,9 +60,19 @@ docker rm "$CONTAINER_ID" > /dev/null
 echo "Copying packer binaries..."
 cp "$BINARIES_PATH"/* "$SHAREDIR/"
 
-# Generate Nyx config
+# Generate Nyx config.
+#
+# Python 3.14 changed the default multiprocessing start method to 'forkserver',
+# which breaks the packer's common/debug.py. We force 'fork' via a
+# sitecustomize.py injected on PYTHONPATH to restore the pre-3.14 behavior.
 echo "Generating Nyx config..."
-(cd "$PACKER_PATH" && python3 nyx_config_gen.py "$SHAREDIR" Kernel -m 4096)
+FORCE_FORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$FORCE_FORK_DIR"' EXIT
+cat > "$FORCE_FORK_DIR/sitecustomize.py" <<'EOF'
+import multiprocessing
+multiprocessing.set_start_method("fork", force=True)
+EOF
+(cd "$PACKER_PATH" && PYTHONPATH="$FORCE_FORK_DIR${PYTHONPATH:+:$PYTHONPATH}" ./nyx_config_gen.py "$SHAREDIR" Kernel -m 4096)
 
 # Create fuzz_no_pt.sh script
 echo "Creating fuzz_no_pt.sh..."


### PR DESCRIPTION
Python 3.14 switched the default to 'forkserver' multiprocessing, which causes an error when running `scripts/setup-nyx.sh`:

<details>
<summary>python 3.14 setup-nyx.sh log</summary>

```
Creating sharedir at: /tmp/smite-nyx
Exporting Docker container to container.tar...
Copying packer binaries...
Generating Nyx config...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; from multiprocessing.forkserver import main; main(5, 7, ['__main__'], sys_argv=sys.argv[1:], **{'sys_path': ['AFLplusplus/nyx_mode/packer/packer', '/usr/lib64/python314.zip', '/usr/lib64/python3.14', '/usr/lib64/python3.14/lib-dynload', '.local/lib/python3.14/site-packages', '/usr/lib64/python3.14/site-packages', '/usr/lib/python3.14/site-packages'], 'main_path': 'AFLplusplus/nyx_mode/packer/packer/nyx_config_gen.py', 'authkey_r': 9})
                                                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/forkserver.py", line 230, in main
    spawn.import_main_path(main_path)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/spawn.py", line 307, in import_main_path
    _fixup_main_from_path(main_path)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                                  run_name="__mp_main__")
  File "<frozen runpy>", line 287, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "AFLplusplus/nyx_mode/packer/packer/nyx_config_gen.py", line 7, in <module>
    from common.util import ask_for_permission
  File "AFLplusplus/nyx_mode/packer/packer/common/util.py", line 33, in <module>
    from common.debug import logger
  File "AFLplusplus/nyx_mode/packer/packer/common/debug.py", line 47, in <module>
    manager = Manager()
  File "/usr/lib64/python3.14/multiprocessing/context.py", line 57, in Manager
    m.start()
    ~~~~~~~^^
  File "/usr/lib64/python3.14/multiprocessing/managers.py", line 566, in start
    self._process.start()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ~~~~~~~~~~~^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/context.py", line 306, in _Popen
    return Popen(process_obj)
  File "/usr/lib64/python3.14/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/popen_fork.py", line 20, in __init__
    self._launch(process_obj)
    ~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/popen_forkserver.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
  File "/usr/lib64/python3.14/multiprocessing/spawn.py", line 164, in get_preparation_data
    _check_not_importing_main()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/multiprocessing/spawn.py", line 140, in _check_not_importing_main
    raise RuntimeError('''
    ...<16 lines>...
    ''')
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html

Traceback (most recent call last):
  File "AFLplusplus/nyx_mode/packer/packer/nyx_config_gen.py", line 7, in <module>
    from common.util import ask_for_permission
  File "AFLplusplus/nyx_mode/packer/packer/common/util.py", line 33, in <module>
    from common.debug import logger
  File "AFLplusplus/nyx_mode/packer/packer/common/debug.py", line 47, in <module>
    manager = Manager()
  File "/usr/lib64/python3.14/multiprocessing/context.py", line 57, in Manager
    m.start()
    ~~~~~~~^^
  File "/usr/lib64/python3.14/multiprocessing/managers.py", line 566, in start
    self._process.start()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ~~~~~~~~~~~^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/context.py", line 306, in _Popen
    return Popen(process_obj)
  File "/usr/lib64/python3.14/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/popen_fork.py", line 20, in __init__
    self._launch(process_obj)
    ~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/popen_forkserver.py", line 51, in _launch
    self.sentinel, w = forkserver.connect_to_new_process(self._fds)
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/forkserver.py", line 106, in connect_to_new_process
    connection.answer_challenge(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
            wrapped_client, self._forkserver_authkey)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/connection.py", line 992, in answer_challenge
    message = connection.recv_bytes(256)         # reject large message
  File "/usr/lib64/python3.14/multiprocessing/connection.py", line 223, in recv_bytes
    buf = self._recv_bytes(maxlength)
  File "/usr/lib64/python3.14/multiprocessing/connection.py", line 448, in _recv_bytes
    buf = self._recv(4)
  File "/usr/lib64/python3.14/multiprocessing/connection.py", line 413, in _recv
    chunk = read(handle, to_read)
ConnectionResetError: [Errno 104] Connection reset by peer
```

</details>

This PR forces the older 'fork' multiprocessing mode which fixes the issue on python 3.14.  It should also work with older pythons, but someone with an older python should verify that before we merge this.