### PR TITLE
smite-ir: add `LoadFee` operation

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -141,6 +141,9 @@ impl ProgramBuilder {
             }
             VariableType::BlockHeight => self.append(Operation::LoadBlockHeight(rng.random()), &[]),
             VariableType::Timestamp => self.append(Operation::LoadTimestamp(rng.random()), &[]),
+            VariableType::ForwardingFee => {
+                self.append(Operation::LoadForwardingFee(rng.random()), &[])
+            }
             VariableType::U16 => self.append(Operation::LoadU16(rng.random()), &[]),
             VariableType::U8 => self.append(Operation::LoadU8(rng.random()), &[]),
             VariableType::Bytes => {

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -43,7 +43,8 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         }
         Operation::LoadFeeratePerKw(v)
         | Operation::LoadBlockHeight(v)
-        | Operation::LoadTimestamp(v) => {
+        | Operation::LoadTimestamp(v)
+        | Operation::LoadForwardingFee(v) => {
             *v = tweak_u32(*v, rng);
             true
         }

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -34,6 +34,9 @@ pub enum Operation {
     LoadBlockHeight(u32),
     /// Load a Unix timestamp in seconds.
     LoadTimestamp(u32),
+    /// Load a BOLT 7 `channel_update` fee parameter (`fee_base_msat` in
+    /// millisatoshi or `fee_proportional_millionths` in millionths).
+    LoadForwardingFee(u32),
     /// Load a u16 protocol parameter (e.g., `to_self_delay`).
     LoadU16(u16),
     /// Load a u8 protocol parameter (e.g., `channel_flags`).
@@ -551,6 +554,7 @@ impl fmt::Display for Operation {
             Self::LoadFeeratePerKw(v) => write!(f, "LoadFeeratePerKw({v})"),
             Self::LoadBlockHeight(v) => write!(f, "LoadBlockHeight({v})"),
             Self::LoadTimestamp(v) => write!(f, "LoadTimestamp({v})"),
+            Self::LoadForwardingFee(v) => write!(f, "LoadForwardingFee({v})"),
             Self::LoadU16(v) => write!(f, "LoadU16({v})"),
             Self::LoadU8(v) => write!(f, "LoadU8({v})"),
             Self::LoadBytes(b) => write!(f, "LoadBytes({})", format_hex(b)),
@@ -591,6 +595,7 @@ impl Operation {
             Self::LoadFeeratePerKw(_) => Some(VariableType::FeeratePerKw),
             Self::LoadBlockHeight(_) => Some(VariableType::BlockHeight),
             Self::LoadTimestamp(_) => Some(VariableType::Timestamp),
+            Self::LoadForwardingFee(_) => Some(VariableType::ForwardingFee),
             Self::LoadU16(_) => Some(VariableType::U16),
             Self::LoadU8(_) => Some(VariableType::U8),
             Self::LoadBytes(_) | Self::LoadShutdownScript(_) => Some(VariableType::Bytes),
@@ -618,6 +623,7 @@ impl Operation {
             | Self::LoadFeeratePerKw(_)
             | Self::LoadBlockHeight(_)
             | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)
@@ -687,6 +693,7 @@ impl Operation {
             | Self::LoadFeeratePerKw(_)
             | Self::LoadBlockHeight(_)
             | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)
@@ -723,6 +730,7 @@ impl Operation {
             | Self::LoadFeeratePerKw(_)
             | Self::LoadBlockHeight(_)
             | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -34,6 +34,9 @@ pub enum Variable {
     BlockHeight(u32),
     /// Unix timestamp in seconds.
     Timestamp(u32),
+    /// BOLT 7 `channel_update` fee (`fee_base_msat` in millisatoshi or
+    /// `fee_proportional_millionths` in millionths).
+    ForwardingFee(u32),
     /// Generic u16 protocol parameter (`to_self_delay`, `max_accepted_htlcs`,
     /// `cltv_expiry_delta`, etc.).
     U16(u16),
@@ -64,6 +67,7 @@ impl Variable {
             Self::FeeratePerKw(_) => VariableType::FeeratePerKw,
             Self::BlockHeight(_) => VariableType::BlockHeight,
             Self::Timestamp(_) => VariableType::Timestamp,
+            Self::ForwardingFee(_) => VariableType::ForwardingFee,
             Self::U16(_) => VariableType::U16,
             Self::U8(_) => VariableType::U8,
             Self::Features(_) => VariableType::Features,
@@ -88,6 +92,7 @@ pub enum VariableType {
     FeeratePerKw,
     BlockHeight,
     Timestamp,
+    ForwardingFee,
     U16,
     U8,
     Features,

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -169,6 +169,7 @@ pub fn execute(
             Operation::LoadFeeratePerKw(v) => Some(Variable::FeeratePerKw(*v)),
             Operation::LoadBlockHeight(v) => Some(Variable::BlockHeight(*v)),
             Operation::LoadTimestamp(v) => Some(Variable::Timestamp(*v)),
+            Operation::LoadForwardingFee(v) => Some(Variable::ForwardingFee(*v)),
             Operation::LoadU16(v) => Some(Variable::U16(*v)),
             Operation::LoadU8(v) => Some(Variable::U8(*v)),
             Operation::LoadBytes(b) => Some(Variable::Bytes(b.clone())),


### PR DESCRIPTION
Fees are needed for BOLT 7 `channel_update` messages (`fee_base_msat` and `fee_proportional_millionths`).

A fee parameter carries a u32 millisatoshi or millionths value, distinct from the existing `Amount` type which holds u64 satoshis.

Part of #71.