### PR TITLE
smite-ir: Introduce affine state variables for strict state enforcement

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -71,6 +71,27 @@ impl ProgramBuilder {
                 actual_type, expected_type,
                 "{operation:?} input {i}: expected {expected_type:?}, got {actual_type:?}",
             );
+            if actual_type.is_affine() {
+                let cands = self.candidates.get_mut(&actual_type).unwrap_or_else(|| {
+                    panic!("{operation:?} input {i}: no candidates for {actual_type:?}")
+                });
+
+                // Find the position, or panic if it doesn't exist.
+                let pos = cands
+                    .iter()
+                    .position(|c| match c {
+                        Candidate::Direct(idx) => *idx == input_idx,
+                        Candidate::Extract { .. } => {
+                            panic!("extractable affine variable in candidate list")
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        panic!("{operation:?} input {i}: affine {actual_type:?} already consumed")
+                    });
+
+                // Consume it.
+                cands.remove(pos);
+            }
         }
 
         let idx = self.instructions.len();
@@ -78,6 +99,11 @@ impl ProgramBuilder {
         if let Some(out_type) = operation.output_type() {
             // Register extractable fields for compound types.
             for (extract_op, field_type) in operation.extractable_fields() {
+                assert!(
+                    !field_type.is_affine(),
+                    "affine variables cannot be extracted"
+                );
+                assert!(!out_type.is_affine(), "compound variables cannot be affine");
                 self.candidates
                     .entry(field_type)
                     .or_default()
@@ -103,11 +129,30 @@ impl ProgramBuilder {
 
     /// Selects or creates a variable of the given type using probabilistic
     /// variable selection (75% most recent, 15% any existing, 10% fresh).
-    #[allow(clippy::missing_panics_doc)] // candidates is always non-empty
+    /// For affine variables the most recent candidate is always selected.
+    ///
+    /// # Panics
+    ///
+    /// Panics in the following scenarios:
+    /// * An affine type is requested but its candidate pool is empty (all
+    ///   instances have been consumed).
+    /// * Attempts to generate a fresh variable for a type that cannot be
+    ///   instantiated out-of-thin-air (e.g., `Message`, `AcceptChannel`,
+    ///   or affine types).
+    /// * Resolving the chosen candidate triggers a panic in the underlying
+    ///   `append` operation.
     pub fn pick_variable(&mut self, var_type: VariableType, rng: &mut impl Rng) -> usize {
         let Some(candidates) = self.candidates.get(&var_type) else {
             return self.generate_fresh(var_type, rng);
         };
+
+        if var_type.is_affine() {
+            let chosen_candidate = candidates
+                .last()
+                .unwrap_or_else(|| panic!("no candidates for {var_type:?}"))
+                .clone();
+            return self.resolve_candidate(chosen_candidate);
+        }
 
         let roll = rng.random_range(0..20);
         match roll {
@@ -176,6 +221,9 @@ impl ProgramBuilder {
             }
             VariableType::FundingTransaction => {
                 panic!("cannot generate fresh FundingTransaction: requires composed inputs")
+            }
+            VariableType::SentOpenChannel => {
+                panic!("cannot generate fresh SentOpenChannel: affine type")
             }
         }
     }

--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -216,6 +216,9 @@ impl ProgramBuilder {
             VariableType::Message => {
                 panic!("cannot generate fresh Message: requires composed inputs")
             }
+            VariableType::OpenChannelMessage => {
+                panic!("cannot generate fresh OpenChannelMessage: requires composed inputs")
+            }
             VariableType::AcceptChannel => {
                 panic!("cannot generate fresh AcceptChannel: requires protocol interaction")
             }

--- a/smite-ir/src/generators/open_channel.rs
+++ b/smite-ir/src/generators/open_channel.rs
@@ -48,7 +48,7 @@ impl Generator for OpenChannelGenerator {
         let channel_type = builder.append(Operation::LoadChannelType(variant), &[]);
 
         // Build and send open_channel.
-        let msg = builder.append(
+        let open_channel_msg = builder.append(
             Operation::BuildOpenChannel,
             &[
                 chain_hash,
@@ -73,9 +73,9 @@ impl Generator for OpenChannelGenerator {
                 channel_type,
             ],
         );
-        builder.append(Operation::SendMessage, &[msg]);
+        let sent_open_channel = builder.append(Operation::SendOpenChannel, &[open_channel_msg]);
 
         // Receive accept_channel.
-        builder.append(Operation::RecvAcceptChannel, &[]);
+        builder.append(Operation::RecvAcceptChannel, &[sent_open_channel]);
     }
 }

--- a/smite-ir/src/mutators/input_swap.rs
+++ b/smite-ir/src/mutators/input_swap.rs
@@ -19,7 +19,16 @@ impl Mutator for InputSwapMutator {
             .instructions
             .iter()
             .enumerate()
-            .flat_map(|(i, instr)| (0..instr.inputs.len()).map(move |j| (i, j)))
+            .flat_map(|(i, instr)| {
+                instr
+                    .operation
+                    .input_types()
+                    .into_iter()
+                    .enumerate()
+                    // Affine variables carry no data, so swapping one affine variable with
+                    // another has no practical effect.
+                    .filter_map(move |(j, ty)| (!ty.is_affine()).then_some((i, j)))
+            })
             .choose(rng)
         else {
             return false;

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -103,6 +103,7 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::BuildOpenChannel
         | Operation::BuildChannelAnnouncement
         | Operation::SendMessage
+        | Operation::SendOpenChannel
         | Operation::RecvAcceptChannel
         | Operation::BroadcastTransaction => {
             unreachable!("is_param_mutable returned true for {op:?}")

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -141,6 +141,10 @@ pub enum Operation {
     /// Send an encoded message over the connection.
     /// Input: `Message`.
     SendMessage,
+    /// Send an `open_channel` message over the connection.
+    /// Produces a `SentOpenChannel` variable.
+    /// Input: `OpenChannelMessage`.
+    SendOpenChannel,
     /// Receive and parse an `accept_channel` response.
     /// Produces an `AcceptChannel` compound variable.
     RecvAcceptChannel,
@@ -594,6 +598,7 @@ impl fmt::Display for Operation {
                 format_hex(alias),
             ),
             Self::SendMessage => write!(f, "SendMessage"),
+            Self::SendOpenChannel => write!(f, "SendOpenChannel"),
         }
     }
 }
@@ -625,6 +630,7 @@ impl Operation {
                 Some(VariableType::Message)
             }
             Self::SendMessage | Self::MineBlocks(_) | Self::BroadcastTransaction => None,
+            Self::SendOpenChannel => Some(VariableType::SentOpenChannel),
             Self::RecvAcceptChannel => Some(VariableType::AcceptChannel),
         }
     }
@@ -649,8 +655,7 @@ impl Operation {
             | Self::LoadChannelType(_)
             | Self::LoadTargetPubkeyFromContext
             | Self::LoadChainHashFromContext
-            | Self::MineBlocks(_)
-            | Self::RecvAcceptChannel => vec![],
+            | Self::MineBlocks(_) => vec![],
 
             Self::DerivePoint => vec![VariableType::PrivateKey],
             Self::ExtractAcceptChannel(_) => vec![VariableType::AcceptChannel],
@@ -661,6 +666,8 @@ impl Operation {
                 VariableType::FeeratePerKw, // feerate_per_kw
             ],
             Self::SendMessage => vec![VariableType::Message],
+            Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
+            Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
             Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
 
             Self::BuildOpenChannel => vec![
@@ -736,6 +743,7 @@ impl Operation {
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::SendMessage
+            | Self::SendOpenChannel
             | Self::MineBlocks(_)
             | Self::BroadcastTransaction => vec![],
 
@@ -776,6 +784,7 @@ impl Operation {
             | Self::BuildOpenChannel
             | Self::BuildChannelAnnouncement
             | Self::SendMessage
+            | Self::SendOpenChannel
             | Self::RecvAcceptChannel
             | Self::BroadcastTransaction => false,
         }

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -620,9 +620,10 @@ impl Operation {
             Self::LoadChainHashFromContext => Some(VariableType::ChainHash),
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
-            Self::BuildOpenChannel
-            | Self::BuildChannelAnnouncement
-            | Self::BuildNodeAnnouncement { .. } => Some(VariableType::Message),
+            Self::BuildOpenChannel => Some(VariableType::OpenChannelMessage),
+            Self::BuildChannelAnnouncement | Self::BuildNodeAnnouncement { .. } => {
+                Some(VariableType::Message)
+            }
             Self::SendMessage | Self::MineBlocks(_) | Self::BroadcastTransaction => None,
             Self::RecvAcceptChannel => Some(VariableType::AcceptChannel),
         }

--- a/smite-ir/src/program.rs
+++ b/smite-ir/src/program.rs
@@ -85,6 +85,14 @@ pub enum ValidateError {
         /// Actual byte length.
         len: usize,
     },
+    /// An affine variable is used more than once.
+    #[error("Variable {index}: affine {var_type:?} consumed twice (max 1)")]
+    AffineOverUse {
+        /// The overused affine variable index.
+        index: usize,
+        /// Type of the affine variable.
+        var_type: VariableType,
+    },
 }
 
 impl Program {
@@ -101,6 +109,8 @@ impl Program {
     ///
     /// Returns the first violation encountered.
     pub fn validate(&self) -> Result<(), ValidateError> {
+        let mut affine_consumed = vec![false; self.instructions.len()];
+
         for (instr_idx, instr) in self.instructions.iter().enumerate() {
             let expected = instr.operation.input_types();
             if instr.inputs.len() != expected.len() {
@@ -134,6 +144,15 @@ impl Program {
                         expected: expected_type,
                         got: actual_type,
                     });
+                }
+                if expected_type.is_affine() {
+                    if affine_consumed[input_idx] {
+                        return Err(ValidateError::AffineOverUse {
+                            index: input_idx,
+                            var_type: expected_type,
+                        });
+                    }
+                    affine_consumed[input_idx] = true;
                 }
             }
             if let Operation::LoadBytes(b) | Operation::LoadFeatures(b) = &instr.operation

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1096,6 +1096,39 @@ fn pick_variable_reuses_existing() {
 }
 
 #[test]
+fn pick_variable_uses_unspent_affine() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+
+    let msg_idx = builder.pick_variable(VariableType::OpenChannelMessage, &mut rng);
+    let unspent_sent_open_channel = builder.append(Operation::SendOpenChannel, &[msg_idx]);
+
+    // pick_variable should prefer an unspent affine variable.
+    let idx = builder.pick_variable(VariableType::SentOpenChannel, &mut rng);
+    assert_eq!(idx, unspent_sent_open_channel);
+}
+
+#[test]
+#[should_panic(expected = "cannot generate fresh SentOpenChannel: affine type")]
+fn pick_variable_panics_on_empty_affine() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    builder.pick_variable(VariableType::SentOpenChannel, &mut rng);
+}
+
+#[test]
+#[should_panic(expected = "no candidates for SentOpenChannel")]
+fn pick_variable_panics_on_all_affine_consumed() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+
+    // All `SentOpenChannel` have been already consumed.
+    builder.pick_variable(VariableType::SentOpenChannel, &mut rng);
+}
+
+#[test]
 #[should_panic(expected = "cannot generate fresh Message")]
 fn generate_fresh_message_panics() {
     let mut rng = SmallRng::seed_from_u64(0);
@@ -1117,6 +1150,14 @@ fn generate_fresh_funding_transaction_panics() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
     builder.generate_fresh(VariableType::FundingTransaction, &mut rng);
+}
+
+#[test]
+#[should_panic(expected = "cannot generate fresh SentOpenChannel: affine type")]
+fn generate_fresh_sent_open_channel_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    builder.generate_fresh(VariableType::SentOpenChannel, &mut rng);
 }
 
 #[test]
@@ -1163,6 +1204,20 @@ fn append_type_mismatch_panics() {
     let mut builder = ProgramBuilder::new();
     let amount = builder.generate_fresh(VariableType::Amount, &mut rng);
     builder.append(Operation::DerivePoint, &[amount]);
+}
+
+#[test]
+#[should_panic(expected = "RecvAcceptChannel input 0: affine SentOpenChannel already consumed")]
+fn append_rejects_affine_overuse() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    OpenChannelGenerator.generate(&mut builder, &mut rng);
+
+    let msg_idx = builder.pick_variable(VariableType::OpenChannelMessage, &mut rng);
+    let sent_open_channel = builder.append(Operation::SendOpenChannel, &[msg_idx]);
+    // Add consecutive `RecvAcceptChannel`s.
+    builder.append(Operation::RecvAcceptChannel, &[sent_open_channel]);
+    builder.append(Operation::RecvAcceptChannel, &[sent_open_channel]);
 }
 
 // -- Program::validate tests --
@@ -1373,6 +1428,34 @@ fn validate_rejects_oversized_features() {
             instr: 0,
             len: MAX_MESSAGE_SIZE + 1,
         }),
+    );
+}
+
+#[test]
+fn validate_accepts_unused_affine() {
+    let mut program = generate_open_channel_program(0);
+    // Remove the `RecvAcceptChannel` instruction at the end.
+    program.instructions.pop();
+
+    // Validation should pass despite the unspent `SentOpenChannel`.
+    assert_eq!(program.validate(), Ok(()));
+}
+
+#[test]
+fn validate_rejects_affine_overuse() {
+    let mut program = generate_open_channel_program(0);
+    let sent_open_channel = program.instructions.len() - 2;
+    // Add another `RecvAcceptChannel` in addition to the existing one.
+    program.instructions.push(Instruction {
+        operation: Operation::RecvAcceptChannel,
+        inputs: vec![sent_open_channel],
+    });
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::AffineOverUse {
+            index: sent_open_channel,
+            var_type: VariableType::SentOpenChannel,
+        })
     );
 }
 

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -956,10 +956,10 @@ fn generated_open_channel_program_structure() {
     let program = generate_open_channel_program(0);
     let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
 
-    // Must end with SendMessage, RecvAcceptChannel.
+    // Must end with SendOpenChannel, RecvAcceptChannel.
     assert!(
-        matches!(ops[ops.len() - 2], Operation::SendMessage),
-        "second-to-last instruction should be SendMessage",
+        matches!(ops[ops.len() - 2], Operation::SendOpenChannel),
+        "second-to-last instruction should be SendOpenChannel",
     );
     assert!(
         matches!(ops[ops.len() - 1], Operation::RecvAcceptChannel),

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1675,3 +1675,37 @@ fn input_swap_preserves_types() {
         }
     }
 }
