### PR TITLE
smite: check if TLV length matches length of known encoding

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -68,7 +68,7 @@ pub use update_fail_htlc::{UpdateFailHtlc, UpdateFailHtlcTlvs};
 pub use update_fail_malformed_htlc::UpdateFailMalformedHtlc;
 pub use update_fulfill_htlc::{UpdateFulfillHtlc, UpdateFulfillHtlcTlvs};
 pub use warning::Warning;
-pub use wire::WireFormat;
+pub use wire::{EmptyTlv, WireFormat};
 
 /// Errors that can occur during BOLT message encoding/decoding.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -105,6 +105,13 @@ pub enum BoltError {
     /// Unknown even TLV type (must reject per BOLT 1)
     #[error("TLV_UNKNOWN_EVEN_TYPE {0}")]
     TlvUnknownEvenType(u64),
+    /// TLV value longer than the known encoding for its type
+    #[error("TLV_TRAILING_BYTES type {tlv_type} expected {expected} got {actual}")]
+    TlvTrailingBytes {
+        tlv_type: u64,
+        expected: usize,
+        actual: usize,
+    },
 }
 
 /// BOLT message type constants.

--- a/smite/src/bolt/accept_channel2.rs
+++ b/smite/src/bolt/accept_channel2.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::ChannelId;
-use super::wire::WireFormat;
+use super::wire::{EmptyTlv, WireFormat};
 use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for upfront shutdown script.
@@ -135,7 +135,7 @@ impl AcceptChannel2 {
             cursor,
             &[TLV_UPFRONT_SHUTDOWN_SCRIPT, TLV_REQUIRE_CONFIRMED_INPUTS],
         )?;
