### PR TITLE
smite-ir: add BroadcastTransaction IR operation

### DIFF
--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -97,7 +97,8 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::LoadChainHashFromContext
         | Operation::BuildOpenChannel
         | Operation::SendMessage
-        | Operation::RecvAcceptChannel => {
+        | Operation::RecvAcceptChannel
+        | Operation::BroadcastTransaction => {
             unreachable!("is_param_mutable returned true for {op:?}")
         }
     }

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -126,6 +126,9 @@ pub enum Operation {
     RecvAcceptChannel,
     /// Mines the given number of blocks on the Bitcoin network.
     MineBlocks(u8),
+    /// Sign wallet inputs of the transaction and broadcast it via `bitcoin-cli`.
+    /// Input: `FundingTransaction`.
+    BroadcastTransaction,
 }
 
 /// A BOLT 2 compliant `upfront_shutdown_script` template.
@@ -553,6 +556,7 @@ impl fmt::Display for Operation {
             Self::LoadChainHashFromContext => write!(f, "LoadChainHashFromContext()"),
             Self::RecvAcceptChannel => write!(f, "RecvAcceptChannel()"),
             Self::MineBlocks(v) => write!(f, "MineBlocks({v})"),
+            Self::BroadcastTransaction => write!(f, "BroadcastTransaction"),
             // Operations with inputs: parens added by Program::Display.
             Self::DerivePoint => write!(f, "DerivePoint"),
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
@@ -592,7 +596,7 @@ impl Operation {
             Self::BuildOpenChannel | Self::BuildNodeAnnouncement { .. } => {
                 Some(VariableType::Message)
             }
-            Self::SendMessage | Self::MineBlocks(_) => None,
+            Self::SendMessage | Self::MineBlocks(_) | Self::BroadcastTransaction => None,
             Self::RecvAcceptChannel => Some(VariableType::AcceptChannel),
         }
     }
@@ -627,6 +631,7 @@ impl Operation {
                 VariableType::FeeratePerKw, // feerate_per_kw
             ],
             Self::SendMessage => vec![VariableType::Message],
+            Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
 
             Self::BuildOpenChannel => vec![
                 VariableType::ChainHash,    // chain_hash
@@ -688,7 +693,8 @@ impl Operation {
             | Self::BuildOpenChannel
             | Self::BuildNodeAnnouncement { .. }
             | Self::SendMessage
-            | Self::MineBlocks(_) => vec![],
+            | Self::MineBlocks(_)
+            | Self::BroadcastTransaction => vec![],
 
             Self::RecvAcceptChannel => AcceptChannelField::ALL
                 .iter()
@@ -724,7 +730,8 @@ impl Operation {
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
             | Self::SendMessage
-            | Self::RecvAcceptChannel => false,
+            | Self::RecvAcceptChannel
+            | Self::BroadcastTransaction => false,
         }
     }
 }

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -304,6 +304,10 @@ fn postcard_roundtrip() {
                 operation: Operation::CreateFundingTransaction,
                 inputs: vec![1, 8, 4, 9],
             },
+            Instruction {
+                operation: Operation::BroadcastTransaction,
+                inputs: vec![10],
+            },
         ],
     };
 
@@ -369,7 +373,7 @@ fn validate_rejects_mine_blocks_with_wrong_input() {
 }
 
 #[test]
