### PR TITLE
smite: change MineBlocks(0) panic into noop

### DIFF
--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -70,6 +70,9 @@ impl BitcoinCli {
     /// If the `bitcoin-cli -generate` command fails to execute or returns
     /// a non-success exit status.
     pub fn mine_blocks(&self, num_blocks: u8) {
+        if num_blocks == 0 {
+            return;
+        }
         let mine_out = self
             .run()
             .arg("-generate")


### PR DESCRIPTION
I have noticed a crash in `BitcoinCli::mine_blocks` when executing the operation `MineBlocks(0)`. I found this on 099c6cb with the LND IR scenario and without custom mutator, so running `afl-fuzz` like this:

```
$ afl-fuzz -X -i /tmp/smite-seeds -o /tmp/smite-out -- /tmp/smite-nyx
```

Crash input IR program (`MineBlocks(0)`):

```
$ xxd -p crash
0113000005152d0f

# to recreate:
$ echo -n "0113000005152d0f" | xxd -r -p > crash

$ cat crash.log
panicked at smite/src/bitcoin.rs:79:9:
bitcoin-cli -generate 0 failed: error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero
```

Local reproduction:

```
$ docker run --rm -v $PWD/crash:/input.bin -e SMITE_INPUT=/input.bin smite-lnd-ir /lnd-scenario
INFO  [smite_scenarios::targets::bitcoind] Starting bitcoind...
INFO  [smite_scenarios::targets::bitcoind] Waiting for bitcoind to be ready...
INFO  [smite_scenarios::targets::bitcoind] bitcoind is ready
INFO  [smite_scenarios::targets::lnd] Starting lnd...
INFO  [smite_scenarios::targets::lnd] Waiting for lnd to be ready and synced...
INFO  [smite_scenarios::targets::lnd] LND identity pubkey: 03857c20775de69a6247eaf074fcd8fd77067930af43c125bf387bf4b3e1167fd8, blockheight: 101, synced_to_chain: false
DEBUG [smite_scenarios::targets::lnd] lnd not yet synced (blockheight=101, synced_to_chain=false)
INFO  [smite_scenarios::targets::lnd] LND identity pubkey: 03857c20775de69a6247eaf074fcd8fd77067930af43c125bf387bf4b3e1167fd8, blockheight: 101, synced_to_chain: true
INFO  [smite_scenarios::targets::lnd] lnd synced (blockheight=101)
INFO  [smite_scenarios::targets::lnd] Both daemons are running, ready to fuzz
DEBUG [smite_scenarios::scenarios] Handshake complete, received target init
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [1.866µs] Executing IR program (1 instructions, 8 input bytes)

thread 'main' (1) panicked at smite/src/bitcoin.rs:79:9:
bitcoin-cli -generate 0 failed: error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
DEBUG [smite::process] lnd: dropping running process, attempting shutdown
DEBUG [smite::process] lnd: sending SIGTERM to process group 55
DEBUG [smite::process] lnd: exited with exit status: 0
DEBUG [smite::process] bitcoind: dropping running process, attempting shutdown
DEBUG [smite::process] bitcoind: sending SIGTERM to process group 7
DEBUG [smite::process] bitcoind: exited with exit status: 0
```

This showed up as a crash in the fuzzer, but I think it shouldn't, since the target didn't crash. I think these programs should be skipped. 

As far as I can tell, without the custom mutator, we don't validate the program before executing it. We only validate the program inside `afl_custom_fuzz` with `decode_and_validate`:

https://github.com/morehouse/smite/blob/099c6cb20a827e0dd8963355de0a1ba10eb0de03/smite-ir-mutator/src/lib.rs#L159-L191

However, I think this would happen even with the custom mutator, even though I wasn't able to reproduce the crash while fuzzing with it. `Program::validate` currently does not check if the input to `mine_blocks` is > 0. This PR fixes that.

Additionally, I'm wondering if we should also validate in `IrScenario::run`:

```diff
diff --git a/smite-scenarios/src/scenarios/ir.rs b/smite-scenarios/src/scenarios/ir.rs
index f171aa3..7492cc8 100644
--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -41,6 +41,11 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
             return ScenarioResult::Skip;
         };

+        if program.validate().is_err() {
+            log::debug!("Invalid program, skipping");
+            return ScenarioResult::Skip;
+        }
+
         log::debug!(
             "[{:?}] Executing IR program ({} instructions, {} input bytes)",
             start.elapsed(),
```