### PR TITLE
smite-ir: add CreateChannelConfig IR operation

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -177,6 +177,9 @@ impl ProgramBuilder {
             VariableType::FundingTransaction => {
                 panic!("cannot generate fresh FundingTransaction: requires composed inputs")
             }
+            VariableType::ChannelConfig => {
+                panic!("cannot generate fresh ChannelConfig: requires composed inputs")
+            }
         }
     }
 

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -98,6 +98,7 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         // match have drifted out of sync.
         Operation::DerivePoint
         | Operation::CreateFundingTransaction
+        | Operation::CreateChannelConfig
         | Operation::LoadTargetPubkeyFromContext
         | Operation::LoadChainHashFromContext
         | Operation::BuildOpenChannel

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -81,6 +81,26 @@ pub enum Operation {
     ///   2: `funding_satoshis` (`Amount`)
     ///   3: `feerate_per_kw` (`FeeratePerKw`)
     CreateFundingTransaction,
+    /// Create a static channel configuration capturing the funding details and
+    /// the channel parameters for both parties.
+    ///
+    /// Inputs (15):
+    ///   0: `funding_transaction` (`FundingTransaction`)
+    ///   1: `funding_satoshis` (`Amount`)
+    ///   2: `channel_type` (`Features`)
+    ///   3: `opener_funding_pubkey` (`Point`)
+    ///   4: `opener_payment_basepoint` (`Point`)
+    ///   5: `opener_revocation_basepoint` (`Point`)
+    ///   6: `opener_delayed_payment_basepoint` (`Point`)
+    ///   7: `opener_dust_limit_satoshis` (`Amount`)
+    ///   8: `opener_to_self_delay` (`U16`)
+    ///   9: `acceptor_funding_pubkey` (`Point`)
+    ///  10: `acceptor_payment_basepoint` (`Point`)
+    ///  11: `acceptor_revocation_basepoint` (`Point`)
+    ///  12: `acceptor_delayed_payment_basepoint` (`Point`)
+    ///  13: `acceptor_dust_limit_satoshis` (`Amount`)
+    ///  14: `acceptor_to_self_delay` (`U16`)
+    CreateChannelConfig,
 
     // -- Build: construct a BOLT message from inputs --
     /// Build an `open_channel` message (BOLT 2, type 32).
@@ -585,6 +605,7 @@ impl fmt::Display for Operation {
             Self::DerivePoint => write!(f, "DerivePoint"),
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
             Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
+            Self::CreateChannelConfig => write!(f, "CreateChannelConfig"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
             Self::BuildChannelAnnouncement => write!(f, "BuildChannelAnnouncement"),
             Self::BuildNodeAnnouncement { rgb_color, alias } => write!(
@@ -620,6 +641,7 @@ impl Operation {
             Self::LoadChainHashFromContext => Some(VariableType::ChainHash),
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
+            Self::CreateChannelConfig => Some(VariableType::ChannelConfig),
             Self::BuildOpenChannel
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. } => Some(VariableType::Message),
@@ -658,6 +680,23 @@ impl Operation {
                 VariableType::Point,        // acceptor_funding_pubkey
                 VariableType::Amount,       // funding_satoshis
                 VariableType::FeeratePerKw, // feerate_per_kw
+            ],
+            Self::CreateChannelConfig => vec![
+                VariableType::FundingTransaction, // funding_transaction
+                VariableType::Amount,             // funding_satoshis
+                VariableType::Features,           // channel_type
+                VariableType::Point,              // opener_funding_pubkey
+                VariableType::Point,              // opener_payment_basepoint
+                VariableType::Point,              // opener_revocation_basepoint
+                VariableType::Point,              // opener_delayed_payment_basepoint
+                VariableType::Amount,             // opener_dust_limit_satoshis
+                VariableType::U16,                // opener_to_self_delay
+                VariableType::Point,              // acceptor_funding_pubkey
+                VariableType::Point,              // acceptor_payment_basepoint
+                VariableType::Point,              // acceptor_revocation_basepoint
+                VariableType::Point,              // acceptor_delayed_payment_basepoint
+                VariableType::Amount,             // acceptor_dust_limit_satoshis
+                VariableType::U16,                // acceptor_to_self_delay
             ],
             Self::SendMessage => vec![VariableType::Message],
             Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
@@ -731,6 +770,7 @@ impl Operation {
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
             | Self::CreateFundingTransaction
+            | Self::CreateChannelConfig
             | Self::BuildOpenChannel
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
@@ -772,6 +812,7 @@ impl Operation {
             | Self::LoadChainHashFromContext
             | Self::DerivePoint
             | Self::CreateFundingTransaction
+            | Self::CreateChannelConfig
             | Self::BuildOpenChannel
             | Self::BuildChannelAnnouncement
             | Self::SendMessage

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -378,6 +378,14 @@ fn postcard_roundtrip() {
                 operation: Operation::BroadcastTransaction,
                 inputs: vec![10],
             },
+            Instruction {
+                operation: Operation::LoadU16(144),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::CreateChannelConfig,
+                inputs: vec![10, 4, 5, 1, 1, 1, 1, 4, 12, 1, 1, 1, 1, 4, 12],
+            },
         ],
     };
 
@@ -664,6 +672,120 @@ fn validate_rejects_broadcast_tx_with_wrong_input_type() {
             input: 0,
             expected: VariableType::FundingTransaction,
             got: VariableType::Amount,
+        }),
+    );
+}
+
+fn create_channel_config_instructions() -> Vec<Instruction> {
+    vec![
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(1)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![0],
+        },
+        Instruction {
+            operation: Operation::LoadAmount(10_000_000),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadFeeratePerKw(15_000),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::CreateFundingTransaction,
+            inputs: vec![1, 1, 2, 3],
+        },
+        Instruction {
+            operation: Operation::LoadFeatures(vec![0x01, 0x02]),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(2)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![6],
+        },
+        Instruction {
+            operation: Operation::LoadAmount(546),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadU16(144),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(3)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![10],
+        },
+        Instruction {
+            operation: Operation::CreateChannelConfig,
+            inputs: vec![4, 2, 5, 7, 7, 7, 7, 8, 9, 11, 11, 11, 11, 8, 9],
+        },
+    ]
+}
+
+#[test]
+fn displays_create_channel_config_program() {
+    let program = Program {
+        instructions: create_channel_config_instructions(),
+    };
+    let text = program.to_string();
+    let lines: Vec<&str> = text.lines().collect();
+
+    let z31 = "00".repeat(31);
+
+    let expected = vec![
+        format!("v0 = LoadPrivateKey(0x{z31}01)"),
+        "v1 = DerivePoint(v0)".into(),
+        "v2 = LoadAmount(10000000)".into(),
+        "v3 = LoadFeeratePerKw(15000)".into(),
+        "v4 = CreateFundingTransaction(v1, v1, v2, v3)".into(),
+        "v5 = LoadFeatures(0x0102)".into(),
+        format!("v6 = LoadPrivateKey(0x{z31}02)"),
+        "v7 = DerivePoint(v6)".into(),
+        "v8 = LoadAmount(546)".into(),
+        "v9 = LoadU16(144)".into(),
+        format!("v10 = LoadPrivateKey(0x{z31}03)"),
+        "v11 = DerivePoint(v10)".into(),
+        "v12 = CreateChannelConfig(v4, v2, v5, v7, v7, v7, v7, v8, v9, v11, v11, v11, v11, v8, v9)"
+            .into(),
+    ];
+    assert_eq!(lines, expected);
+}
+
+#[test]
+fn validate_accepts_create_channel_config() {
+    let program = Program {
+        instructions: create_channel_config_instructions(),
+    };
+    program
+        .validate()
+        .expect("CreateChannelConfig should validate");
+}
+
+#[test]
+fn validate_rejects_create_channel_config_with_wrong_input_count() {
+    let program = Program {
+        instructions: vec![Instruction {
+            operation: Operation::CreateChannelConfig,
+            inputs: vec![],
+        }],
+    };
+    assert_eq!(
+        program.validate(),
+        Err(ValidateError::WrongInputCount {
+            instr: 0,
+            expected: 15,
+            got: 0,
         }),
     );
 }
