### PR TITLE
smite-ir: add CreateFundingTransaction IR operation

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -168,6 +168,9 @@ impl ProgramBuilder {
             VariableType::AcceptChannel => {
                 panic!("cannot generate fresh AcceptChannel: requires protocol interaction")
             }
+            VariableType::FundingTransaction => {
+                panic!("cannot generate fresh FundingTransaction: requires composed inputs")
+            }
         }
     }
 

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -92,6 +92,7 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         // Non-mutable variants. Reaching here means `is_param_mutable` and this
         // match have drifted out of sync.
         Operation::DerivePoint
+        | Operation::CreateFundingTransaction
         | Operation::LoadTargetPubkeyFromContext
         | Operation::LoadChainHashFromContext
         | Operation::BuildOpenChannel

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -66,6 +66,14 @@ pub enum Operation {
     /// Extract a field from a parsed `accept_channel` response.
     /// Input: `AcceptChannel`.
     ExtractAcceptChannel(AcceptChannelField),
+    /// Create a BOLT 3 funding transaction for the channel funding flow.
+    ///
+    /// Inputs (4):
+    ///   0: `opener_funding_pubkey` (`Point`)
+    ///   1: `acceptor_funding_pubkey` (`Point`)
+    ///   2: `funding_satoshis` (`Amount`)
+    ///   3: `feerate_per_kw` (`FeeratePerKw`)
+    CreateFundingTransaction,
 
     // -- Build: construct a BOLT message from inputs --
     /// Build an `open_channel` message (BOLT 2, type 32).
@@ -548,6 +556,7 @@ impl fmt::Display for Operation {
             // Operations with inputs: parens added by Program::Display.
             Self::DerivePoint => write!(f, "DerivePoint"),
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
+            Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
             Self::BuildNodeAnnouncement { rgb_color, alias } => write!(
                 f,
@@ -579,6 +588,7 @@ impl Operation {
             Self::LoadTargetPubkeyFromContext | Self::DerivePoint => Some(VariableType::Point),
             Self::LoadChainHashFromContext => Some(VariableType::ChainHash),
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
+            Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
             Self::BuildOpenChannel | Self::BuildNodeAnnouncement { .. } => {
                 Some(VariableType::Message)
             }
@@ -610,6 +620,12 @@ impl Operation {
 
             Self::DerivePoint => vec![VariableType::PrivateKey],
             Self::ExtractAcceptChannel(_) => vec![VariableType::AcceptChannel],
+            Self::CreateFundingTransaction => vec![
+                VariableType::Point,        // opener_funding_pubkey
+                VariableType::Point,        // acceptor_funding_pubkey
+                VariableType::Amount,       // funding_satoshis
+                VariableType::FeeratePerKw, // feerate_per_kw
+            ],
             Self::SendMessage => vec![VariableType::Message],
 
             Self::BuildOpenChannel => vec![
@@ -668,6 +684,7 @@ impl Operation {
             | Self::LoadChainHashFromContext
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
+            | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
             | Self::BuildNodeAnnouncement { .. }
             | Self::SendMessage
@@ -704,6 +721,7 @@ impl Operation {
             Self::LoadTargetPubkeyFromContext
             | Self::LoadChainHashFromContext
             | Self::DerivePoint
+            | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
             | Self::SendMessage
             | Self::RecvAcceptChannel => false,

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -288,6 +288,22 @@ fn postcard_roundtrip() {
                 operation: Operation::MineBlocks(6),
                 inputs: vec![],
             },
+            Instruction {
+                operation: Operation::LoadPrivateKey(key(2)),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![7],
+            },
+            Instruction {
+                operation: Operation::LoadFeeratePerKw(15_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::CreateFundingTransaction,
+                inputs: vec![1, 8, 4, 9],
+            },
         ],
     };
 
@@ -348,6 +364,175 @@ fn validate_rejects_mine_blocks_with_wrong_input() {
             instr: 1,
             expected: 0,
             got: 1
+        }),
+    );
+}
+
+#[test]
+fn create_funding_transaction_operation() {
+    let op = Operation::CreateFundingTransaction;
+    assert_eq!(
+        op.input_types(),
+        vec![
+            VariableType::Point,
+            VariableType::Point,
+            VariableType::Amount,
+            VariableType::FeeratePerKw,
+        ],
+    );
+    assert_eq!(op.output_type(), Some(VariableType::FundingTransaction));
+    assert!(!op.is_param_mutable());
+}
+
+fn create_funding_transaction_instructions() -> Vec<Instruction> {
+    vec![
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(1)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![0],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(2)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![2],
+        },
+        Instruction {
+            operation: Operation::LoadAmount(10_000_000),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadFeeratePerKw(15_000),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::CreateFundingTransaction,
+            inputs: vec![1, 3, 4, 5],
+        },
+    ]
+}
+
+#[test]
+fn displays_create_funding_transaction_program() {
+    let program = Program {
+        instructions: create_funding_transaction_instructions(),
+    };
+    let text = program.to_string();
+    let lines: Vec<&str> = text.lines().collect();
+
+    let z31 = "00".repeat(31);
+
+    let expected = vec![
+        format!("v0 = LoadPrivateKey(0x{z31}01)"),
+        "v1 = DerivePoint(v0)".into(),
+        format!("v2 = LoadPrivateKey(0x{z31}02)"),
+        "v3 = DerivePoint(v2)".into(),
+        "v4 = LoadAmount(10000000)".into(),
+        "v5 = LoadFeeratePerKw(15000)".into(),
+        "v6 = CreateFundingTransaction(v1, v3, v4, v5)".into(),
+    ];
+    assert_eq!(lines, expected);
+}
+
+#[test]
+fn validate_accepts_create_funding_transaction() {
+    let program = Program {
+        instructions: create_funding_transaction_instructions(),
+    };
+    program
+        .validate()
+        .expect("CreateFundingTransaction should validate");
+}
+
+#[test]
+fn validate_rejects_create_funding_transaction_with_wrong_input_count() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::CreateFundingTransaction,
+            inputs: vec![],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::WrongInputCount {
+            instr: 0,
+            expected: 4,
+            got: 0,
+        }),
+    );
+}
+
+fn create_funding_transaction_with_wrong_input(input: usize, wrong: Operation) -> Program {
+    // We will take the correct set of instructions for creating the funding
+    // transaction, and then at given input position insert an invalid input
+    // type that `CreateFundingTransaction` does not expect.
+    let mut instructions = create_funding_transaction_instructions();
+    let producer = instructions.last().unwrap().inputs[input];
+    instructions[producer] = Instruction {
+        operation: wrong,
+        inputs: vec![],
+    };
+    Program { instructions }
+}
+
+#[test]
+fn validate_rejects_create_funding_transaction_with_wrong_opener_funding_pubkey() {
+    let program = create_funding_transaction_with_wrong_input(0, Operation::LoadAmount(100_000));
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::TypeMismatch {
+            instr: 6,
+            input: 0,
+            expected: VariableType::Point,
+            got: VariableType::Amount,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_create_funding_transaction_with_wrong_acceptor_funding_pubkey() {
+    let program =
+        create_funding_transaction_with_wrong_input(1, Operation::LoadFeeratePerKw(1_500));
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::TypeMismatch {
+            instr: 6,
+            input: 1,
+            expected: VariableType::Point,
+            got: VariableType::FeeratePerKw,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_create_funding_transaction_with_wrong_funding_satoshis() {
+    let program = create_funding_transaction_with_wrong_input(2, Operation::LoadPrivateKey(key(1)));
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::TypeMismatch {
+            instr: 6,
+            input: 2,
+            expected: VariableType::Amount,
+            got: VariableType::PrivateKey,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_create_funding_transaction_with_wrong_feerate_per_kw() {
+    let program = create_funding_transaction_with_wrong_input(3, Operation::LoadAmount(100_000));
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::TypeMismatch {
+            instr: 6,
+            input: 3,
+            expected: VariableType::FeeratePerKw,
+            got: VariableType::Amount,
         }),
     );
 }
@@ -793,6 +978,14 @@ fn generate_fresh_accept_channel_panics() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
     builder.generate_fresh(VariableType::AcceptChannel, &mut rng);
+}
+
+#[test]
+#[should_panic(expected = "cannot generate fresh FundingTransaction")]
+fn generate_fresh_funding_transaction_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    builder.generate_fresh(VariableType::FundingTransaction, &mut rng);
 }
 
 #[test]

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -5,6 +5,7 @@
 
 use bitcoin::secp256k1::PublicKey;
 use smite::bolt::{AcceptChannel, ChannelId};
+use smite::channel_tx::FundingTransaction;
 
 const CHAIN_HASH_SIZE: usize = 32;
 const PRIVATE_KEY_SIZE: usize = 32;
@@ -42,6 +43,8 @@ pub enum Variable {
     Message(Vec<u8>),
     /// Parsed `accept_channel` response.
     AcceptChannel(AcceptChannel),
+    /// Constructed funding transaction with funding output index.
+    FundingTransaction(FundingTransaction),
 }
 
 impl Variable {
@@ -63,6 +66,7 @@ impl Variable {
             Self::Features(_) => VariableType::Features,
             Self::Message(_) => VariableType::Message,
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
+            Self::FundingTransaction(_) => VariableType::FundingTransaction,
         }
     }
 }
@@ -85,4 +89,5 @@ pub enum VariableType {
     Features,
     Message,
     AcceptChannel,
+    FundingTransaction,
 }

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -3,13 +3,15 @@
 //! Executes an IR program against a target node over an established connection,
 //! producing side effects (sending/receiving messages).
 
+use bitcoin::ScriptBuf;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::{BitcoinCli, Utxo};
 use smite::bolt::{
     AcceptChannel, ChannelId, Message, NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong,
     msg_type,
 };
+use smite::channel_tx::{FundingTransaction, build_funding_transaction};
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable, VariableType};
@@ -18,11 +20,25 @@ use smite_ir::{Operation, Program, Variable, VariableType};
 pub trait BitcoinRpc {
     /// Mines the given number of blocks.
     fn mine_blocks(&mut self, num_blocks: u8);
+
+    /// Returns the wallet's spendable UTXOs.
+    fn get_utxos(&mut self) -> Vec<Utxo>;
+
+    /// Returns the scriptPubKey for a newly generated wallet address.
+    fn get_new_address_script_pubkey(&mut self) -> ScriptBuf;
 }
 
 impl BitcoinRpc for BitcoinCli {
     fn mine_blocks(&mut self, num_blocks: u8) {
         BitcoinCli::mine_blocks(self, num_blocks);
+    }
+
+    fn get_utxos(&mut self) -> Vec<Utxo> {
+        BitcoinCli::get_utxos(self)
+    }
+
+    fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
+        BitcoinCli::get_new_address_script_pubkey(self)
     }
 }
 
