### PR TITLE
smite-ir: implement `NodeAnnouncementGenerator`

### DIFF
--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -32,7 +32,7 @@ use std::slice;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
-use smite_ir::generators::OpenChannelGenerator;
+use smite_ir::generators::{NodeAnnouncementGenerator, OpenChannelGenerator};
 use smite_ir::mutators::{InputSwapMutator, OperationParamMutator};
 use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
 
@@ -61,10 +61,14 @@ impl MutatorState {
         }
     }
 
-    /// Generates a fresh program from scratch using `OpenChannelGenerator`.
+    /// Generates a fresh program from scratch using our custom generators.
     fn generate_fresh(&mut self) -> Program {
         let mut builder = ProgramBuilder::new();
-        OpenChannelGenerator.generate(&mut builder, &mut self.rng);
+        if self.rng.random() {
+            OpenChannelGenerator.generate(&mut builder, &mut self.rng);
+        } else {
+            NodeAnnouncementGenerator.generate(&mut builder, &mut self.rng);
+        }
         self.last_sequence.clear();
         self.last_sequence.push("fresh");
         builder.build()

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -5,8 +5,10 @@
 //! protocol flow but delegates value selection and variable reuse to
 //! `ProgramBuilder`.
 
+mod node_announcement;
 mod open_channel;
 
+pub use node_announcement::NodeAnnouncementGenerator;
 pub use open_channel::OpenChannelGenerator;
 
 use rand::Rng;

--- a/smite-ir/src/generators/node_announcement.rs
+++ b/smite-ir/src/generators/node_announcement.rs
@@ -1,0 +1,35 @@
+//! Generator for `node_announcement` gossip message.
+
+use rand::{Rng, RngExt};
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::{Operation, VariableType};
+
+/// Generates an unsolicited `node_announcement` send.
+pub struct NodeAnnouncementGenerator;
+
+impl Generator for NodeAnnouncementGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        let node_sk = builder.pick_variable(VariableType::PrivateKey, rng);
+        let features = builder.pick_variable(VariableType::Features, rng);
+        let timestamp = builder.pick_variable(VariableType::Timestamp, rng);
+        let addresses = builder.pick_variable(VariableType::Bytes, rng);
+
+        // rgb_color and alias are op-level params (not variable inputs) so the
+        // mutator can flip bits inside them without changing their lengths.
+        let rgb_color: [u8; 3] = rng.random();
+        let mut alias = [0u8; 32];
+        for b in &mut alias {
+            // BOLT 7 requires alias to be valid UTF-8, which Eclair actually
+            // enforces on decode.
+            *b = rng.random_range(0x00..=0x7F);
+        }
+
+        let msg = builder.append(
+            Operation::BuildNodeAnnouncement { rgb_color, alias },
+            &[node_sk, features, timestamp, addresses],
+        );
+        builder.append(Operation::SendMessage, &[msg]);
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -6,7 +6,7 @@ use rand::rngs::SmallRng;
 use smite::bolt::MAX_MESSAGE_SIZE;
 
 use super::*;
-use generators::OpenChannelGenerator;
+use generators::{NodeAnnouncementGenerator, OpenChannelGenerator};
 use mutators::{InputSwapMutator, OperationParamMutator};
 use operation::{AcceptChannelField, ChannelTypeVariant, ShutdownScriptVariant};
 use program::ValidateError;
@@ -669,9 +669,65 @@ fn generated_program_structure() {
     );
 }
 