-fn create_funding_transaction_operation() {
+fn create_and_broadcast_tx_operation() {
     let op = Operation::CreateFundingTransaction;
     assert_eq!(
         op.input_types(),
@@ -382,9 +386,14 @@ fn create_funding_transaction_operation() {
     );
     assert_eq!(op.output_type(), Some(VariableType::FundingTransaction));
     assert!(!op.is_param_mutable());
+
+    let op = Operation::BroadcastTransaction;
+    assert_eq!(op.input_types(), vec![VariableType::FundingTransaction]);
+    assert_eq!(op.output_type(), None);
+    assert!(!op.is_param_mutable());
 }
 
-fn create_funding_transaction_instructions() -> Vec<Instruction> {
+fn create_and_broadcast_tx_instructions() -> Vec<Instruction> {
     vec![
         Instruction {
             operation: Operation::LoadPrivateKey(key(1)),
@@ -414,13 +423,17 @@ fn create_funding_transaction_instructions() -> Vec<Instruction> {
             operation: Operation::CreateFundingTransaction,
             inputs: vec![1, 3, 4, 5],
         },
+        Instruction {
+            operation: Operation::BroadcastTransaction,
+            inputs: vec![6],
+        },
     ]
 }
 
 #[test]
-fn displays_create_funding_transaction_program() {
+fn displays_create_and_broadcast_tx_program() {
     let program = Program {
-        instructions: create_funding_transaction_instructions(),
+        instructions: create_and_broadcast_tx_instructions(),
     };
     let text = program.to_string();
     let lines: Vec<&str> = text.lines().collect();
@@ -435,18 +448,19 @@ fn displays_create_funding_transaction_program() {
         "v4 = LoadAmount(10000000)".into(),
         "v5 = LoadFeeratePerKw(15000)".into(),
         "v6 = CreateFundingTransaction(v1, v3, v4, v5)".into(),
+        "BroadcastTransaction(v6)".into(),
     ];
     assert_eq!(lines, expected);
 }
 
 #[test]
-fn validate_accepts_create_funding_transaction() {
+fn validate_accepts_create_and_broadcast_tx() {
     let program = Program {
-        instructions: create_funding_transaction_instructions(),
+        instructions: create_and_broadcast_tx_instructions(),
     };
     program
         .validate()
-        .expect("CreateFundingTransaction should validate");
+        .expect("CreateFundingTransaction and BroadcastTransaction should validate");
 }
 
 #[test]
@@ -471,8 +485,12 @@ fn create_funding_transaction_with_wrong_input(input: usize, wrong: Operation) -
     // We will take the correct set of instructions for creating the funding
     // transaction, and then at given input position insert an invalid input
     // type that `CreateFundingTransaction` does not expect.
-    let mut instructions = create_funding_transaction_instructions();
-    let producer = instructions.last().unwrap().inputs[input];
+    let mut instructions = create_and_broadcast_tx_instructions();
+    let producer = instructions
+        .iter()
+        .find(|i| matches!(i.operation, Operation::CreateFundingTransaction))
+        .unwrap()
+        .inputs[input];
     instructions[producer] = Instruction {
         operation: wrong,
         inputs: vec![],
@@ -532,6 +550,49 @@ fn validate_rejects_create_funding_transaction_with_wrong_feerate_per_kw() {
             instr: 6,
             input: 3,
             expected: VariableType::FeeratePerKw,
+            got: VariableType::Amount,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_broadcast_tx_with_wrong_input_count() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::BroadcastTransaction,
+            inputs: vec![],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::WrongInputCount {
+            instr: 0,
+            expected: 1,
+            got: 0,
+        }),
+    );
+}
+
+#[test]
+fn validate_rejects_broadcast_tx_with_wrong_input_type() {
+    let program = Program {
+        instructions: vec![
+            Instruction {
+                operation: Operation::LoadAmount(100_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::BroadcastTransaction,
+                inputs: vec![0],
+            },
+        ],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::TypeMismatch {
+            instr: 1,
+            input: 0,
+            expected: VariableType::FundingTransaction,
             got: VariableType::Amount,
         }),
     );

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -26,6 +26,9 @@ pub trait BitcoinRpc {
 
     /// Returns the scriptPubKey for a newly generated wallet address.
     fn get_new_address_script_pubkey(&mut self) -> ScriptBuf;
+
+    /// Signs and broadcasts a transaction
+    fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction);
 }
 
 impl BitcoinRpc for BitcoinCli {
@@ -39,6 +42,10 @@ impl BitcoinRpc for BitcoinCli {
 
     fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
         BitcoinCli::get_new_address_script_pubkey(self)
+    }
+
+    fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) {
+        BitcoinCli::sign_and_broadcast_tx(self, tx);
     }
 }
 
@@ -227,6 +234,17 @@ pub fn execute(
                 log::debug!("[{:?}] MineBlocks: mined {} block(s)", start.elapsed(), v);
                 None
             }
+
+            Operation::BroadcastTransaction => {
+                let ft = resolve_funding_transaction(&variables, instr.inputs[0])?;
+                log::debug!(
+                    "[{:?}] BroadcastTransaction: txid={}",
+                    start.elapsed(),
+                    ft.tx.compute_txid(),
+                );
+                bitcoin_cli.sign_and_broadcast_tx(&ft.tx);
+                None
+            }
         };
 
         variables.push(result);
@@ -370,6 +388,17 @@ fn resolve_accept_channel(
     match var {
         Variable::AcceptChannel(v) => Ok(v),
         _ => Err(type_err(VariableType::AcceptChannel, var)),
+    }
+}
+
+fn resolve_funding_transaction(
+    variables: &[Option<Variable>],
+    index: usize,
+) -> Result<&FundingTransaction, ExecuteError> {
+    let var = resolve(variables, index)?;
+    match var {
+        Variable::FundingTransaction(v) => Ok(v),
+        _ => Err(type_err(VariableType::FundingTransaction, var)),
     }
 }
 
@@ -548,7 +577,7 @@ mod tests {
 
     use super::*;
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
-    use bitcoin::{Amount, OutPoint};
+    use bitcoin::{Amount, OutPoint, Transaction};
     use smite::bolt::{AcceptChannelTlvs, Init, Ping};
     use smite_ir::Instruction;
 
@@ -590,6 +619,7 @@ mod tests {
     #[derive(Default)]
     struct MockBitcoinCli {
         mine_blocks_calls: Vec<u8>,
+        broadcast_calls: Vec<Transaction>,
         utxos: Vec<Utxo>,
         change_spk: ScriptBuf,
     }
@@ -605,6 +635,10 @@ mod tests {
 
         fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
             self.change_spk.clone()
+        }
+
+        fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) {
+            self.broadcast_calls.push(tx.clone());
         }
     }
 
@@ -759,7 +793,7 @@ mod tests {
         ]
     }
 
-    fn create_funding_transaction_instructions() -> Vec<Instruction> {
+    fn create_and_broadcast_tx_instructions() -> Vec<Instruction> {
         let opener_privkey =
             SecretKey::from_str("30ff4956bbdd3222d44cc5e8a1261dab1e07957bdac5ae88fe3261ef321f3749")
                 .unwrap()
@@ -797,6 +831,10 @@ mod tests {
             Instruction {
                 operation: Operation::CreateFundingTransaction,
                 inputs: vec![1, 3, 4, 5],
+            },
+            Instruction {
+                operation: Operation::BroadcastTransaction,
+                inputs: vec![6],
             },
         ]
     }
@@ -1349,7 +1387,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_create_funding_transaction() {
+    fn execute_create_and_broadcast_tx() {
         let mut conn = MockConnection::new();
         let mut mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],
@@ -1358,19 +1396,21 @@ mod tests {
         };
         execute(
             &Program {
-                instructions: create_funding_transaction_instructions(),
+                instructions: create_and_broadcast_tx_instructions(),
             },
             &sample_context(),
             &mut conn,
             &mut mock_cli,
             std::time::Instant::now(),
         )
-        .expect("funding tx construction should succeed");
+        .expect("tx construction and broadcast should succeed");
 
-        // TODO: Once we have the `BroadcastTransaction` IR operation, we can
-        // add `broadcast_calls` to the `mock_cli` to retrieve the funding tx
-        // here and assert that it matches the expected tx constructed from the
-        // sample UTXO and change script pubkey.
+        assert_eq!(mock_cli.broadcast_calls.len(), 1);
+        let broadcast_tx = &mock_cli.broadcast_calls[0];
+        assert_eq!(
+            broadcast_tx.compute_txid().to_string(),
+            "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
+        );
     }
 
     #[test]
@@ -1388,7 +1428,7 @@ mod tests {
         };
         let err = execute(
             &Program {
-                instructions: create_funding_transaction_instructions(),
+                instructions: create_and_broadcast_tx_instructions(),
             },
             &sample_context(),
             &mut conn,


### PR DESCRIPTION
ref: https://github.com/morehouse/smite/pull/90#issuecomment-4532231730 and https://github.com/morehouse/smite/pull/90#issuecomment-4549524815

Depends-on: https://github.com/morehouse/smite/pull/90

This will be used to broadcast the transaction. Right now, we only take the funding transaction as input, but in the future, once we have more transaction types, we will likely move to accepting a generic transaction input and allow broadcasting at arbitrary points.

Currently, this will be used to broadcast the funding transaction after `funding_signed` is received (or possibly even before that), so that the targets can exchange `channel_ready` messages after some number of blocks are mined.