@@ -1117,6 +1239,14 @@ fn generate_fresh_funding_transaction_panics() {
     let mut rng = SmallRng::seed_from_u64(0);
     let mut builder = ProgramBuilder::new();
     builder.generate_fresh(VariableType::FundingTransaction, &mut rng);
+}
+
+#[test]
+#[should_panic(expected = "cannot generate fresh ChannelConfig")]
+fn generate_fresh_channel_config_panics() {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut builder = ProgramBuilder::new();
+    builder.generate_fresh(VariableType::ChannelConfig, &mut rng);
 }
 
 #[test]

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -5,7 +5,7 @@
 
 use bitcoin::secp256k1::PublicKey;
 use smite::bolt::{AcceptChannel, ChannelId, ShortChannelId};
-use smite::channel_tx::FundingTransaction;
+use smite::channel_tx::{ChannelConfig, FundingTransaction};
 
 const CHAIN_HASH_SIZE: usize = 32;
 const PRIVATE_KEY_SIZE: usize = 32;
@@ -50,6 +50,8 @@ pub enum Variable {
     AcceptChannel(AcceptChannel),
     /// Constructed funding transaction with funding output index.
     FundingTransaction(FundingTransaction),
+    /// Static channel configuration (funding details and both parties).
+    ChannelConfig(ChannelConfig),
 }
 
 impl Variable {
@@ -74,6 +76,7 @@ impl Variable {
             Self::Message(_) => VariableType::Message,
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
             Self::FundingTransaction(_) => VariableType::FundingTransaction,
+            Self::ChannelConfig(_) => VariableType::ChannelConfig,
         }
     }
 }