+
+#[test]
+fn input_swap_preserves_affine() {
+    let mut program = generate_open_channel_program(0);
+    // Get rid of the last instruction in the program: `RecvAcceptChannel`.
+    program.instructions.pop();
+    // `BuildOpenChannel` is the second-to-last, while `SendOpenChannel`
+    // is the last instruction in the program now.
+    let open_channel_msg = program.instructions.len() - 2;
+    let send_open_channel_1 = program.instructions.len() - 1;
+
+    program.instructions.extend([
+        Instruction {
+            operation: Operation::SendOpenChannel,
+            inputs: vec![open_channel_msg],
+        },
+        Instruction {
+            operation: Operation::RecvAcceptChannel,
+            inputs: vec![send_open_channel_1],
+        },
+    ]);
+    let accept_channel = program.instructions.len() - 1;
+
+    let mutator = InputSwapMutator;
+    let mut rng = SmallRng::seed_from_u64(0);
+    for _ in 0..100 {
+        mutator.mutate(&mut program, &mut rng);
+        // Ensure `RecvAcceptChannel`'s input never changed to the inserted `SentOpenChannel`.
+        assert_eq!(
+            send_open_channel_1,
+            program.instructions[accept_channel].inputs[0]
+        );
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1138,10 +1138,10 @@ fn append_out_of_bounds_panics() {
 fn append_void_reference_panics() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
-    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    NodeAnnouncementGenerator.generate(&mut builder, &mut rng);
     let program = builder.build();
-    // SendMessage is second-to-last and has void output.
-    let send_idx = program.instructions.len() - 2;
+    // SendMessage is last and has void output.
+    let send_idx = program.instructions.len() - 1;
     assert!(
         program.instructions[send_idx]
             .operation
@@ -1152,7 +1152,7 @@ fn append_void_reference_panics() {
     // Rebuild the same program and try to reference the void instruction.
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
-    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    NodeAnnouncementGenerator.generate(&mut builder, &mut rng);
     builder.append(Operation::SendMessage, &[send_idx]);
 }
 
@@ -1280,17 +1280,14 @@ fn validate_rejects_self_reference() {
 
 #[test]
 fn validate_rejects_void_input() {
-    // Build a valid program, then append a DerivePoint that references the void
-    // SendMessage instruction emitted by the generator.
+    // Build a valid program, then append a DerivePoint that references
+    // the void output emitted by SendMessage.
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
-    OpenChannelGenerator.generate(&mut builder, &mut rng);
+    NodeAnnouncementGenerator.generate(&mut builder, &mut rng);
     let mut program = builder.build();
-    let send_idx = program
-        .instructions
-        .iter()
-        .position(|i| matches!(i.operation, Operation::SendMessage))
-        .expect("generator emits SendMessage");
+    // SendMessage is the last instruction in the program.
+    let send_idx = program.instructions.len() - 1;
     program.instructions.push(Instruction {
         operation: Operation::DerivePoint,
         inputs: vec![send_idx],

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -50,6 +50,10 @@ pub enum Variable {
     AcceptChannel(AcceptChannel),
     /// Constructed funding transaction with funding output index.
     FundingTransaction(FundingTransaction),
+
+    // Affine (single-use) variables
+    /// `open_channel` has been sent, so `accept_channel` may now be received.
+    SentOpenChannel,
 }
 
 impl Variable {
@@ -74,6 +78,7 @@ impl Variable {
             Self::Message(_) => VariableType::Message,
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
             Self::FundingTransaction(_) => VariableType::FundingTransaction,
+            Self::SentOpenChannel => VariableType::SentOpenChannel,
         }
     }
 }
@@ -99,4 +104,32 @@ pub enum VariableType {
     Message,
     AcceptChannel,
     FundingTransaction,
+    SentOpenChannel,
+}
+
+impl VariableType {
+    #[must_use]
+    pub fn is_affine(&self) -> bool {
+        match self {
+            Self::SentOpenChannel => true,
+
+            Self::Bytes
+            | Self::ChainHash
+            | Self::ChannelId
+            | Self::Point
+            | Self::PrivateKey
+            | Self::Amount
+            | Self::FeeratePerKw
+            | Self::BlockHeight
+            | Self::Timestamp
+            | Self::ForwardingFee
+            | Self::U16
+            | Self::U8
+            | Self::Features
+            | Self::Message
+            | Self::AcceptChannel
+            | Self::ShortChannelId
+            | Self::FundingTransaction => false,
+        }
+    }
 }

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -46,6 +46,8 @@ pub enum Variable {
     Features(Vec<u8>),
     /// Encoded BOLT message with type prefix, ready to send.
     Message(Vec<u8>),
+    /// Encoded BOLT `open_channel` message with type 32 prefix, ready to send.
+    OpenChannelMessage(Vec<u8>),
     /// Parsed `accept_channel` response.
     AcceptChannel(AcceptChannel),
     /// Constructed funding transaction with funding output index.
@@ -76,6 +78,7 @@ impl Variable {
             Self::U8(_) => VariableType::U8,
             Self::Features(_) => VariableType::Features,
             Self::Message(_) => VariableType::Message,
+            Self::OpenChannelMessage(_) => VariableType::OpenChannelMessage,
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
             Self::FundingTransaction(_) => VariableType::FundingTransaction,
             Self::SentOpenChannel => VariableType::SentOpenChannel,
@@ -102,6 +105,7 @@ pub enum VariableType {
     U8,
     Features,
     Message,
+    OpenChannelMessage,
     AcceptChannel,
     FundingTransaction,
     SentOpenChannel,
@@ -127,6 +131,7 @@ impl VariableType {
             | Self::U8
             | Self::Features
             | Self::Message
+            | Self::OpenChannelMessage
             | Self::AcceptChannel
             | Self::ShortChannelId
             | Self::FundingTransaction => false,

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -1693,6 +1693,71 @@ mod tests {
         assert!(matches!(err, ExecuteError::InvalidPrivateKey));
     }
 
+    #[test]
+    fn execute_send_open_channel_wrong_type() {
+        let instrs = vec![
+            Instruction {
+                operation: Operation::LoadAmount(42),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::SendOpenChannel,
+                inputs: vec![0],
+            },
+        ];
+
+        let program = Program {
+            instructions: instrs,
+        };
+
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut MockConnection::new(),
+            &mut MockBitcoinCli::default(),
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ExecuteError::TypeMismatch {
+                expected: VariableType::OpenChannelMessage,
+                got: VariableType::Amount,
+            }
+        ));
+    }
+
+    #[test]
+    fn execute_affine_overuse() {
+        let mut instrs = send_open_channel_instructions();
+        let sent_open_channel = instrs.len() - 1;
+        instrs.extend([
+            Instruction {
+                operation: Operation::RecvAcceptChannel,
+                inputs: vec![sent_open_channel],
+            },
+            Instruction {
+                operation: Operation::RecvAcceptChannel,
+                inputs: vec![sent_open_channel],
+            },
+        ]);
+        let program = Program {
+            instructions: instrs,
+        };
+        let mut conn = MockConnection::new();
+        let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
+        conn.queue_recv(ac_bytes);
+        let err = execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            &mut MockBitcoinCli::default(),
+            std::time::Instant::now(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ExecuteError::AffineOverUse { index } if index == sent_open_channel));
+    }
+
     // -- extract_field tests --
 
     // TODO: Once we can actually construct and send accept_channel messages, it

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -117,6 +117,10 @@ pub enum ExecuteError {
     #[error("invalid private key")]
     InvalidPrivateKey,
 
+    /// An affine variable is consumed more than once.
+    #[error("affine variable {index} consumed more than once")]
+    AffineOverUse { index: usize },
+
     /// Connection or send/receive failure.
     #[error("connection: {0}")]
     Connection(#[from] smite::noise::ConnectionError),
@@ -140,6 +144,7 @@ pub enum ExecuteError {
 ///
 /// Returns an error if any instruction fails (type mismatch, connection error,
 /// decode error, etc.).
+#[allow(clippy::too_many_lines)]
 pub fn execute(
     program: &Program,
     context: &ProgramContext,
@@ -204,7 +209,7 @@ pub fn execute(
             Operation::BuildOpenChannel => {
                 let oc = build_open_channel(&variables, &instr.inputs)?;
                 let encoded = Message::OpenChannel(oc).encode();
-                Some(Variable::Message(encoded))
+                Some(Variable::OpenChannelMessage(encoded))
             }
 
             Operation::BuildChannelAnnouncement => {
@@ -232,7 +237,19 @@ pub fn execute(
                 None
             }
 
+            Operation::SendOpenChannel => {
+                let bytes = resolve_open_channel_message(&variables, instr.inputs[0])?;
+                log::debug!(
+                    "[{:?}] SendOpenChannel: {} bytes",
+                    start.elapsed(),
+                    bytes.len(),
+                );
+                conn.send_message(bytes)?;
+                Some(Variable::SentOpenChannel)
+            }
+
             Operation::RecvAcceptChannel => {
+                consume_sent_open_channel(&mut variables, instr.inputs[0])?;
                 log::debug!("[{:?}] RecvAcceptChannel: waiting", start.elapsed());
                 let ac = recv_accept_channel(conn)?;
                 log::debug!("[{:?}] RecvAcceptChannel: received", start.elapsed());
@@ -401,6 +418,17 @@ fn resolve_message(variables: &[Option<Variable>], index: usize) -> Result<&[u8]
     }
 }
 
+fn resolve_open_channel_message(
+    variables: &[Option<Variable>],
+    index: usize,
+) -> Result<&[u8], ExecuteError> {
+    let var = resolve(variables, index)?;
+    match var {
+        Variable::OpenChannelMessage(v) => Ok(v),
+        _ => Err(type_err(VariableType::OpenChannelMessage, var)),
+    }
+}
+
 fn resolve_accept_channel(
     variables: &[Option<Variable>],
     index: usize,
@@ -420,6 +448,23 @@ fn resolve_funding_transaction(
     match var {
         Variable::FundingTransaction(v) => Ok(v),
         _ => Err(type_err(VariableType::FundingTransaction, var)),
+    }
+}
+
+fn consume_sent_open_channel(
+    variables: &mut [Option<Variable>],
+    index: usize,
+) -> Result<(), ExecuteError> {
+    match resolve(variables, index) {
+        Ok(Variable::SentOpenChannel) => {
+            // Consume the affine `SentOpenChannel`.
+            variables[index] = None;
+            Ok(())
+        }
+        Ok(wrong_var) => Err(type_err(VariableType::SentOpenChannel, wrong_var)),
+        // Map `VoidVariable` to `AffineOverUse`.
+        Err(ExecuteError::VoidVariable { index }) => Err(ExecuteError::AffineOverUse { index }),
+        Err(e) => Err(e),
     }
 }
 
@@ -914,6 +959,21 @@ mod tests {
         }
     }
 
+    fn send_open_channel_instructions() -> Vec<Instruction> {
+        let mut instructions = open_channel_instructions();
+        instructions.extend([
+            Instruction {
+                operation: Operation::BuildOpenChannel,
+                inputs: (0..20).collect(),
+            },
+            Instruction {
+                operation: Operation::SendOpenChannel,
+                inputs: vec![20],
+            },
+        ]);
+        instructions
+    }
+
     // -- execute() tests --
 
     #[test]
@@ -925,7 +985,7 @@ mod tests {
             inputs: (0..20).collect(),
         });
         instrs.push(Instruction {
-            operation: Operation::SendMessage,
+            operation: Operation::SendOpenChannel,
             inputs: vec![20],
         });
 
@@ -1134,7 +1194,7 @@ mod tests {
             inputs: (0..20).collect(),
         });
         instrs.push(Instruction {
-            operation: Operation::SendMessage,
+            operation: Operation::SendOpenChannel,
             inputs: vec![20],
         });
 
@@ -1184,7 +1244,7 @@ mod tests {
             inputs: build_inputs,
         });
         instrs.push(Instruction {
-            operation: Operation::SendMessage,
+            operation: Operation::SendOpenChannel,
             inputs: vec![base + 20],
         });
 
@@ -1233,14 +1293,17 @@ mod tests {
             AcceptChannelField::ChannelType,
         ];
 
-        let mut instrs = vec![Instruction {
+        let mut instrs = send_open_channel_instructions();
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
             operation: Operation::RecvAcceptChannel,
-            inputs: vec![],
-        }];
+            inputs: vec![sent_open_channel],
+        });
+        let accept_channel_idx = instrs.len() - 1;
         for field in fields {
             instrs.push(Instruction {
                 operation: Operation::ExtractAcceptChannel(field),
-                inputs: vec![0],
+                inputs: vec![accept_channel_idx],
             });
         }
 
@@ -1267,10 +1330,12 @@ mod tests {
     fn execute_recv_unexpected_message() {
         let init_bytes = Message::Init(Init::empty()).encode();
 
-        let instrs = vec![Instruction {
+        let mut instrs = send_open_channel_instructions();
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
             operation: Operation::RecvAcceptChannel,
-            inputs: vec![],
-        }];
+            inputs: vec![sent_open_channel],
+        });
 
         let program = Program {
             instructions: instrs,
@@ -1304,10 +1369,12 @@ mod tests {
         let ping_bytes = Message::Ping(ping).encode();
         let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
 
-        let instrs = vec![Instruction {
+        let mut instrs = send_open_channel_instructions();
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
             operation: Operation::RecvAcceptChannel,
-            inputs: vec![],
-        }];
+            inputs: vec![sent_open_channel],
+        });
 
         let program = Program {
             instructions: instrs,
@@ -1324,9 +1391,17 @@ mod tests {
         )
         .unwrap();
 
-        // Verify a correctly-sized pong was sent.
-        assert_eq!(conn.sent.len(), 1);
-        let pong = Message::decode(&conn.sent[0]).unwrap();
+        // Verify exactly two messages were sent: `open_channel` and `pong`.
+        assert_eq!(conn.sent.len(), 2);
+
+        // Verify the first message was `open_channel`.
+        let oc = Message::decode(&conn.sent[0]).unwrap();
+        let Message::OpenChannel(_) = oc else {
+            panic!("expected OpenChannel, got {:?}", oc.msg_type());
+        };
+
+        // Verify the second message was the pong.
+        let pong = Message::decode(&conn.sent[1]).unwrap();
         let Message::Pong(pong) = pong else {
             panic!("expected Pong, got {:?}", pong.msg_type());
         };
@@ -1398,7 +1473,7 @@ mod tests {
     #[test]
     fn execute_variable_out_of_bounds() {
         let instrs = vec![Instruction {
-            operation: Operation::SendMessage,
+            operation: Operation::SendOpenChannel,
             inputs: vec![99],
         }];
         let program = Program {
@@ -1446,23 +1521,19 @@ mod tests {
 
     #[test]
     fn execute_void_variable_reference() {
-        // SendMessage produces no output variable. Referencing it should fail.
-        let mut instrs = open_channel_instructions();
-        // v20 = Message
-        instrs.push(Instruction {
-            operation: Operation::BuildOpenChannel,
-            inputs: (0..20).collect(),
-        });
-        // v21 = void
-        instrs.push(Instruction {
-            operation: Operation::SendMessage,
-            inputs: vec![20],
-        });
-        // Try to use the void variable.
-        instrs.push(Instruction {
-            operation: Operation::SendMessage,
-            inputs: vec![21],
-        });
+        // MineBlocks produces no output variable. Referencing it should fail.
+        let instrs = vec![
+            // v0 = void
+            Instruction {
+                operation: Operation::MineBlocks(1),
+                inputs: vec![],
+            },
+            // Try to use the void variable.
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![0],
+            },
+        ];
 
         let program = Program {
             instructions: instrs,
@@ -1476,7 +1547,7 @@ mod tests {
             std::time::Instant::now(),
         )
         .unwrap_err();
-        assert!(matches!(err, ExecuteError::VoidVariable { index: 21 }));
+        assert!(matches!(err, ExecuteError::VoidVariable { index: 0 }));
     }
 
     // MineBlocks should track calls to mine_blocks


### PR DESCRIPTION
This PR introduces affine (single-use) types to the IR to strictly enforce the Lightning Network state machine during fuzzing, in order to prevent timeout hangs caused by semantically invalid mutation sequences.

Solves issue #75, see it for more details.