@@ -105,6 +121,10 @@ pub enum ExecuteError {
     /// Received a different message type than expected.
     #[error("unexpected message: expected type {expected}, got {got}")]
     UnexpectedMessage { expected: u16, got: u16 },
+
+    /// Wallet UTXOs could not cover the funding amount and fees.
+    #[error("funding: {0}")]
+    InsufficientFunds(#[from] smite::channel_tx::InsufficientFunds),
 }
 
 /// Executes an IR program against a target over the given connection.
@@ -162,6 +182,11 @@ pub fn execute(
             Operation::ExtractAcceptChannel(field) => {
                 let ac = resolve_accept_channel(&variables, instr.inputs[0])?;
                 Some(extract_field(ac, *field))
+            }
+
+            Operation::CreateFundingTransaction => {
+                let ft = create_funding_transaction(&variables, &instr.inputs, bitcoin_cli)?;
+                Some(Variable::FundingTransaction(ft))
             }
 
             // -- Build operations --
@@ -350,6 +375,35 @@ fn resolve_accept_channel(
 
 // -- Operation handlers --
 
+/// Create a funding transaction by querying the bitcoind for UTXOs and a
+/// change address, then calling [`build_funding_transaction`].
+fn create_funding_transaction(
+    variables: &[Option<Variable>],
+    inputs: &[usize],
+    cli: &mut impl BitcoinRpc,
+) -> Result<FundingTransaction, ExecuteError> {
+    let opener_pubkey = resolve_pubkey(variables, inputs[0])?;
+    let acceptor_pubkey = resolve_pubkey(variables, inputs[1])?;
+    let funding_satoshis = resolve_amount(variables, inputs[2])?;
+    let feerate_per_kw = resolve_feerate(variables, inputs[3])?;
+
+    // Query wallet state from bitcoind for coin selection and change.
+    let utxos = cli.get_utxos();
+    let change_spk = cli.get_new_address_script_pubkey();
+
+    // Create the funding transaction.
+    let funding = build_funding_transaction(
+        &opener_pubkey,
+        &acceptor_pubkey,
+        funding_satoshis,
+        feerate_per_kw,
+        utxos,
+        change_spk,
+    )?;
+
+    Ok(funding)
+}
+
 /// Builds an `OpenChannel` from 20 input variables (wire order).
 fn build_open_channel(
     variables: &[Option<Variable>],
@@ -490,9 +544,11 @@ fn nonempty_or_none(bytes: &[u8]) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::str::FromStr;
 
     use super::*;
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::{Amount, OutPoint};
     use smite::bolt::{AcceptChannelTlvs, Init, Ping};
     use smite_ir::Instruction;
 
@@ -534,11 +590,21 @@ mod tests {
     #[derive(Default)]
     struct MockBitcoinCli {
         mine_blocks_calls: Vec<u8>,
+        utxos: Vec<Utxo>,
+        change_spk: ScriptBuf,
     }
 
     impl BitcoinRpc for MockBitcoinCli {
         fn mine_blocks(&mut self, num_blocks: u8) {
             self.mine_blocks_calls.push(num_blocks);
+        }
+
+        fn get_utxos(&mut self) -> Vec<Utxo> {
+            self.utxos.clone()
+        }
+
+        fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
+            self.change_spk.clone()
         }
     }
 
@@ -559,6 +625,29 @@ mod tests {
             block_height: 800_000,
             target_features: vec![],
         }
+    }
+
+    fn sample_utxo() -> Utxo {
+        Utxo {
+            amount: Amount::from_sat(10_008_942),
+            outpoint: OutPoint {
+                txid: "a1f7b953dc8c3db0222d931d3e2613f9971af75a09a005b31af057f8414cc5d7"
+                    .parse()
+                    .expect("valid txid"),
+                vout: 0,
+            },
+            script_pubkey: ScriptBuf::from(
+                hex::decode("0014a10d9257489e685dda030662390dc177852faf13")
+                    .expect("valid P2WPKH scriptpubkey hex"),
+            ),
+        }
+    }
+
+    fn sample_change_spk() -> ScriptBuf {
+        ScriptBuf::from(
+            hex::decode("00142e532c12351a5c81e23c8a76d19345ca7b6de57a")
+                .expect("valid P2WPKH scriptpubkey hex"),
+        )
     }
 
     fn sample_accept_channel() -> AcceptChannel {
@@ -666,6 +755,48 @@ mod tests {
             Instruction {
                 operation: Operation::LoadFeatures(vec![]),
                 inputs: vec![],
+            },
+        ]
+    }
+
+    fn create_funding_transaction_instructions() -> Vec<Instruction> {
+        let opener_privkey =
+            SecretKey::from_str("30ff4956bbdd3222d44cc5e8a1261dab1e07957bdac5ae88fe3261ef321f3749")
+                .unwrap()
+                .secret_bytes();
+        let acceptor_privkey =
+            SecretKey::from_str("1552dfba4f6cf29a62a0af13c8d6981d36d0ef8d61ba10fb0fe90da7634d7e13")
+                .unwrap()
+                .secret_bytes();
+
+        vec![
+            Instruction {
+                operation: Operation::LoadPrivateKey(opener_privkey),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![0],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey(acceptor_privkey),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![2],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(10_000_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadFeeratePerKw(15_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::CreateFundingTransaction,
+                inputs: vec![1, 3, 4, 5],
             },
         ]
     }
@@ -1215,6 +1346,61 @@ mod tests {
                 got: 1,
             }
         ));
+    }
+
+    #[test]
+    fn execute_create_funding_transaction() {
+        let mut conn = MockConnection::new();
+        let mut mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        execute(
+            &Program {
+                instructions: create_funding_transaction_instructions(),
+            },
+            &sample_context(),
+            &mut conn,
+            &mut mock_cli,
+            std::time::Instant::now(),
+        )
+        .expect("funding tx construction should succeed");
+
+        // TODO: Once we have the `BroadcastTransaction` IR operation, we can
+        // add `broadcast_calls` to the `mock_cli` to retrieve the funding tx
+        // here and assert that it matches the expected tx constructed from the
+        // sample UTXO and change script pubkey.
+    }
+
+    #[test]
+    fn execute_create_funding_transaction_insufficient_funds() {
+        // UTXO too small to cover the funding amount and fees.
+        let small_utxo = Utxo {
+            amount: Amount::from_sat(1_000),
+            ..sample_utxo()
+        };
+        let mut conn = MockConnection::new();
+        let mut mock_cli = MockBitcoinCli {
+            utxos: vec![small_utxo],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        let err = execute(
+            &Program {
+                instructions: create_funding_transaction_instructions(),
+            },
+            &sample_context(),
+            &mut conn,
+            &mut mock_cli,
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
+        let ExecuteError::InsufficientFunds(funds_err) = err else {
+            panic!("expected InsufficientFunds, got {err:?}");
+        };
+        assert_eq!(funds_err.available, Amount::from_sat(1_000));
+        assert_eq!(funds_err.required, Amount::from_sat(10_007_290));
     }
 
     #[test]


### PR DESCRIPTION
This commit adds the `CreateFundingTransaction` IR operation. For this, a new `VariableType`, `FundingTransaction`, has been added. This is required because we need the funding transaction after receiving the funding signed message so that we can broadcast the transaction and exchange `channel_ready` messages