### PR TITLE
Recommend setting `AFL_FRAMESHIFT_DISABLE=1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ printf '\x00' > /tmp/smite-seeds/empty
 # Start fuzzing with the custom mutator
 AFL_CUSTOM_MUTATOR_LIBRARY=target/release/libsmite_ir_mutator.so \
 AFL_CUSTOM_MUTATOR_ONLY=1 \
+AFL_FRAMESHIFT_DISABLE=1 \
 AFL_DISABLE_TRIM=1 \
 ~/AFLplusplus/afl-fuzz -X -i /tmp/smite-seeds -o /tmp/smite-out -- /tmp/smite-nyx
 ```

--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -13,6 +13,9 @@
 //! - `AFL_CUSTOM_MUTATOR_ONLY=1` -- disable AFL++'s byte mutators. This also
 //!   disables the havoc stage entirely, so we deliberately do not implement
 //!   `afl_custom_havoc_mutation`.
+//! - `AFL_FRAMESHIFT_DISABLE=1` -- disable AFL++'s `FrameShift` analysis that
+//!   bypasses our custom mutators. This was an AFL++ bug fixed upstream in
+//!   commit eddb2701b022351fb34b696ccf923bb856e9d953.
 //! - `AFL_DISABLE_TRIM=1` -- this library does not implement custom trim and
 //!   AFL++'s default byte-level trim would corrupt our structured programs.
 //!


### PR DESCRIPTION
AFL++ 4.40c added a new [FrameShift](https://github.com/AFLplusplus/AFLplusplus/blob/59b74094f214db61ce2615cb4a634aa28a634e28/docs/FrameShift.md) analysis feature that bypasses our custom mutators and can invalidate postcard-encoded IR programs, leading to crashes during fuzzing.

Fixes #82.