-        let tlvs = AcceptChannel2Tlvs::from_stream(&tlv_stream);
+        let tlvs = AcceptChannel2Tlvs::from_stream(&tlv_stream)?;
 
         Ok(Self {
             temporary_channel_id,
@@ -160,16 +160,22 @@ impl AcceptChannel2 {
 
 impl AcceptChannel2Tlvs {
     /// Extracts accept channel2 TLVs from a parsed TLV stream.
-    fn from_stream(stream: &TlvStream) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BoltError` if a TLV value has invalid length.
+    fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
         let upfront_shutdown_script = stream.get(TLV_UPFRONT_SHUTDOWN_SCRIPT).map(Vec::from);
         let channel_type = stream.get(TLV_CHANNEL_TYPE).map(Vec::from);
-        let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
+        let require_confirmed_inputs = stream
+            .get_as::<EmptyTlv>(TLV_REQUIRE_CONFIRMED_INPUTS)?
+            .is_some();
 
-        Self {
+        Ok(Self {
             upfront_shutdown_script,
             channel_type,
             require_confirmed_inputs,
-        }
+        })
     }
 }
 
@@ -546,6 +552,21 @@ mod tests {
         assert!(decoded.tlvs.upfront_shutdown_script.is_none());
         assert!(decoded.tlvs.channel_type.is_none());
         assert!(!decoded.tlvs.require_confirmed_inputs);
+    }
+
+    #[test]
+    fn decode_reject_require_confirmed_inputs_trailing_bytes() {
+        let mut encoded = sample_accept_channel2(None).encode();
+        // type 2 (`require_confirmed_inputs`), len 1 — must be zero-length
+        encoded.extend_from_slice(&[0x02, 0x01, 0xff]);
+        assert_eq!(
+            AcceptChannel2::decode(&encoded),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: TLV_REQUIRE_CONFIRMED_INPUTS,
+                expected: 0,
+                actual: 1,
+            })
+        );
     }
 
     #[test]

--- a/smite/src/bolt/attribution_data.rs
+++ b/smite/src/bolt/attribution_data.rs
@@ -53,12 +53,7 @@ impl AttributionData {
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(Self::SIZE);
-        for &t in &self.htlc_hold_times {
-            t.write(&mut out);
-        }
-        for hmac in &self.truncated_hmacs {
-            hmac.write(&mut out);
-        }
+        self.write(&mut out);
         out
     }
 
@@ -75,18 +70,33 @@ impl AttributionData {
             });
         }
         let mut cursor = data;
+        AttributionData::read(&mut cursor)
+    }
+}
+
+impl WireFormat for AttributionData {
+    fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
         let mut htlc_hold_times = [0u32; ATTRIBUTION_MAX_HOPS];
         for ht in &mut htlc_hold_times {
-            *ht = WireFormat::read(&mut cursor)?;
+            *ht = WireFormat::read(&mut *data)?;
         }
         let mut truncated_hmacs = [TruncatedHmac::default(); ATTRIBUTION_NUM_HMACS];
         for hmac in &mut truncated_hmacs {
-            *hmac = WireFormat::read(&mut cursor)?;
+            *hmac = WireFormat::read(&mut *data)?;
         }
         Ok(Self {
             htlc_hold_times,
             truncated_hmacs,
         })
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        for &t in &self.htlc_hold_times {
+            t.write(out);
+        }
+        for hmac in &self.truncated_hmacs {
+            hmac.write(out);
+        }
     }
 }
 
@@ -132,5 +142,87 @@ mod tests {
                 actual: 100,
             })
         );
+    }
+
+    #[test]
+    fn read_truncated_empty() {
+        let mut data: &[u8] = &[];
+        assert_eq!(
+            AttributionData::read(&mut data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn read_truncated_during_hold_times() {
+        // 19 x hold_time(4) = 76, add three of last
+        let mut data: &[u8] = &[0xaa; 79];
+        assert_eq!(
+            AttributionData::read(&mut data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn read_truncated_before_hmacs() {
+        // All 20 hold times (80 bytes), no HMAC data.
+        let mut data: &[u8] = &[0xaa; 80];
+        assert_eq!(
+            AttributionData::read(&mut data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn read_truncated_during_hmacs() {
+        // All hold times + 2 bytes of the first truncated HMAC.
+        let mut data: &[u8] = &[0xaa; 82];
+        assert_eq!(
+            AttributionData::read(&mut data),
+            Err(BoltError::Truncated {
+                expected: 4,
+                actual: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn attribution_data_read_leaves_trailing_bytes() {
+        let original = AttributionData {
+            htlc_hold_times: [42; ATTRIBUTION_MAX_HOPS],
+            truncated_hmacs: [TruncatedHmac([0xcc; 4]); ATTRIBUTION_NUM_HMACS],
+        };
+        let mut data = original.encode();
+        data.extend_from_slice(&[0xaa, 0xbb, 0xcc]);
+        let mut cursor: &[u8] = &data;
+        let decoded = AttributionData::read(&mut cursor).unwrap();
+        assert_eq!(decoded, original);
+        assert_eq!(cursor, &[0xaa, 0xbb, 0xcc]);
+    }
+
+    #[test]
+    fn attribution_data_write_roundtrip() {
+        let original = AttributionData {
+            htlc_hold_times: [42; ATTRIBUTION_MAX_HOPS],
+            truncated_hmacs: [TruncatedHmac([0xcc; 4]); ATTRIBUTION_NUM_HMACS],
+        };
+
+        let mut buf = Vec::new();
+        original.write(&mut buf);
+        assert_eq!(buf.len(), AttributionData::SIZE);
+
+        let mut cursor: &[u8] = &buf;
+        let decoded = AttributionData::read(&mut cursor).unwrap();
+        assert_eq!(decoded, original);
+        assert!(cursor.is_empty());
     }
 }

--- a/smite/src/bolt/channel_ready.rs
+++ b/smite/src/bolt/channel_ready.rs
@@ -80,16 +80,9 @@ impl ChannelReadyTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if the short channel ID TLV has invalid length.
+    /// Returns a `BoltError` if the short channel ID TLV has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let short_channel_id = if let Some(data) = stream.get(TLV_SHORT_CHANNEL_ID) {
-            let mut cursor = data;
-            let scid = u64::read(&mut cursor)?;
-            Some(scid)
-        } else {
-            None
-        };
-
+        let short_channel_id = stream.get_as::<u64>(TLV_SHORT_CHANNEL_ID)?;
         Ok(Self { short_channel_id })
     }
 }
@@ -219,6 +212,28 @@ mod tests {
             Err(BoltError::Truncated {
                 expected: 8,
                 actual: 4
+            })
+        );
+    }
+
+    #[test]
+    // Test constants are known to fit in u8
+    #[allow(clippy::cast_possible_truncation)]
+    fn decode_short_channel_id_reject_trailing_bytes() {
+        let msg = sample_channel_ready(None);
+        let mut encoded = msg.encode();
+
+        // short_channel_id TLV should be 8 bytes, but we push 9 bytes
+        encoded.push(TLV_SHORT_CHANNEL_ID as u8);
+        encoded.push(0x09);
+        encoded.extend_from_slice(&[0xbb; 9]);
+
+        assert_eq!(
+            ChannelReady::decode(&encoded),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: TLV_SHORT_CHANNEL_ID,
+                expected: 8,
+                actual: 9,
             })
         );
     }

--- a/smite/src/bolt/init.rs
+++ b/smite/src/bolt/init.rs
@@ -125,21 +125,9 @@ impl InitTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if the networks TLV has invalid length.
+    /// Returns a `BoltError` if the networks TLV has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let networks = if let Some(data) = stream.get(TLV_NETWORKS) {
-            let (chunks, remainder) = data.as_chunks::<CHAIN_HASH_SIZE>();
-            if !remainder.is_empty() {
-                return Err(BoltError::Truncated {
-                    expected: (chunks.len() + 1) * CHAIN_HASH_SIZE,
-                    actual: data.len(),
-                });
-            }
-            Some(chunks.to_vec())
-        } else {
-            None
-        };
-
+        let networks = stream.get_as_many::<[u8; CHAIN_HASH_SIZE]>(TLV_NETWORKS)?;
         let remote_addr = stream.get(TLV_REMOTE_ADDR).map(Vec::from);
 
         Ok(Self {
@@ -389,8 +377,9 @@ mod tests {
 
         assert_eq!(
             Init::decode(&data),
-            Err(BoltError::Truncated {
-                expected: CHAIN_HASH_SIZE * 2, // Next multiple of 32
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: 1,
+                expected: 32,
                 actual: 33
             })
         );

--- a/smite/src/bolt/open_channel2.rs
+++ b/smite/src/bolt/open_channel2.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::{CHAIN_HASH_SIZE, ChannelId};
-use super::wire::WireFormat;
+use super::wire::{EmptyTlv, WireFormat};
 use bitcoin::secp256k1::PublicKey;
 
 /// TLV type for upfront shutdown script.
@@ -151,7 +151,7 @@ impl OpenChannel2 {
             cursor,
             &[TLV_UPFRONT_SHUTDOWN_SCRIPT, TLV_REQUIRE_CONFIRMED_INPUTS],
         )?;
-        let tlvs = OpenChannel2Tlvs::from_stream(&tlv_stream);
+        let tlvs = OpenChannel2Tlvs::from_stream(&tlv_stream)?;
 
         Ok(Self {
             chain_hash,
@@ -180,16 +180,22 @@ impl OpenChannel2 {
 
 impl OpenChannel2Tlvs {
     /// Extracts open channel2 TLVs from a parsed TLV stream.
-    fn from_stream(stream: &TlvStream) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BoltError` if a TLV value has invalid length.
+    fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
         let upfront_shutdown_script = stream.get(TLV_UPFRONT_SHUTDOWN_SCRIPT).map(Vec::from);
         let channel_type = stream.get(TLV_CHANNEL_TYPE).map(Vec::from);
-        let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
+        let require_confirmed_inputs = stream
+            .get_as::<EmptyTlv>(TLV_REQUIRE_CONFIRMED_INPUTS)?
+            .is_some();
 
-        Self {
+        Ok(Self {
             upfront_shutdown_script,
             channel_type,
             require_confirmed_inputs,
-        }
+        })
     }
 }
 
@@ -618,6 +624,21 @@ mod tests {
         assert!(decoded.tlvs.upfront_shutdown_script.is_none());
         assert!(decoded.tlvs.channel_type.is_none());
         assert!(!decoded.tlvs.require_confirmed_inputs);
+    }
+
+    #[test]
+    fn decode_reject_require_confirmed_inputs_trailing_bytes() {
+        let mut encoded = sample_open_channel2(None).encode();
+        // type 2 (`require_confirmed_inputs`), len 1 — must be zero-length
+        encoded.extend_from_slice(&[0x02, 0x01, 0xff]);
+        assert_eq!(
+            OpenChannel2::decode(&encoded),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: TLV_REQUIRE_CONFIRMED_INPUTS,
+                expected: 0,
+                actual: 1,
+            })
+        );
     }
 
     #[test]

