### PR TITLE
smite-ir: implement BuildChannelAnnouncement operation

### DIFF
--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -100,6 +100,7 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::LoadTargetPubkeyFromContext
         | Operation::LoadChainHashFromContext
         | Operation::BuildOpenChannel
+        | Operation::BuildChannelAnnouncement
         | Operation::SendMessage
         | Operation::RecvAcceptChannel
         | Operation::BroadcastTransaction => {

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -104,6 +104,19 @@ pub enum Operation {
     ///  18: `upfront_shutdown_script` (`Bytes`, empty = omit TLV)
     ///  19: `channel_type` (`Features`, empty = omit TLV)
     BuildOpenChannel,
+    /// Build a `channel_announcement` message (BOLT 7, type 256).
+    ///
+    /// All four `PrivateKey` inputs are used to sign the body.
+    ///
+    /// Inputs (7):
+    ///   0: `features`         (`Features`)
+    ///   1: `chain_hash`       (`ChainHash`)
+    ///   2: `short_channel_id` (`ShortChannelId`)
+    ///   3: `node_sk_1`        (`PrivateKey`) -- derives `node_id_1`
+    ///   4: `node_sk_2`        (`PrivateKey`) -- derives `node_id_2`
+    ///   5: `bitcoin_sk_1`     (`PrivateKey`) -- derives `bitcoin_key_1`
+    ///   6: `bitcoin_sk_2`     (`PrivateKey`) -- derives `bitcoin_key_2`
+    BuildChannelAnnouncement,
     /// Build a `node_announcement` message (BOLT 7, type 257).
     ///
     /// `rgb_color` and `alias` are op-level params (not variable inputs) so the
@@ -569,6 +582,7 @@ impl fmt::Display for Operation {
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
             Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
+            Self::BuildChannelAnnouncement => write!(f, "BuildChannelAnnouncement"),
             Self::BuildNodeAnnouncement { rgb_color, alias } => write!(
                 f,
                 "BuildNodeAnnouncement{{rgb={}, alias={}}}",
@@ -601,9 +615,9 @@ impl Operation {
             Self::LoadChainHashFromContext => Some(VariableType::ChainHash),
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
-            Self::BuildOpenChannel | Self::BuildNodeAnnouncement { .. } => {
-                Some(VariableType::Message)
-            }
+            Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
+            | Self::BuildNodeAnnouncement { .. } => Some(VariableType::Message),
             Self::SendMessage | Self::MineBlocks(_) | Self::BroadcastTransaction => None,
             Self::RecvAcceptChannel => Some(VariableType::AcceptChannel),
         }
@@ -665,6 +679,16 @@ impl Operation {
                 VariableType::Features,     // channel_type
             ],
 
+            Self::BuildChannelAnnouncement => vec![
+                VariableType::Features,       // features
+                VariableType::ChainHash,      // chain_hash
+                VariableType::ShortChannelId, // short_channel_id
+                VariableType::PrivateKey,     // node_sk_1
+                VariableType::PrivateKey,     // node_sk_2
+                VariableType::PrivateKey,     // bitcoin_sk_1
+                VariableType::PrivateKey,     // bitcoin_sk_2
+            ],
+
             Self::BuildNodeAnnouncement { .. } => vec![
                 VariableType::PrivateKey, // node_sk
                 VariableType::Features,   // features
@@ -701,6 +725,7 @@ impl Operation {
             | Self::ExtractAcceptChannel(_)
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::SendMessage
             | Self::MineBlocks(_)
@@ -740,6 +765,7 @@ impl Operation {
             | Self::DerivePoint
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
             | Self::SendMessage
             | Self::RecvAcceptChannel
             | Self::BroadcastTransaction => false,

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -203,6 +203,70 @@ fn display_open_channel_program() {
 }
 
 #[test]
+fn display_build_channel_announcement_program() {
+    let scid = ShortChannelId::new(539_268, 845, 1);
+    let instructions = vec![
+        Instruction {
+            operation: Operation::LoadFeatures(vec![0x01, 0x02]),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadChainHashFromContext,
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadShortChannelId(scid.as_u64()),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(1)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(2)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(3)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(4)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::BuildChannelAnnouncement,
+            inputs: vec![0, 1, 2, 3, 4, 5, 6],
+        },
+        Instruction {
+            operation: Operation::SendMessage,
+            inputs: vec![7],
+        },
+    ];
+
+    let program = Program { instructions };
+    let text = program.to_string();
+    let lines: Vec<&str> = text.lines().collect();
+
+    let z31 = "00".repeat(31);
+    let expected: Vec<String> = vec![
+        "v0 = LoadFeatures(0x0102)".into(),
+        "v1 = LoadChainHashFromContext()".into(),
+        format!("v2 = LoadShortChannelId({scid})"),
+        format!("v3 = LoadPrivateKey(0x{z31}01)"),
+        format!("v4 = LoadPrivateKey(0x{z31}02)"),
+        format!("v5 = LoadPrivateKey(0x{z31}03)"),
+        format!("v6 = LoadPrivateKey(0x{z31}04)"),
+        "v7 = BuildChannelAnnouncement(v0, v1, v2, v3, v4, v5, v6)".into(),
+        "SendMessage(v7)".into(),
+    ];
+    assert_eq!(lines.len(), expected.len(), "line count mismatch");
+    for (i, (got, want)) in lines.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(got, want, "line {i} mismatch");
+    }
+}
+
+#[test]
 fn display_build_node_announcement_program() {
     let mut alias = [0u8; 32];
     alias[..5].copy_from_slice(b"smite");

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -8,8 +8,8 @@ use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use smite::bitcoin::{BitcoinCli, Utxo};
 use smite::bolt::{
-    AcceptChannel, ChannelId, Message, NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong,
-    ShortChannelId, msg_type,
+    AcceptChannel, ChannelAnnouncement, ChannelId, Message, NodeAnnouncement, OpenChannel,
+    OpenChannelTlvs, Pong, ShortChannelId, msg_type,
 };
 use smite::channel_tx::{FundingTransaction, build_funding_transaction};
 use smite::noise::{ConnectionError, NoiseConnection};
@@ -206,6 +206,12 @@ pub fn execute(
                 Some(Variable::Message(encoded))
             }
 
+            Operation::BuildChannelAnnouncement => {
+                let ca = build_channel_announcement(&variables, &instr.inputs)?;
+                let encoded = Message::ChannelAnnouncement(ca).encode();
+                Some(Variable::Message(encoded))
+            }
+
             Operation::BuildNodeAnnouncement { rgb_color, alias } => {
                 let na = build_node_announcement(&variables, &instr.inputs, *rgb_color, *alias)?;
                 let encoded = Message::NodeAnnouncement(na).encode();
@@ -356,6 +362,17 @@ fn resolve_channel_id(
     }
 }
 
+fn resolve_short_channel_id(
+    variables: &[Option<Variable>],
+    index: usize,
+) -> Result<ShortChannelId, ExecuteError> {
+    let var = resolve(variables, index)?;
+    match var {
+        Variable::ShortChannelId(v) => Ok(*v),
+        _ => Err(type_err(VariableType::ShortChannelId, var)),
+    }
+}
+
 fn resolve_pubkey(variables: &[Option<Variable>], index: usize) -> Result<PublicKey, ExecuteError> {
     let var = resolve(variables, index)?;
     match var {
@@ -469,6 +486,53 @@ fn build_open_channel(
             channel_type: nonempty_or_none(resolve_features(variables, inputs[19])?),
         },
     })
+}
+
+/// Builds a signed `ChannelAnnouncement` from 7 input variables.
+fn build_channel_announcement(
+    variables: &[Option<Variable>],
+    inputs: &[usize],
+) -> Result<ChannelAnnouncement, ExecuteError> {
+    let features = resolve_features(variables, inputs[0])?.to_vec();
+    let chain_hash = resolve_chain_hash(variables, inputs[1])?;
+    let short_channel_id = resolve_short_channel_id(variables, inputs[2])?;
+    let node_sk_1_bytes = resolve_private_key(variables, inputs[3])?;
+    let node_sk_2_bytes = resolve_private_key(variables, inputs[4])?;
+    let bitcoin_sk_1_bytes = resolve_private_key(variables, inputs[5])?;
+    let bitcoin_sk_2_bytes = resolve_private_key(variables, inputs[6])?;
+
+    let node_sk_1 =
+        SecretKey::from_slice(&node_sk_1_bytes).map_err(|_| ExecuteError::InvalidPrivateKey)?;
+    let node_sk_2 =
+        SecretKey::from_slice(&node_sk_2_bytes).map_err(|_| ExecuteError::InvalidPrivateKey)?;
+    let bitcoin_sk_1 =
+        SecretKey::from_slice(&bitcoin_sk_1_bytes).map_err(|_| ExecuteError::InvalidPrivateKey)?;
+    let bitcoin_sk_2 =
+        SecretKey::from_slice(&bitcoin_sk_2_bytes).map_err(|_| ExecuteError::InvalidPrivateKey)?;
+
+    let secp = Secp256k1::new();
+    let node_id_1 = PublicKey::from_secret_key(&secp, &node_sk_1);
+    let node_id_2 = PublicKey::from_secret_key(&secp, &node_sk_2);
+    let bitcoin_key_1 = PublicKey::from_secret_key(&secp, &bitcoin_sk_1);
+    let bitcoin_key_2 = PublicKey::from_secret_key(&secp, &bitcoin_sk_2);
+
+    let placeholder = Signature::from_compact(&[0u8; 64]).expect("zero bytes parse as a signature");
+    let mut ca = ChannelAnnouncement {
+        node_signature_1: placeholder,
+        node_signature_2: placeholder,
+        bitcoin_signature_1: placeholder,
+        bitcoin_signature_2: placeholder,
+        features,
+        chain_hash,
+        short_channel_id,
+        node_id_1,
+        node_id_2,
+        bitcoin_key_1,
+        bitcoin_key_2,
+        extra: Vec::new(),
+    };
+    ca.sign(&node_sk_1, &node_sk_2, &bitcoin_sk_1, &bitcoin_sk_2);
+    Ok(ca)
 }
 
 /// Builds a signed `NodeAnnouncement` from 4 input variables.
@@ -899,6 +963,90 @@ mod tests {
         assert_eq!(oc.channel_flags, 1);
         assert_eq!(oc.tlvs.upfront_shutdown_script, Some(vec![]));
         assert!(oc.tlvs.channel_type.is_none());
+    }
+
+    #[test]
+    fn execute_build_channel_announcement() {
+        let node_sk_1_bytes = [0x11; 32];
+        let node_sk_2_bytes = [0x22; 32];
+        let bitcoin_sk_1_bytes = [0x33; 32];
+        let bitcoin_sk_2_bytes = [0x44; 32];
+        let scid = ShortChannelId::new(539_268, 845, 1);
+        let features = vec![0x01, 0x02];
+
+        let instrs = vec![
+            Instruction {
+                operation: Operation::LoadFeatures(features.clone()),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadChainHashFromContext,
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadShortChannelId(scid.as_u64()),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey(node_sk_1_bytes),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey(node_sk_2_bytes),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey(bitcoin_sk_1_bytes),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey(bitcoin_sk_2_bytes),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::BuildChannelAnnouncement,
+                inputs: vec![0, 1, 2, 3, 4, 5, 6],
+            },
+            Instruction {
+                operation: Operation::SendMessage,
+                inputs: vec![7],
+            },
+        ];
+
+        let program = Program {
+            instructions: instrs,
+        };
+        let mut conn = MockConnection::new();
+        execute(
+            &program,
+            &sample_context(),
+            &mut conn,
+            &mut MockBitcoinCli::default(),
+            std::time::Instant::now(),
+        )
+        .unwrap();
+
+        assert_eq!(conn.sent.len(), 1);
+        let ca = match Message::decode(&conn.sent[0]).expect("valid message") {
+            Message::ChannelAnnouncement(ca) => ca,
+            other => panic!(
+                "expected ChannelAnnouncement, got type {}",
+                other.msg_type()
+            ),
+        };
+
+        let secp = Secp256k1::new();
+        let pk =
+            |b: &[u8; 32]| PublicKey::from_secret_key(&secp, &SecretKey::from_slice(b).unwrap());
+        assert_eq!(ca.features, features);
+        assert_eq!(ca.chain_hash, sample_context().chain_hash);
+        assert_eq!(ca.short_channel_id, scid);
+        assert_eq!(ca.node_id_1, pk(&node_sk_1_bytes));
+        assert_eq!(ca.node_id_2, pk(&node_sk_2_bytes));
+        assert_eq!(ca.bitcoin_key_1, pk(&bitcoin_sk_1_bytes));
+        assert_eq!(ca.bitcoin_key_2, pk(&bitcoin_sk_2_bytes));
+        assert!(ca.extra.is_empty());
+        assert!(ca.verify());
     }
 
     #[test]


### PR DESCRIPTION
Enables programs that build signed `channel_announcement` messages and send them to the target.

Ref: #71 