@@ -99,4 +102,5 @@ pub enum VariableType {
     Message,
     AcceptChannel,
     FundingTransaction,
+    ChannelConfig,
 }

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -3,15 +3,17 @@
 //! Executes an IR program against a target node over an established connection,
 //! producing side effects (sending/receiving messages).
 
-use bitcoin::ScriptBuf;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use bitcoin::{OutPoint, ScriptBuf};
 use smite::bitcoin::{BitcoinCli, Utxo};
 use smite::bolt::{
     AcceptChannel, ChannelAnnouncement, ChannelId, Message, NodeAnnouncement, OpenChannel,
     OpenChannelTlvs, Pong, ShortChannelId, msg_type,
 };
-use smite::channel_tx::{FundingTransaction, build_funding_transaction};
+use smite::channel_tx::{
+    ChannelConfig, ChannelPartyConfig, FundingTransaction, build_funding_transaction,
+};
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable, VariableType};
@@ -198,6 +200,11 @@ pub fn execute(
             Operation::CreateFundingTransaction => {
                 let ft = create_funding_transaction(&variables, &instr.inputs, bitcoin_cli)?;
                 Some(Variable::FundingTransaction(ft))
+            }
+
+            Operation::CreateChannelConfig => {
+                let cfg = create_channel_config(&variables, &instr.inputs)?;
+                Some(Variable::ChannelConfig(cfg))
             }
 
             // -- Build operations --
@@ -454,6 +461,44 @@ fn create_funding_transaction(
     Ok(funding)
 }
 
+/// Creates a [`ChannelConfig`] from input variables. The funding outpoint is
+/// derived from the input [`FundingTransaction`].
+fn create_channel_config(
+    variables: &[Option<Variable>],
+    inputs: &[usize],
+) -> Result<ChannelConfig, ExecuteError> {
+    let funding_tx = resolve_funding_transaction(variables, inputs[0])?;
+    let funding_outpoint = OutPoint {
+        txid: funding_tx.tx.compute_txid(),
+        vout: funding_tx.vout,
+    };
+    let funding_satoshis = resolve_amount(variables, inputs[1])?;
+    let channel_type = resolve_features(variables, inputs[2])?.to_vec();
+    let opener = ChannelPartyConfig {
+        funding_pubkey: resolve_pubkey(variables, inputs[3])?,
+        payment_basepoint: resolve_pubkey(variables, inputs[4])?,
+        revocation_basepoint: resolve_pubkey(variables, inputs[5])?,
+        delayed_payment_basepoint: resolve_pubkey(variables, inputs[6])?,
+        dust_limit_satoshis: resolve_amount(variables, inputs[7])?,
+        to_self_delay: resolve_u16(variables, inputs[8])?,
+    };
+    let acceptor = ChannelPartyConfig {
+        funding_pubkey: resolve_pubkey(variables, inputs[9])?,
+        payment_basepoint: resolve_pubkey(variables, inputs[10])?,
+        revocation_basepoint: resolve_pubkey(variables, inputs[11])?,
+        delayed_payment_basepoint: resolve_pubkey(variables, inputs[12])?,
+        dust_limit_satoshis: resolve_amount(variables, inputs[13])?,
+        to_self_delay: resolve_u16(variables, inputs[14])?,
+    };
+    Ok(ChannelConfig {
+        funding_outpoint,
+        funding_satoshis,
+        channel_type,
+        opener,
+        acceptor,
+    })
+}
+
 /// Builds an `OpenChannel` from 20 input variables (wire order).
 fn build_open_channel(
     variables: &[Option<Variable>],
@@ -645,7 +690,7 @@ mod tests {
 
     use super::*;
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
-    use bitcoin::{Amount, OutPoint, Transaction};
+    use bitcoin::{Amount, Transaction};
     use smite::bolt::{AcceptChannelTlvs, Init, Ping};
     use smite_ir::Instruction;
 
@@ -1593,6 +1638,77 @@ mod tests {
         };
         assert_eq!(funds_err.available, Amount::from_sat(1_000));
         assert_eq!(funds_err.required, Amount::from_sat(10_007_290));
+    }
+
+    #[test]
+    fn execute_create_channel_config() {
+        let instrs = vec![
+            Instruction {
+                operation: Operation::LoadPrivateKey([0x11; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![0],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey([0x22; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![2],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(10_000_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadFeeratePerKw(15_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::CreateFundingTransaction,
+                inputs: vec![1, 3, 4, 5],
+            },
+            Instruction {
+                operation: Operation::LoadFeatures(vec![0x40, 0x00, 0x00]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(546),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadU16(144),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::CreateChannelConfig,
+                inputs: vec![6, 4, 7, 1, 1, 1, 1, 8, 9, 3, 3, 3, 3, 8, 9],
+            },
+        ];
+
+        let mut conn = MockConnection::new();
+        let mut mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        execute(
+            &Program {
+                instructions: instrs,
+            },
+            &sample_context(),
+            &mut conn,
+            &mut mock_cli,
+            std::time::Instant::now(),
+        )
+        .expect("CreateChannelConfig should succeed");
+
+        // TODO: Once we add support for `CommitmentState`, we can construct the
+        // commitment signature here and verify it, indirectly ensuring that the
+        // generated variable matches the expected result.
     }
 
     #[test]

--- a/smite/src/channel_tx/commitment.rs
+++ b/smite/src/channel_tx/commitment.rs
@@ -54,6 +54,7 @@ pub struct HolderIdentity {
 }
 
 /// Static public keys and channel parameters for one side of a channel (opener or acceptor).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChannelPartyConfig {
     /// Funding pubkey used in the funding output.
     pub funding_pubkey: PublicKey,
@@ -70,6 +71,7 @@ pub struct ChannelPartyConfig {
 }
 
 /// Channel configuration including funding details and both parties configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChannelConfig {
     /// Funding transaction outpoint.
     pub funding_outpoint: OutPoint,


### PR DESCRIPTION
ref: https://github.com/morehouse/smite/pull/90#issuecomment-4532231730
Depends-on: https://github.com/morehouse/smite/pull/100

This commit introduces a new compute operation `CreateChannelConfig`, which takes the static channel and party inputs and constructs a new variable type `ChannelConfig`. This will later be used as an input while constructing the `BuildFundingCreated` message.

Some reasons why I went with `CreateChannelConfig` operation in funding flow:
- This helps keep inputs cleaner for subsequent operations. For example, `BuildFundingCreated` can now directly take `ChannelConfig` instead of many raw inputs.
- Another reason for not building `funding_created` directly from raw inputs is signature verification. Once we receive `funding_signed`, we need the same `ChannelConfig` to verify the received signature. Reconstructing it again from raw inputs could lead to false positives if the reconstructed config differs from the original. By reusing the previously created `ChannelConfig`, verification stays consistent and avoids such issues.

Some points worth mentioning are:
- With this approach, mutations from mutators effectively shift from `BuildFundingCreated` to `CreateChannelConfig`. So I think we will still receive the same mutation coverage as before. After construction, `ChannelConfig` becomes immutable, which helps preserve the exact configuration for later signature verification. Because of that, I do not think there is any real tradeoff from the mutator side.
- Its usage for subsequent normal channel operations is still an open discussion point, and I plan to open a separate issue to finalize that design.