--- a/smite/src/bolt/tlv.rs
+++ b/smite/src/bolt/tlv.rs
@@ -231,6 +231,7 @@ impl TlvStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bolt::wire::EmptyTlv;
 
     // ===== Basic functionality tests =====
 
@@ -319,6 +320,29 @@ mod tests {
                 tlv_type: 1,
                 expected: 8,
                 actual: 9
+            })
+        );
+    }
+
+    #[test]
+    fn get_as_empty_tlv_exact_length() {
+        let mut stream = TlvStream::new();
+        stream.add(1, vec![]);
+
+        assert_eq!(stream.get_as::<EmptyTlv>(1).unwrap(), Some(EmptyTlv));
+    }
+
+    #[test]
+    fn get_as_empty_tlv_overlength_rejected() {
+        let mut stream = TlvStream::new();
+        stream.add(1, vec![0xff]);
+
+        assert_eq!(
+            stream.get_as::<EmptyTlv>(1),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: 1,
+                expected: 0,
+                actual: 1,
             })
         );
     }

--- a/smite/src/bolt/tlv.rs
+++ b/smite/src/bolt/tlv.rs
@@ -63,6 +63,85 @@ impl TlvStream {
             .map(|r| r.value.as_slice())
     }
 
+    /// Gets a record by type and decodes it as a fixed-size `WireFormat` value.
+    ///
+    /// Returns `None` if the record is absent. Rejects TLV values that are
+    /// longer than the type's known wire encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BoltError` if the value is truncated or contains trailing
+    /// bytes after decoding.
+    pub fn get_as<T: WireFormat>(&self, tlv_type: u64) -> Result<Option<T>, BoltError> {
+        self.get(tlv_type)
+            .map(|data| {
+                let mut cursor = data;
+                let value = T::read(&mut cursor)?;
+                // we must fail to parse the stream
+                // "if length is not exactly equal to that required for the known encoding for type"
+                // [BOLT 1]: https://github.com/lightning/bolts/blob/master/01-messaging.md#type-length-value-format
+                if !cursor.is_empty() {
+                    let bytes_read = data.len() - cursor.len();
+                    return Err(BoltError::TlvTrailingBytes {
+                        tlv_type,
+                        expected: bytes_read,
+                        actual: data.len(),
+                    });
+                }
+                Ok(value)
+            })
+            .transpose()
+    }
+
+    /// Gets all records by type and decodes them as fixed-size `WireFormat`
+    /// values.
+    ///
+    /// Returns `None` if no records are found, or `Some(vec)` if present.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BoltError` if decoding a TLV value fails or the TLV values
+    /// cannot be divided into fixed-size chunks.
+    pub fn get_as_many<T: WireFormat>(&self, tlv_type: u64) -> Result<Option<Vec<T>>, BoltError> {
+        match self.get(tlv_type) {
+            Some(data) => {
+                if data.is_empty() {
+                    return Ok(Some(Vec::new()));
+                }
+
+                let total_bytes = data.len();
+                let mut cursor = data;
+
+                // read first element to determine chunk size
+                let first = T::read(&mut cursor)?;
+
+                let chunk_size = total_bytes - cursor.len();
+                if chunk_size == 0 {
+                    return Err(BoltError::Truncated {
+                        expected: 1,
+                        actual: 0,
+                    });
+                }
+                if total_bytes % chunk_size != 0 {
+                    return Err(BoltError::TlvTrailingBytes {
+                        tlv_type,
+                        expected: (total_bytes / chunk_size) * chunk_size,
+                        actual: total_bytes,
+                    });
+                }
+
+                let mut values = Vec::with_capacity(total_bytes / chunk_size);
+                values.push(first);
+                for chunk in cursor.chunks(chunk_size) {
+                    let mut chunk_cursor = chunk;
+                    values.push(T::read(&mut chunk_cursor)?);
+                }
+                Ok(Some(values))
+            }
+            None => Ok(None),
+        }
+    }
+
     /// Returns an iterator over all records.
     pub fn iter(&self) -> impl Iterator<Item = &TlvRecord> {
         self.records.iter()
@@ -208,6 +287,81 @@ mod tests {
         assert_eq!(decoded.get(1), Some(&[0x01, 0x02, 0x03][..]));
         assert_eq!(decoded.get(3), Some(&[][..]));
         assert_eq!(decoded.get(255), Some(&[0xff; 100][..]));
+    }
+
+    #[test]
+    fn get_as_missing_returns_none() {
+        let stream = TlvStream::new();
+        assert_eq!(stream.get_as::<u64>(1).unwrap(), None);
+    }
+
+    #[test]
+    fn get_as_exact_length() {
+        let mut stream = TlvStream::new();
+        let mut value = Vec::new();
+        42u64.write(&mut value);
+        stream.add(1, value);
+
+        assert_eq!(stream.get_as::<u64>(1).unwrap(), Some(42));
+    }
+
+    #[test]
+    fn get_as_overlength_rejected() {
+        let mut stream = TlvStream::new();
+        let mut value = Vec::new();
+        42u64.write(&mut value);
+        value.push(0xff);
+        stream.add(1, value);
+
+        assert_eq!(
+            stream.get_as::<u64>(1),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: 1,
+                expected: 8,
+                actual: 9
+            })
+        );
+    }
+
+    #[test]
+    fn get_as_underlength_truncated() {
+        let mut stream = TlvStream::new();
+        stream.add(1, vec![0xaa; 4]);
+
+        assert_eq!(
+            stream.get_as::<u64>(1),
+            Err(BoltError::Truncated {
+                expected: 8,
+                actual: 4
+            })
+        );
+    }
+
+    #[test]
+    fn get_as_many() {
+        let mut stream = TlvStream::new();
+        let value = [[0u8; 32], [1u8; 32]].as_flattened().to_vec();
+        stream.add(1, value);
+
+        assert_eq!(
+            stream.get_as_many::<[u8; 32]>(1).unwrap(),
+            Some(vec![[0u8; 32], [1u8; 32]])
+        );
+    }
+
+    #[test]
+    fn get_as_many_reject_trailing_bytes() {
+        let mut stream = TlvStream::new();
+        stream.add(1, vec![0u8; 33]);
+
+        assert_eq!(
+            stream.get_as_many::<[u8; 32]>(1),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: 1,
+                expected: 32,
+                actual: 33
+            })
+        );
     }
 
     #[test]

