### PR TITLE
smite-ir: implement `ChannelUpdateGenerator`

### DIFF
--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -40,7 +40,8 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use smite_ir::generators::{
-    ChannelAnnouncementGenerator, NodeAnnouncementGenerator, OpenChannelGenerator,
+    ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
+    OpenChannelGenerator,
 };
 use smite_ir::minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use smite_ir::mutators::{InputSwapMutator, OperationParamMutator};
@@ -75,10 +76,11 @@ impl MutatorState {
     /// the registered generators.
     fn generate_fresh(&mut self) -> Program {
         let mut builder = ProgramBuilder::new();
-        match self.rng.random_range(0..3) {
+        match self.rng.random_range(0..4) {
             0 => OpenChannelGenerator.generate(&mut builder, &mut self.rng),
             1 => ChannelAnnouncementGenerator.generate(&mut builder, &mut self.rng),
             2 => NodeAnnouncementGenerator.generate(&mut builder, &mut self.rng),
+            3 => ChannelUpdateGenerator.generate(&mut builder, &mut self.rng),
             _ => unreachable!("random_range() bound out of sync with match arms"),
         }
         self.last_sequence.clear();

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -6,10 +6,12 @@
 //! `ProgramBuilder`.
 
 mod channel_announcement;
+mod channel_update;
 mod node_announcement;
 mod open_channel;
 
 pub use channel_announcement::ChannelAnnouncementGenerator;
+pub use channel_update::ChannelUpdateGenerator;
 pub use node_announcement::NodeAnnouncementGenerator;
 pub use open_channel::OpenChannelGenerator;
 

--- a/smite-ir/src/generators/channel_update.rs
+++ b/smite-ir/src/generators/channel_update.rs
@@ -1,0 +1,53 @@
+//! Generator for `channel_update` gossip message.
+
+use rand::Rng;
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::{Operation, VariableType};
+
+/// Generates an unsolicited `channel_update` send.
+///
+/// Emits instructions to build and send a single signed `channel_update`. The
+/// signing key, chain hash, and short channel id are drawn via
+/// `pick_variable` so they can be shared with other gossip messages (e.g. a
+/// preceding `channel_announcement`) when generators are composed.
+pub struct ChannelUpdateGenerator;
+
+impl Generator for ChannelUpdateGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        let node_sk = builder.pick_variable(VariableType::PrivateKey, rng);
+        let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
+        let short_channel_id = builder.pick_variable(VariableType::ShortChannelId, rng);
+        let timestamp = builder.pick_variable(VariableType::Timestamp, rng);
+
+        // message_flags and channel_flags are plain U8s so the mutator can flip
+        // individual bits (e.g. must_be_one, direction, disable).
+        let message_flags = builder.pick_variable(VariableType::U8, rng);
+        let channel_flags = builder.pick_variable(VariableType::U8, rng);
+
+        let cltv_expiry_delta = builder.pick_variable(VariableType::U16, rng);
+        let htlc_minimum_msat = builder.pick_variable(VariableType::Amount, rng);
+        let fee_base_msat = builder.pick_variable(VariableType::ForwardingFee, rng);
+        let fee_proportional_millionths = builder.pick_variable(VariableType::ForwardingFee, rng);
+        let htlc_maximum_msat = builder.pick_variable(VariableType::Amount, rng);
+
+        let msg = builder.append(
+            Operation::BuildChannelUpdate,
+            &[
+                node_sk,
+                chain_hash,
+                short_channel_id,
+                timestamp,
+                message_flags,
+                channel_flags,
+                cltv_expiry_delta,
+                htlc_minimum_msat,
+                fee_base_msat,
+                fee_proportional_millionths,
+                htlc_maximum_msat,
+            ],
+        );
+        builder.append(Operation::SendMessage, &[msg]);
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -6,7 +6,10 @@ use rand::rngs::SmallRng;
 use smite::bolt::{MAX_MESSAGE_SIZE, ShortChannelId};
 
 use super::*;
-use generators::{ChannelAnnouncementGenerator, NodeAnnouncementGenerator, OpenChannelGenerator};
+use generators::{
+    ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
+    OpenChannelGenerator,
+};
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use mutators::{InputSwapMutator, OperationParamMutator};
 use operation::{AcceptChannelField, ChannelTypeVariant, ShutdownScriptVariant};
@@ -982,6 +985,38 @@ fn generated_node_announcement_alias_is_utf8() {
     }
 }
 
+fn generate_channel_update_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    ChannelUpdateGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+// If ChannelUpdateGenerator completes without panicking, every instruction has
+// correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_channel_update_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_channel_update_program(seed);
+    }
+}
+
+#[test]
+fn generated_channel_update_program_structure() {
+    let program = generate_channel_update_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::SendMessage),
+        "last instruction should be SendMessage",
+    );
+    let build_count = ops
+        .iter()
+        .filter(|op| matches!(op, Operation::BuildChannelUpdate))
+        .count();
+    assert_eq!(build_count, 1, "expected exactly one BuildChannelUpdate");
+}
+
 #[test]
 fn generated_open_channel_program_postcard_roundtrip() {
     let program = generate_open_channel_program(42);
@@ -1001,6 +1036,14 @@ fn generated_channel_announcement_program_postcard_roundtrip() {
 #[test]
 fn generated_node_announcement_program_postcard_roundtrip() {
     let program = generate_node_announcement_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generated_channel_update_program_postcard_roundtrip() {
+    let program = generate_channel_update_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);


### PR DESCRIPTION
Generates programs that build and send correctly-signed `channel_update` messages to the target.

The signing key, chain hash, and short channel id are drawn via `pick_variable` so they can be shared with other gossip messages (e.g. a preceding `channel_announcement`) when generators are composed in the future.

`message_flags` and `channel_flags` are exposed as plain `U8` variables so that OperationParamMutator can flip individual bits, including must_be_one, direction, and disable.


Ref: #71