### PR TITLE
smite: add `closing_sig` codec

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -11,6 +11,7 @@ mod channel_announcement;
 mod channel_ready;
 mod channel_update;
 mod closing_complete;
+mod closing_sig;
 mod error;
 mod funding_created;
 mod funding_signed;
@@ -45,6 +46,7 @@ pub use channel_announcement::ChannelAnnouncement;
 pub use channel_ready::{ChannelReady, ChannelReadyTlvs};
 pub use channel_update::ChannelUpdate;
 pub use closing_complete::{ClosingComplete, ClosingTlvs};
+pub use closing_sig::ClosingSig;
 pub use error::Error;
 pub use funding_created::FundingCreated;
 pub use funding_signed::FundingSigned;
@@ -144,6 +146,8 @@ pub mod msg_type {
     pub const SHUTDOWN: u16 = 38;
     /// `closing_complete` message (BOLT 2).
     pub const CLOSING_COMPLETE: u16 = 40;
+    /// `closing_sig` message (BOLT 2).
+    pub const CLOSING_SIG: u16 = 41;
     /// `open_channel2` message (BOLT 2).
     pub const OPEN_CHANNEL2: u16 = 64;
     /// `accept_channel2` message (BOLT 2).
@@ -208,6 +212,8 @@ pub enum Message {
     Shutdown(Shutdown),
     /// `closing_complete` message (type 40).
     ClosingComplete(ClosingComplete),
+    /// `closing_sig` message (type 41).
+    ClosingSig(ClosingSig),
     /// `open_channel2` message (type 64).
     OpenChannel2(OpenChannel2),
     /// `accept_channel2` message (type 65).
@@ -271,6 +277,7 @@ impl Message {
             Self::ChannelReady(_) => msg_type::CHANNEL_READY,
             Self::Shutdown(_) => msg_type::SHUTDOWN,
             Self::ClosingComplete(_) => msg_type::CLOSING_COMPLETE,
+            Self::ClosingSig(_) => msg_type::CLOSING_SIG,
             Self::OpenChannel2(_) => msg_type::OPEN_CHANNEL2,
             Self::AcceptChannel2(_) => msg_type::ACCEPT_CHANNEL2,
             Self::TxAddInput(_) => msg_type::TX_ADD_INPUT,
@@ -310,6 +317,7 @@ impl Message {
             Self::ChannelReady(m) => out.extend(m.encode()),
             Self::Shutdown(m) => out.extend(m.encode()),
             Self::ClosingComplete(m) => out.extend(m.encode()),
+            Self::ClosingSig(m) => out.extend(m.encode()),
             Self::OpenChannel2(m) => out.extend(m.encode()),
             Self::AcceptChannel2(m) => out.extend(m.encode()),
             Self::TxAddInput(m) => out.extend(m.encode()),
@@ -358,6 +366,7 @@ impl Message {
             msg_type::CLOSING_COMPLETE => {
                 Ok(Self::ClosingComplete(ClosingComplete::decode(cursor)?))
             }
+            msg_type::CLOSING_SIG => Ok(Self::ClosingSig(ClosingSig::decode(cursor)?)),
             msg_type::OPEN_CHANNEL2 => Ok(Self::OpenChannel2(OpenChannel2::decode(cursor)?)),
             msg_type::ACCEPT_CHANNEL2 => Ok(Self::AcceptChannel2(AcceptChannel2::decode(cursor)?)),
             msg_type::TX_ADD_INPUT => Ok(Self::TxAddInput(TxAddInput::decode(cursor)?)),
@@ -646,6 +655,28 @@ mod tests {
         let encoded = msg.encode();
         let decoded = Message::decode(&encoded).unwrap();
         assert_eq!(decoded, Message::ClosingComplete(cc));
+    }
+
+    /// Valid `ClosingSig` message for testing.
+    fn sample_closing_sig() -> ClosingSig {
+        let cc = sample_closing_complete();
+        ClosingSig {
+            channel_id: cc.channel_id,
+            closer_scriptpubkey: cc.closer_scriptpubkey,
+            closee_scriptpubkey: cc.closee_scriptpubkey,
+            fee_satoshis: cc.fee_satoshis,
+            locktime: cc.locktime,
+            tlvs: cc.tlvs,
+        }
+    }
+
+    #[test]
+    fn message_closing_sig_roundtrip() {
+        let cs = sample_closing_sig();
+        let msg = Message::ClosingSig(cs.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::ClosingSig(cs));
     }
 
     /// Valid `OpenChannel2` message for testing.
@@ -1039,6 +1070,10 @@ mod tests {
         assert_eq!(
             Message::ClosingComplete(sample_closing_complete()).msg_type(),
             msg_type::CLOSING_COMPLETE,
+        );
+        assert_eq!(
+            Message::ClosingSig(sample_closing_sig()).msg_type(),
+            msg_type::CLOSING_SIG,
         );
         assert_eq!(
             Message::OpenChannel2(sample_open_channel2()).msg_type(),

--- a/smite/src/bolt/closing_sig.rs
+++ b/smite/src/bolt/closing_sig.rs
@@ -1,24 +1,18 @@
-//! BOLT 2 `closing_complete` message.
+//! BOLT 2 `closing_sig` message.
 
 use super::BoltError;
+use super::closing_complete::{ClosingTlvs, TLV_CLOSEE_OUTPUT_ONLY};
 use super::tlv::TlvStream;
 use super::types::ChannelId;
 use super::wire::WireFormat;
-use bitcoin::secp256k1::ecdsa::Signature;
 
-/// TLV type for closer output only.
-pub const TLV_CLOSER_OUTPUT_ONLY: u64 = 1;
-/// TLV type for closee output only.
-pub const TLV_CLOSEE_OUTPUT_ONLY: u64 = 2;
-/// TLV type for closer and closee outputs.
-pub const TLV_CLOSER_AND_CLOSEE_OUTPUTS: u64 = 3;
-
-/// BOLT 2 `closing_complete` message (type 40).
+/// BOLT 2 `closing_sig` message (type 41).
 ///
-/// When closing a channel and shutdown is complete, each peer sends
-/// `closing_complete` with the transaction details.
+/// In response to `closing_complete`, the closee signs the proposed closing
+/// transaction and sends back `closing_sig` with the signature in the same TLV
+/// field that was used in `closing_complete`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ClosingComplete {
+pub struct ClosingSig {
     /// The ID of the channel to be closed.
     pub channel_id: ChannelId,
     /// Output script for the initiator of the co-op close.
@@ -33,18 +27,7 @@ pub struct ClosingComplete {
     pub tlvs: ClosingTlvs,
 }
 
-/// TLV extensions for the `closing_complete` and `closing_sig` message.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ClosingTlvs {
-    /// Signature if closing tx only has local output.
-    pub closer_output_only: Option<Signature>,
-    /// Signature if closing tx only has remote output.
-    pub closee_output_only: Option<Signature>,
-    /// Signature if closing tx has local and remote output.
-    pub closer_and_closee_outputs: Option<Signature>,
-}
-
-impl ClosingComplete {
+impl ClosingSig {
     /// Encodes to wire format (without message type prefix).
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
@@ -92,58 +75,19 @@ impl ClosingComplete {
     }
 }
 
-impl ClosingTlvs {
-    /// Encodes closing TLVs into a TLV stream.
-    #[must_use]
-    pub fn to_stream(&self) -> TlvStream {
-        let mut tlv_stream = TlvStream::new();
-        if let Some(closer_output_only) = &self.closer_output_only {
-            tlv_stream.add(
-                TLV_CLOSER_OUTPUT_ONLY,
-                closer_output_only.serialize_compact().to_vec(),
-            );
-        }
-        if let Some(closee_output_only) = &self.closee_output_only {
-            tlv_stream.add(
-                TLV_CLOSEE_OUTPUT_ONLY,
-                closee_output_only.serialize_compact().to_vec(),
-            );
-        }
-        if let Some(closer_and_closee_outputs) = &self.closer_and_closee_outputs {
-            tlv_stream.add(
-                TLV_CLOSER_AND_CLOSEE_OUTPUTS,
-                closer_and_closee_outputs.serialize_compact().to_vec(),
-            );
-        }
-        tlv_stream
-    }
-
-    /// Extracts `closing_complete` and `closing_sig` TLVs from a parsed TLV
-    /// stream.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Truncated` if a signature TLV has invalid length, or
-    /// `InvalidSignature` if the bytes are not a valid compact ECDSA signature.
-    pub fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        Ok(Self {
-            closer_output_only: stream.get_as::<Signature>(TLV_CLOSER_OUTPUT_ONLY)?,
-            closee_output_only: stream.get_as::<Signature>(TLV_CLOSEE_OUTPUT_ONLY)?,
-            closer_and_closee_outputs: stream.get_as::<Signature>(TLV_CLOSER_AND_CLOSEE_OUTPUTS)?,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use bitcoin::secp256k1::ecdsa::Signature;
 
+    use super::super::closing_complete::{
+        TLV_CLOSEE_OUTPUT_ONLY, TLV_CLOSER_AND_CLOSEE_OUTPUTS, TLV_CLOSER_OUTPUT_ONLY,
+    };
     use super::super::{CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE};
     use super::*;
 
-    /// Valid `ClosingComplete` message for testing.
-    fn sample_closing_complete(tlvs: Option<ClosingTlvs>) -> ClosingComplete {
-        ClosingComplete {
+    /// Valid `ClosingSig` message for testing.
+    fn sample_closing_sig(tlvs: Option<ClosingTlvs>) -> ClosingSig {
+        ClosingSig {
             channel_id: ChannelId::new([0xaa; 32]),
             closer_scriptpubkey: vec![0x00; 22],
             closee_scriptpubkey: vec![0x11; 22],
@@ -155,16 +99,16 @@ mod tests {
 
     #[test]
     fn roundtrip() {
-        let original = sample_closing_complete(None);
+        let original = sample_closing_sig(None);
         let encoded = original.encode();
-        let decoded = ClosingComplete::decode(&encoded).unwrap();
+        let decoded = ClosingSig::decode(&encoded).unwrap();
         assert_eq!(original, decoded);
     }
 
     #[test]
     fn decode_truncated_channel_id() {
         assert_eq!(
-            ClosingComplete::decode(&[0x11; 20]),
+            ClosingSig::decode(&[0x11; 20]),
             Err(BoltError::Truncated {
                 expected: CHANNEL_ID_SIZE,
                 actual: 20
@@ -178,7 +122,7 @@ mod tests {
         // one byte intead of two for length prefix
         data.extend_from_slice(&[0x00]);
         assert_eq!(
-            ClosingComplete::decode(&data),
+            ClosingSig::decode(&data),
             Err(BoltError::Truncated {
                 expected: 2,
                 actual: 1
@@ -193,7 +137,7 @@ mod tests {
         data.extend_from_slice(&[0x00, 0x0a]);
         data.extend_from_slice(&[0x22; 5]);
         assert_eq!(
-            ClosingComplete::decode(&data),
+            ClosingSig::decode(&data),
             Err(BoltError::Truncated {
                 expected: 10,
                 actual: 5
@@ -204,12 +148,12 @@ mod tests {
     #[test]
     fn decode_truncated_closee_scriptpubkey_length_prefix() {
         let mut data = vec![0x11; CHANNEL_ID_SIZE];
-        data.extend_from_slice(&[0x00, 10]);
+        data.extend_from_slice(&[0x00, 0x0a]);
         data.extend_from_slice(&[0x22; 10]);
         // one byte instead of two for length prefix
         data.extend_from_slice(&[0x00]);
         assert_eq!(
-            ClosingComplete::decode(&data),
+            ClosingSig::decode(&data),
             Err(BoltError::Truncated {
                 expected: 2,
                 actual: 1
@@ -220,13 +164,13 @@ mod tests {
     #[test]
     fn decode_truncated_closee_scriptpubkey() {
         let mut data = vec![0x11; CHANNEL_ID_SIZE];
-        data.extend_from_slice(&[0x00, 10]);
+        data.extend_from_slice(&[0x00, 0x0a]);
         data.extend_from_slice(&[0x22; 10]);
         // 11 as length prefix, but only give 10 bytes
-        data.extend_from_slice(&[0x00, 11]);
+        data.extend_from_slice(&[0x00, 0x0b]);
         data.extend_from_slice(&[0x33; 10]);
         assert_eq!(
-            ClosingComplete::decode(&data),
+            ClosingSig::decode(&data),
             Err(BoltError::Truncated {
                 expected: 11,
                 actual: 10
@@ -237,14 +181,14 @@ mod tests {
     #[test]
     fn decode_truncated_fee_satoshis() {
         let mut data = vec![0x11; CHANNEL_ID_SIZE];
-        data.extend_from_slice(&[0x00, 10]);
+        data.extend_from_slice(&[0x00, 0x0a]);
         data.extend_from_slice(&[0x22; 10]);
-        data.extend_from_slice(&[0x00, 11]);
+        data.extend_from_slice(&[0x00, 0x0b]);
         data.extend_from_slice(&[0x33; 11]);
         // only three of eight bytes for fee_satoshis
         data.extend_from_slice(&[0x44; 3]);
         assert_eq!(
-            ClosingComplete::decode(&data),
+            ClosingSig::decode(&data),
             Err(BoltError::Truncated {
                 expected: 8,
                 actual: 3
@@ -255,15 +199,15 @@ mod tests {
     #[test]
     fn decode_truncated_locktime() {
         let mut data = vec![0x11; CHANNEL_ID_SIZE];
-        data.extend_from_slice(&[0x00, 10]);
+        data.extend_from_slice(&[0x00, 0x0a]);
         data.extend_from_slice(&[0x22; 10]);
-        data.extend_from_slice(&[0x00, 11]);
+        data.extend_from_slice(&[0x00, 0x0b]);
         data.extend_from_slice(&[0x33; 11]);
         data.extend_from_slice(&[0x44; 8]);
         // only 1 of four bytes for locktime
         data.extend_from_slice(&[0x55]);
         assert_eq!(
-            ClosingComplete::decode(&data),
+            ClosingSig::decode(&data),
             Err(BoltError::Truncated {
                 expected: 4,
                 actual: 1
@@ -284,9 +228,9 @@ mod tests {
             closee_output_only: Some(sig2),
             closer_and_closee_outputs: Some(sig3),
         };
-        let original = sample_closing_complete(Some(tlvs));
+        let original = sample_closing_sig(Some(tlvs));
         let encoded = original.encode();
-        let decoded = ClosingComplete::decode(&encoded).unwrap();
+        let decoded = ClosingSig::decode(&encoded).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -296,8 +240,8 @@ mod tests {
         assert!(tlvs.closer_output_only.is_none());
         assert!(tlvs.closee_output_only.is_none());
         assert!(tlvs.closer_and_closee_outputs.is_none());
-        let msg = sample_closing_complete(Some(tlvs));
-        let decoded = ClosingComplete::decode(&msg.encode()).unwrap();
+        let msg = sample_closing_sig(None);
+        let decoded = ClosingSig::decode(&msg.encode()).unwrap();
         assert!(decoded.tlvs.closer_output_only.is_none());
         assert!(decoded.tlvs.closee_output_only.is_none());
         assert!(decoded.tlvs.closer_and_closee_outputs.is_none());
@@ -305,19 +249,19 @@ mod tests {
 
     #[test]
     fn decode_invalid_signature_tlv() {
-        let sig1 =
-            Signature::from_compact(&[1u8; COMPACT_SIGNATURE_SIZE]).expect("valid signature");
+        let sig = Signature::from_compact(&[1u8; COMPACT_SIGNATURE_SIZE]).expect("valid signature");
         let tlvs = ClosingTlvs {
-            closer_output_only: Some(sig1),
+            closer_output_only: Some(sig),
             ..Default::default()
         };
-        let msg = sample_closing_complete(Some(tlvs));
-        let mut encoded = msg.encode();
+        let cs = sample_closing_sig(Some(tlvs));
+        let mut encoded = cs.encode();
+
         let sig_start = encoded.len() - COMPACT_SIGNATURE_SIZE;
         encoded[sig_start..].copy_from_slice(&[0xff; COMPACT_SIGNATURE_SIZE]);
 
         assert!(matches!(
-            ClosingComplete::decode(&encoded),
+            ClosingSig::decode(&encoded),
             Err(BoltError::InvalidSignature(_))
         ));
     }
@@ -325,11 +269,11 @@ mod tests {
     #[test]
     #[allow(clippy::cast_possible_truncation)]
     fn decode_closer_output_only_reject_trailing_bytes() {
-        let mut encoded = sample_closing_complete(None).encode();
+        let mut encoded = sample_closing_sig(None).encode();
         encoded.extend_from_slice(&[TLV_CLOSER_OUTPUT_ONLY as u8, 0x41]);
         encoded.extend_from_slice(&[1u8; COMPACT_SIGNATURE_SIZE + 1]);
         assert_eq!(
-            ClosingComplete::decode(&encoded),
+            ClosingSig::decode(&encoded),
             Err(BoltError::TlvTrailingBytes {
                 tlv_type: TLV_CLOSER_OUTPUT_ONLY,
                 expected: COMPACT_SIGNATURE_SIZE,
@@ -341,11 +285,11 @@ mod tests {
     #[test]
     #[allow(clippy::cast_possible_truncation)]
     fn decode_closee_output_only_reject_trailing_bytes() {
-        let mut encoded = sample_closing_complete(None).encode();
+        let mut encoded = sample_closing_sig(None).encode();
         encoded.extend_from_slice(&[TLV_CLOSEE_OUTPUT_ONLY as u8, 0x41]);
         encoded.extend_from_slice(&[1u8; COMPACT_SIGNATURE_SIZE + 1]);
         assert_eq!(
-            ClosingComplete::decode(&encoded),
+            ClosingSig::decode(&encoded),
             Err(BoltError::TlvTrailingBytes {
                 tlv_type: TLV_CLOSEE_OUTPUT_ONLY,
                 expected: COMPACT_SIGNATURE_SIZE,
@@ -357,11 +301,11 @@ mod tests {
     #[test]
     #[allow(clippy::cast_possible_truncation)]
     fn decode_closer_and_closee_outputs_reject_trailing_bytes() {
-        let mut encoded = sample_closing_complete(None).encode();
+        let mut encoded = sample_closing_sig(None).encode();
         encoded.extend_from_slice(&[TLV_CLOSER_AND_CLOSEE_OUTPUTS as u8, 0x41]);
         encoded.extend_from_slice(&[1u8; COMPACT_SIGNATURE_SIZE + 1]);
         assert_eq!(
-            ClosingComplete::decode(&encoded),
+            ClosingSig::decode(&encoded),
             Err(BoltError::TlvTrailingBytes {
                 tlv_type: TLV_CLOSER_AND_CLOSEE_OUTPUTS,
                 expected: COMPACT_SIGNATURE_SIZE,


### PR DESCRIPTION
part of #98 | based on #105

This is basically the same as #105.