--- a/smite/src/bolt/tx_ack_rbf.rs
+++ b/smite/src/bolt/tx_ack_rbf.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::ChannelId;
-use super::wire::WireFormat;
+use super::wire::{EmptyTlv, WireFormat};
 
 /// TLV type for funding output contribution.
 const TLV_FUNDING_OUTPUT_CONTRIBUTION: u64 = 0;
@@ -90,11 +90,12 @@ impl TxAckRbfTlvs {
     ///
     /// # Errors
     ///
-    /// Returns a `BoltError` if `funding_output_contribution` has invalid
-    /// length.
+    /// Returns a `BoltError` if a TLV value has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
         let funding_output_contribution = stream.get_as::<i64>(TLV_FUNDING_OUTPUT_CONTRIBUTION)?;
-        let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
+        let require_confirmed_inputs = stream
+            .get_as::<EmptyTlv>(TLV_REQUIRE_CONFIRMED_INPUTS)?
+            .is_some();
 
         Ok(Self {
             funding_output_contribution,
@@ -188,6 +189,21 @@ mod tests {
             TxAckRbf::decode(&encoded),
             Err(BoltError::TlvUnknownEvenType(4))
         ));
+    }
+
+    #[test]
+    fn decode_reject_require_confirmed_inputs_trailing_bytes() {
+        let mut encoded = sample_msg().encode();
+        // type 2 (`require_confirmed_inputs`), len 1 — must be zero-length
+        encoded.extend_from_slice(&[0x02, 0x01, 0xff]);
+        assert_eq!(
+            TxAckRbf::decode(&encoded),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: TLV_REQUIRE_CONFIRMED_INPUTS,
+                expected: 0,
+                actual: 1,
+            })
+        );
     }
 
     #[test]

