### PR TITLE
smite-ir: implement `ChannelAnnouncementGenerator`

### DIFF
--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -32,7 +32,9 @@ use std::slice;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
-use smite_ir::generators::{NodeAnnouncementGenerator, OpenChannelGenerator};
+use smite_ir::generators::{
+    ChannelAnnouncementGenerator, NodeAnnouncementGenerator, OpenChannelGenerator,
+};
 use smite_ir::mutators::{InputSwapMutator, OperationParamMutator};
 use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
 
@@ -61,13 +63,15 @@ impl MutatorState {
         }
     }
 
-    /// Generates a fresh program from scratch using our custom generators.
+    /// Generates a fresh program from scratch by randomly delegating to one of
+    /// the registered generators.
     fn generate_fresh(&mut self) -> Program {
         let mut builder = ProgramBuilder::new();
-        if self.rng.random() {
-            OpenChannelGenerator.generate(&mut builder, &mut self.rng);
-        } else {
-            NodeAnnouncementGenerator.generate(&mut builder, &mut self.rng);
+        match self.rng.random_range(0..3) {
+            0 => OpenChannelGenerator.generate(&mut builder, &mut self.rng),
+            1 => ChannelAnnouncementGenerator.generate(&mut builder, &mut self.rng),
+            2 => NodeAnnouncementGenerator.generate(&mut builder, &mut self.rng),
+            _ => unreachable!("random_range() bound out of sync with match arms"),
         }
         self.last_sequence.clear();
         self.last_sequence.push("fresh");

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -5,9 +5,11 @@
 //! protocol flow but delegates value selection and variable reuse to
 //! `ProgramBuilder`.
 
+mod channel_announcement;
 mod node_announcement;
 mod open_channel;
 
+pub use channel_announcement::ChannelAnnouncementGenerator;
 pub use node_announcement::NodeAnnouncementGenerator;
 pub use open_channel::OpenChannelGenerator;
 

--- a/smite-ir/src/generators/channel_announcement.rs
+++ b/smite-ir/src/generators/channel_announcement.rs
@@ -1,0 +1,39 @@
+//! Generator for `channel_announcement` gossip message.
+
+use rand::Rng;
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::{Operation, VariableType};
+
+/// Generates an unsolicited `channel_announcement` send.
+pub struct ChannelAnnouncementGenerator;
+
+impl Generator for ChannelAnnouncementGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        let features = builder.pick_variable(VariableType::Features, rng);
+        let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
+        let scid = builder.pick_variable(VariableType::ShortChannelId, rng);
+
+        // Use fresh private keys since channel_announcement validation
+        // generally requires distinct keys.
+        let node_sk_1 = builder.generate_fresh(VariableType::PrivateKey, rng);
+        let node_sk_2 = builder.generate_fresh(VariableType::PrivateKey, rng);
+        let bitcoin_sk_1 = builder.generate_fresh(VariableType::PrivateKey, rng);
+        let bitcoin_sk_2 = builder.generate_fresh(VariableType::PrivateKey, rng);
+
+        let msg = builder.append(
+            Operation::BuildChannelAnnouncement,
+            &[
+                features,
+                chain_hash,
+                scid,
+                node_sk_1,
+                node_sk_2,
+                bitcoin_sk_1,
+                bitcoin_sk_2,
+            ],
+        );
+        builder.append(Operation::SendMessage, &[msg]);
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -6,7 +6,7 @@ use rand::rngs::SmallRng;
 use smite::bolt::{MAX_MESSAGE_SIZE, ShortChannelId};
 
 use super::*;
-use generators::{NodeAnnouncementGenerator, OpenChannelGenerator};
+use generators::{ChannelAnnouncementGenerator, NodeAnnouncementGenerator, OpenChannelGenerator};
 use mutators::{InputSwapMutator, OperationParamMutator};
 use operation::{AcceptChannelField, ChannelTypeVariant, ShutdownScriptVariant};
 use program::ValidateError;
@@ -985,6 +985,41 @@ fn generated_open_channel_program_structure() {
     );
 }
 
+fn generate_channel_announcement_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    ChannelAnnouncementGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+// If ChannelAnnouncementGenerator completes without panicking, every
+// instruction has correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_channel_announcement_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_channel_announcement_program(seed);
+    }
+}
+
+#[test]
+fn generated_channel_announcement_program_structure() {
+    let program = generate_channel_announcement_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::SendMessage),
+        "last instruction should be SendMessage",
+    );
+    let build_count = ops
+        .iter()
+        .filter(|op| matches!(op, Operation::BuildChannelAnnouncement))
+        .count();
+    assert_eq!(
+        build_count, 1,
+        "expected exactly one BuildChannelAnnouncement"
+    );
+}
+
 fn generate_node_announcement_program(seed: u64) -> Program {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut builder = ProgramBuilder::new();
@@ -1036,6 +1071,14 @@ fn generated_node_announcement_alias_is_utf8() {
 #[test]
 fn generated_open_channel_program_postcard_roundtrip() {
     let program = generate_open_channel_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generated_channel_announcement_program_postcard_roundtrip() {
+    let program = generate_channel_announcement_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);
@@ -1171,6 +1214,16 @@ fn append_type_mismatch_panics() {
 fn validate_accepts_generated_open_channel_program() {
     for seed in 0..100 {
         let program = generate_open_channel_program(seed);
+        program
+            .validate()
+            .expect("generated program should validate");
+    }
+}
+
+#[test]
+fn validate_accepts_generated_channel_announcement_program() {
+    for seed in 0..100 {
+        let program = generate_channel_announcement_program(seed);
         program
             .validate()
             .expect("generated program should validate");


### PR DESCRIPTION
Generates programs that send correctly-signed `channel_announcement` messages to the target.

Verified that all 4 targets successfully decode the `channel_announcement`s we send and pass initial validation, including signature checks.  Once we can actually mine fake funding transactions, we will be able to exercise even deeper code paths.

[ldk-coverage.tar.gz](https://github.com/user-attachments/files/28481561/ldk-coverage.tar.gz)
[lnd-coverage.tar.gz](https://github.com/user-attachments/files/28481565/lnd-coverage.tar.gz)
[cln-coverage.tar.gz](https://github.com/user-attachments/files/28481575/cln-coverage.tar.gz)
[eclair-coverage.tar.gz](https://github.com/user-attachments/files/28481583/eclair-coverage.tar.gz)

Ref: #71