+fn generate_node_announcement_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    NodeAnnouncementGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+// If NodeAnnouncementGenerator completes without panicking, every instruction
+// has correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_node_announcement_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_node_announcement_program(seed);
+    }
+}
+
+#[test]
+fn generated_node_announcement_program_structure() {
+    let program = generate_node_announcement_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::SendMessage),
+        "last instruction should be SendMessage",
+    );
+    let build_count = ops
+        .iter()
+        .filter(|op| matches!(op, Operation::BuildNodeAnnouncement { .. }))
+        .count();
+    assert_eq!(build_count, 1, "expected exactly one BuildNodeAnnouncement");
+}
+
+#[test]
+fn generated_node_announcement_alias_is_utf8() {
+    for seed in 0..100 {
+        let program = generate_node_announcement_program(seed);
+        let alias = program
+            .instructions
+            .iter()
+            .find_map(|i| match i.operation {
+                Operation::BuildNodeAnnouncement { alias, .. } => Some(alias),
+                _ => None,
+            })
+            .expect("BuildNodeAnnouncement present");
+        assert!(str::from_utf8(&alias).is_ok(), "alias is not UTF-8");
+    }
+}
+
 #[test]
 fn generated_program_postcard_roundtrip() {
     let program = generate_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generated_node_announcement_program_postcard_roundtrip() {
+    let program = generate_node_announcement_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);
@@ -791,6 +847,16 @@ fn append_type_mismatch_panics() {
 fn validate_accepts_generated_program() {
     for seed in 0..100 {
         let program = generate_program(seed);
+        program
+            .validate()
+            .expect("generated program should validate");
+    }
+}
+
+#[test]
+fn validate_accepts_generated_node_announcement_program() {
+    for seed in 0..100 {
+        let program = generate_node_announcement_program(seed);
         program
             .validate()
             .expect("generated program should validate");

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -619,7 +619,7 @@ fn channel_type_encode_matches_bits_for_all_variants() {
     }
 }
 
-fn generate_program(seed: u64) -> Program {
+fn generate_open_channel_program(seed: u64) -> Program {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut builder = ProgramBuilder::new();
     OpenChannelGenerator.generate(&mut builder, &mut rng);
@@ -629,15 +629,15 @@ fn generate_program(seed: u64) -> Program {
 // If OpenChannelGenerator completes without panicking, every instruction has
 // correct input types (enforced by ProgramBuilder::append).
 #[test]
-fn generated_program_is_type_correct() {
+fn generated_open_channel_program_is_type_correct() {
     for seed in 0..100 {
-        generate_program(seed);
+        generate_open_channel_program(seed);
     }
 }
 
 #[test]
-fn generated_program_structure() {
-    let program = generate_program(0);
+fn generated_open_channel_program_structure() {
+    let program = generate_open_channel_program(0);
     let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
 
     // Must end with SendMessage, RecvAcceptChannel.
@@ -718,8 +718,8 @@ fn generated_node_announcement_alias_is_utf8() {
 }
 
 #[test]
-fn generated_program_postcard_roundtrip() {
-    let program = generate_program(42);
+fn generated_open_channel_program_postcard_roundtrip() {
+    let program = generate_open_channel_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);
@@ -844,9 +844,9 @@ fn append_type_mismatch_panics() {
 // -- Program::validate tests --
 
 #[test]
-fn validate_accepts_generated_program() {
+fn validate_accepts_generated_open_channel_program() {
     for seed in 0..100 {
-        let program = generate_program(seed);
+        let program = generate_open_channel_program(seed);
         program
             .validate()
             .expect("generated program should validate");
@@ -1059,7 +1059,7 @@ fn validate_rejects_oversized_features() {
 
 #[test]
 fn param_mutator_changes_values() {
-    let original = generate_program(0);
+    let original = generate_open_channel_program(0);
     let mut program = original.clone();
     let mutator = OperationParamMutator;
     let mut rng = SmallRng::seed_from_u64(0);
@@ -1242,7 +1242,7 @@ fn param_mutator_preserves_extract_field_type() {
 
 #[test]
 fn input_swap_changes_references() {
-    let original = generate_program(0);
+    let original = generate_open_channel_program(0);
     let mut program = original.clone();
     let mutator = InputSwapMutator;
     let mut rng = SmallRng::seed_from_u64(0);
@@ -1288,7 +1288,7 @@ fn input_swap_returns_false_when_no_alternatives() {
 
 #[test]
 fn input_swap_preserves_types() {
-    let original = generate_program(0);
+    let original = generate_open_channel_program(0);
     let mutator = InputSwapMutator;
     let mut rng = SmallRng::seed_from_u64(0);
 


### PR DESCRIPTION
Generates programs that send correctly-signed `node_announcement` messages to the target.

Verified that all 4 targets successfully decode the `node_announcement`s we send and pass initial validation, including signature checks (except LND, which only checks signatures if we send a matching `channel_announcement` first).  Once we can send `channel_announcement`s that match the `node_announcement`s, we will be able to exercise even deeper code paths.

[ldk-coverage.tar.gz](https://github.com/user-attachments/files/28158045/ldk-coverage.tar.gz)
[lnd-coverage.tar.gz](https://github.com/user-attachments/files/28158049/lnd-coverage.tar.gz)
[cln-coverage.tar.gz](https://github.com/user-attachments/files/28158059/cln-coverage.tar.gz)
[eclair-coverage.tar.gz](https://github.com/user-attachments/files/28158062/eclair-coverage.tar.gz)

Ref: #71