--- a/smite/src/bolt/tx_ack_rbf.rs
+++ b/smite/src/bolt/tx_ack_rbf.rs
@@ -90,16 +90,10 @@ impl TxAckRbfTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if `funding_output_contribution` has invalid length.
+    /// Returns a `BoltError` if `funding_output_contribution` has invalid
+    /// length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let funding_output_contribution =
-            if let Some(data) = stream.get(TLV_FUNDING_OUTPUT_CONTRIBUTION) {
-                let mut cursor = data;
-                Some(i64::read(&mut cursor)?)
-            } else {
-                None
-            };
-
+        let funding_output_contribution = stream.get_as::<i64>(TLV_FUNDING_OUTPUT_CONTRIBUTION)?;
         let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
 
         Ok(Self {

--- a/smite/src/bolt/tx_add_input.rs
+++ b/smite/src/bolt/tx_add_input.rs
@@ -44,15 +44,9 @@ impl TxAddInputTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if `shared_input_txid` has invalid length.
+    /// Returns a `BoltError` if `shared_input_txid` has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let shared_input_txid = stream
-            .get(TLV_SHARED_INPUT_TXID)
-            .map(|v| {
-                let mut cursor = v;
-                Txid::read(&mut cursor)
-            })
-            .transpose()?;
+        let shared_input_txid = stream.get_as::<Txid>(TLV_SHARED_INPUT_TXID)?;
         Ok(Self { shared_input_txid })
     }
 }

--- a/smite/src/bolt/tx_init_rbf.rs
+++ b/smite/src/bolt/tx_init_rbf.rs
@@ -3,7 +3,7 @@
 use super::BoltError;
 use super::tlv::TlvStream;
 use super::types::ChannelId;
-use super::wire::WireFormat;
+use super::wire::{EmptyTlv, WireFormat};
 
 /// TLV type for funding output contribution.
 const TLV_FUNDING_OUTPUT_CONTRIBUTION: u64 = 0;
@@ -103,11 +103,12 @@ impl TxInitRbfTlvs {
     ///
     /// # Errors
     ///
-    /// Returns a `BoltError` if `funding_output_contribution` has invalid
-    /// length.
+    /// Returns a `BoltError` if a TLV value has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
         let funding_output_contribution = stream.get_as::<i64>(TLV_FUNDING_OUTPUT_CONTRIBUTION)?;
-        let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
+        let require_confirmed_inputs = stream
+            .get_as::<EmptyTlv>(TLV_REQUIRE_CONFIRMED_INPUTS)?
+            .is_some();
 
         Ok(Self {
             funding_output_contribution,
@@ -206,6 +207,21 @@ mod tests {
             TxInitRbf::decode(&encoded),
             Err(BoltError::TlvUnknownEvenType(4))
         ));
+    }
+
+    #[test]
+    fn decode_reject_require_confirmed_inputs_trailing_bytes() {
+        let mut encoded = sample_msg().encode();
+        // type 2 (`require_confirmed_inputs`), len 1 — must be zero-length
+        encoded.extend_from_slice(&[0x02, 0x01, 0xff]);
+        assert_eq!(
+            TxInitRbf::decode(&encoded),
+            Err(BoltError::TlvTrailingBytes {
+                tlv_type: TLV_REQUIRE_CONFIRMED_INPUTS,
+                expected: 0,
+                actual: 1,
+            })
+        );
     }
 
     #[test]

--- a/smite/src/bolt/tx_init_rbf.rs
+++ b/smite/src/bolt/tx_init_rbf.rs
@@ -103,16 +103,10 @@ impl TxInitRbfTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if `funding_output_contribution` has invalid length.
+    /// Returns a `BoltError` if `funding_output_contribution` has invalid
+    /// length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let funding_output_contribution =
-            if let Some(data) = stream.get(TLV_FUNDING_OUTPUT_CONTRIBUTION) {
-                let mut cursor = data;
-                Some(i64::read(&mut cursor)?)
-            } else {
-                None
-            };
-
+        let funding_output_contribution = stream.get_as::<i64>(TLV_FUNDING_OUTPUT_CONTRIBUTION)?;
         let require_confirmed_inputs = stream.get(TLV_REQUIRE_CONFIRMED_INPUTS).is_some();
 
         Ok(Self {

--- a/smite/src/bolt/update_fail_htlc.rs
+++ b/smite/src/bolt/update_fail_htlc.rs
@@ -82,12 +82,9 @@ impl UpdateFailHtlcTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if `attribution_data` has invalid length.
+    /// Returns a `BoltError` if `attribution_data` has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let attribution_data = stream
-            .get(TLV_ATTRIBUTION_DATA)
-            .map(AttributionData::decode)
-            .transpose()?;
+        let attribution_data = stream.get_as::<AttributionData>(TLV_ATTRIBUTION_DATA)?;
         Ok(Self { attribution_data })
     }
 }
@@ -157,15 +154,16 @@ mod tests {
     fn decode_truncated_attribution_data() {
         let msg = sample_msg();
         let mut encoded = msg.encode();
-        // Append a TLV type 1 with only 100 bytes (should be 920)
-        encoded.push(0x01); // type
-        encoded.push(0x64); // length = 100
-        encoded.extend_from_slice(&[0x00; 100]);
+        // add type 1 TLV (attribution data) with only 3 bytes
+        encoded.push(0x01);
+        encoded.push(0x03);
+        encoded.extend_from_slice(&[0x00; 3]);
         assert_eq!(
             UpdateFailHtlc::decode(&encoded),
+            // only three of four bytes of first hold_time
             Err(BoltError::Truncated {
-                expected: AttributionData::SIZE,
-                actual: 100
+                expected: 4,
+                actual: 3,
             })
         );
     }

--- a/smite/src/bolt/update_fulfill_htlc.rs
+++ b/smite/src/bolt/update_fulfill_htlc.rs
@@ -86,12 +86,9 @@ impl UpdateFulfillHtlcTlvs {
     ///
     /// # Errors
     ///
-    /// Returns `Truncated` if `attribution_data` has invalid length.
+    /// Returns a `BoltError` if `attribution_data` has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let attribution_data = stream
-            .get(TLV_ATTRIBUTION_DATA)
-            .map(AttributionData::decode)
-            .transpose()?;
+        let attribution_data = stream.get_as::<AttributionData>(TLV_ATTRIBUTION_DATA)?;
         Ok(Self { attribution_data })
     }
 }
@@ -148,15 +145,16 @@ mod tests {
     fn decode_truncated_attribution_data() {
         let msg = sample_msg();
         let mut encoded = msg.encode();
-        // Append a TLV type 1 with only 100 bytes (should be 920)
-        encoded.push(0x01); // type
-        encoded.push(0x64); // length = 100
-        encoded.extend_from_slice(&[0x00; 100]);
+        // add type 1 TLV (attribution data) with only 3 bytes
+        encoded.push(0x01);
+        encoded.push(0x03);
+        encoded.extend_from_slice(&[0x00; 3]);
         assert_eq!(
             UpdateFulfillHtlc::decode(&encoded),
+            // only three of four bytes of first hold_time
             Err(BoltError::Truncated {
-                expected: AttributionData::SIZE,
-                actual: 100
+                expected: 4,
+                actual: 3,
             })
         );
     }

--- a/smite/src/bolt/wire.rs
+++ b/smite/src/bolt/wire.rs
@@ -23,6 +23,21 @@ pub trait WireFormat: Sized {
     fn write(&self, out: &mut Vec<u8>);
 }
 
+/// Wire encoding for a zero-length TLV value (boolean flags in BOLT).
+///
+/// Used with [`TlvStream::get_as`] to decode presence-only TLVs and reject
+/// non-empty values as trailing bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmptyTlv;
+
+impl WireFormat for EmptyTlv {
+    fn read(_data: &mut &[u8]) -> Result<Self, BoltError> {
+        Ok(EmptyTlv)
+    }
+
+    fn write(&self, _out: &mut Vec<u8>) {}
+}
+
 impl<const N: usize> WireFormat for [u8; N] {
     fn read(data: &mut &[u8]) -> Result<Self, BoltError> {
         if data.len() < N {
@@ -493,6 +508,13 @@ mod tests {
                 actual: 0
             })
         );
+    }
+
+    #[test]
+    fn empty_tlv_read_leaves_trailing_bytes() {
+        let mut data: &[u8] = &[0xaa, 0xbb, 0xcc];
+        EmptyTlv::read(&mut data).unwrap();
+        assert_eq!(data, &[0xaa, 0xbb, 0xcc]);
     }
 
     #[test]


### PR DESCRIPTION
close #107 

This is the suggestion in #107.