### PR TITLE
smitebot: add campaign configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +363,16 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "inout"
@@ -565,6 +587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +686,7 @@ dependencies = [
  "simple_logger",
  "tempfile",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -714,6 +746,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/smitebot/Cargo.toml
+++ b/smitebot/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 serde_json.workspace = true
 simple_logger.workspace = true
 thiserror.workspace = true
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -17,7 +17,33 @@ smitebot doctor --aflpp-path ~/AFLplusplus
 smitebot doctor --aflpp-path ~/AFLplusplus --json
 ```
 
+## Configuration
+
+Campaign settings are stored in a TOML file. See [`sample-campaign.toml`](sample-campaign.toml) for a complete example.
+
+| Field        | Required | Description                                                          |
+| ------------ | -------- | -------------------------------------------------------------------- |
+| `target`     | yes      | Lightning implementation to fuzz (`lnd`, `cln`, `ldk`, or `eclair`). |
+| `scenario`   | yes      | Scenario binary selected by the workload Dockerfile.                 |
+| `aflpp_path` | yes      | Path to the AFL++ source tree.                                       |
+| `smite_dir`  | yes      | Path to the smite repository root.                                   |
+| `runners`    | yes      | Number of parallel AFL++ instances to launch (must be at least 1).   |
+| `seed_dir`   | no       | Directory containing seed inputs; omit to start from an empty corpus.|
+| `output_dir` | yes      | AFL++ output directory for findings and stats.                       |
+| `sharedir`   | yes      | Nyx shared directory path; created automatically by `smitebot start`.|
+| `image`      | no       | Docker image tag override; defaults to `smite-<target>-<scenario>`.  |
+| `afl_env`    | no       | Extra environment variables passed to AFL++ instances.               |
+| `afl_flags`  | no       | Extra CLI flags appended to `afl-fuzz`.                              |
+
 ## Commands
+
+### smitebot config
+
+`smitebot config` validates a campaign configuration file, reports the resolved settings, and checks that referenced paths exist on disk.
+
+```bash
+smitebot config sample-campaign.toml
+```
 
 ### smitebot build
 

--- a/smitebot/sample-campaign.toml
+++ b/smitebot/sample-campaign.toml
@@ -1,0 +1,35 @@
+# Sample smitebot campaign configuration for fuzzing LND with the encrypted_bytes scenario on 8 cores.
+
+# Target Lightning implementation (lnd, ldk, cln, eclair).
+target = "lnd"
+
+# Fuzzing scenario.
+scenario = "encrypted_bytes"
+
+# Path to AFL++ source tree.
+aflpp_path = "/home/user/AFLplusplus"
+
+# Path to smite repository root.
+smite_dir = "."
+
+# Number of parallel AFL++ instances to launch.
+runners = 8
+
+# Seed corpus directory (optional; omit to start from an empty corpus).
+seed_dir = "/tmp/smite-seeds"
+
+# AFL++ output directory.
+output_dir = "/tmp/smite-out"
+
+# Nyx shared directory path; created automatically by `smitebot start`.
+sharedir = "/tmp/smite-nyx"
+
+# Docker image tag override (default: smite-<target>-<scenario>).
+# image = "smite-lnd-encrypted_bytes"
+
+# Extra environment variables passed to AFL++ instances.
+# [afl_env]
+# AFL_KEEP_TIMEOUTS = "1"
+
+# Extra CLI flags appended to afl-fuzz.
+# afl_flags = ["-t", "1000+"]

--- a/smitebot/src/commands.rs
+++ b/smitebot/src/commands.rs
@@ -1,5 +1,7 @@
 pub mod build;
+pub mod config;
 pub mod doctor;
 
 pub use build::{BuildArgs, BuildCommand};
+pub use config::{ConfigArgs, ConfigCommand};
 pub use doctor::{DoctorArgs, DoctorCommand};

--- a/smitebot/src/commands/build.rs
+++ b/smitebot/src/commands/build.rs
@@ -1,11 +1,12 @@
 //! Docker image builds for Smite workloads.
 //! The command keeps Docker's output visible so rebuild failures are easy to debug.
 
-use std::fmt;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 
-use clap::{Args, ValueEnum};
+use clap::Args;
+
+use crate::config::Target;
 
 /// Command handler for `smitebot build`.
 pub struct BuildCommand;
@@ -15,7 +16,7 @@ pub struct BuildCommand;
 pub struct BuildArgs {
     /// Target implementation to build.
     #[arg(long)]
-    target: WorkloadTarget,
+    target: Target,
     /// Scenario binary selected by the workload Dockerfile.
     #[arg(long)]
     scenario: String,
@@ -31,31 +32,6 @@ pub struct BuildArgs {
     /// Pass --no-cache to docker build.
     #[arg(long)]
     no_cache: bool,
-}
-
-/// Smite workload targets with Dockerfiles under `workloads/`.
-#[derive(Clone, Copy, Debug, ValueEnum)]
-enum WorkloadTarget {
-    /// Lightning Network Daemon workload.
-    Lnd,
-    /// Core Lightning workload.
-    Cln,
-    /// LDK Node workload.
-    Ldk,
-    /// Eclair workload.
-    Eclair,
-}
-
-impl fmt::Display for WorkloadTarget {
-    /// Formats the lowercase target name used in paths and Docker image tags.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Lnd => write!(f, "lnd"),
-            Self::Cln => write!(f, "cln"),
-            Self::Ldk => write!(f, "ldk"),
-            Self::Eclair => write!(f, "eclair"),
-        }
-    }
 }
 
 /// Fully resolved Docker build inputs.
@@ -132,7 +108,7 @@ impl BuildCommand {
 }
 
 /// Returns the default image tag used by Smite's manual Docker build flow.
-fn default_workload_image_tag(target: WorkloadTarget, scenario: &str, coverage: bool) -> String {
+fn default_workload_image_tag(target: Target, scenario: &str, coverage: bool) -> String {
     let suffix = if coverage { "-coverage" } else { "" };
     format!("smite-{target}-{scenario}{suffix}")
 }
@@ -161,7 +137,7 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    fn sample_build_args(target: WorkloadTarget, scenario: &str) -> BuildArgs {
+    fn sample_build_args(target: Target, scenario: &str) -> BuildArgs {
         BuildArgs {
             target,
             scenario: scenario.to_string(),
@@ -175,18 +151,18 @@ mod tests {
     #[test]
     fn default_workload_image_tag_matches_smite_convention() {
         assert_eq!(
-            default_workload_image_tag(WorkloadTarget::Lnd, "encrypted_bytes", false),
+            default_workload_image_tag(Target::Lnd, "encrypted_bytes", false),
             "smite-lnd-encrypted_bytes"
         );
         assert_eq!(
-            default_workload_image_tag(WorkloadTarget::Cln, "noise", true),
+            default_workload_image_tag(Target::Cln, "noise", true),
             "smite-cln-noise-coverage"
         );
     }
 
     #[test]
     fn build_inputs_use_normal_dockerfile_by_default() {
-        let args = sample_build_args(WorkloadTarget::Ldk, "init");
+        let args = sample_build_args(Target::Ldk, "init");
         let inputs = BuildInputs::from_args(&args);
 
         assert_eq!(inputs.image, "smite-ldk-init");
@@ -202,13 +178,10 @@ mod tests {
     #[test]
     fn build_inputs_select_expected_dockerfile_for_each_target() {
         let cases = [
-            (WorkloadTarget::Lnd, "/repo/smite/workloads/lnd/Dockerfile"),
-            (WorkloadTarget::Cln, "/repo/smite/workloads/cln/Dockerfile"),
-            (WorkloadTarget::Ldk, "/repo/smite/workloads/ldk/Dockerfile"),
-            (
-                WorkloadTarget::Eclair,
-                "/repo/smite/workloads/eclair/Dockerfile",
-            ),
+            (Target::Lnd, "/repo/smite/workloads/lnd/Dockerfile"),
+            (Target::Cln, "/repo/smite/workloads/cln/Dockerfile"),
+            (Target::Ldk, "/repo/smite/workloads/ldk/Dockerfile"),
+            (Target::Eclair, "/repo/smite/workloads/eclair/Dockerfile"),
         ];
 
         for (target, expected_dockerfile) in cases {
@@ -221,7 +194,7 @@ mod tests {
 
     #[test]
     fn build_inputs_support_coverage_and_custom_image() {
-        let mut args = sample_build_args(WorkloadTarget::Eclair, "encrypted_bytes");
+        let mut args = sample_build_args(Target::Eclair, "encrypted_bytes");
         args.coverage = true;
         args.image = Some("local/eclair-eb:debug".to_string());
         args.no_cache = true;
@@ -238,7 +211,7 @@ mod tests {
 
     #[test]
     fn build_inputs_use_default_coverage_image_when_not_overridden() {
-        let mut args = sample_build_args(WorkloadTarget::Cln, "noise");
+        let mut args = sample_build_args(Target::Cln, "noise");
         args.coverage = true;
 
         let inputs = BuildInputs::from_args(&args);
@@ -252,7 +225,7 @@ mod tests {
 
     #[test]
     fn build_inputs_preserve_custom_smite_dir() {
-        let mut args = sample_build_args(WorkloadTarget::Lnd, "encrypted_bytes");
+        let mut args = sample_build_args(Target::Lnd, "encrypted_bytes");
         args.smite_dir = PathBuf::from("/tmp/local-smite");
 
         let inputs = BuildInputs::from_args(&args);

--- a/smitebot/src/commands/config.rs
+++ b/smitebot/src/commands/config.rs
@@ -1,0 +1,169 @@
+//! Campaign configuration validation.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::config::CampaignConfig;
+
+/// Command handler for `smitebot config`.
+pub struct ConfigCommand;
+
+/// CLI arguments for `smitebot config`.
+#[derive(Debug, Args)]
+pub struct ConfigArgs {
+    /// Path to the campaign configuration TOML file.
+    path: PathBuf,
+    /// Emit machine-readable JSON output.
+    #[arg(long)]
+    json: bool,
+}
+
+/// JSON-serializable report for `smitebot config --json`.
+#[derive(Debug, Serialize)]
+struct ConfigReport {
+    target: String,
+    scenario: String,
+    aflpp_path: String,
+    smite_dir: String,
+    runners: u16,
+    seed_dir: Option<String>,
+    output_dir: String,
+    sharedir: String,
+    image: String,
+    afl_env: HashMap<String, String>,
+    afl_flags: Vec<String>,
+    errors: Vec<String>,
+    valid: bool,
+}
+
+/// JSON-serializable error report when config fails to load.
+#[derive(Debug, Serialize)]
+struct ConfigErrorReport {
+    error: String,
+    valid: bool,
+}
+
+impl ConfigCommand {
+    /// Validates a campaign configuration file and reports the result.
+    pub fn execute(args: &ConfigArgs) -> bool {
+        match CampaignConfig::load(&args.path) {
+            Ok(config) => {
+                let errors = config.check_paths();
+                let valid = errors.is_empty();
+
+                if args.json {
+                    let report = ConfigReport {
+                        target: config.target.to_string(),
+                        scenario: config.scenario.clone(),
+                        aflpp_path: config.aflpp_path.display().to_string(),
+                        smite_dir: config.smite_dir.display().to_string(),
+                        runners: config.runners,
+                        seed_dir: config.seed_dir.as_ref().map(|p| p.display().to_string()),
+                        output_dir: config.output_dir.display().to_string(),
+                        sharedir: config.sharedir.display().to_string(),
+                        image: config.image_tag(),
+                        afl_env: config.afl_env.clone(),
+                        afl_flags: config.afl_flags.clone(),
+                        errors,
+                        valid,
+                    };
+                    let json = serde_json::to_string_pretty(&report)
+                        .expect("ConfigReport is always serializable");
+                    println!("{json}");
+                } else {
+                    println!("target:     {}", config.target);
+                    println!("scenario:   {}", config.scenario);
+                    println!("aflpp_path: {}", config.aflpp_path.display());
+                    println!("smite_dir:  {}", config.smite_dir.display());
+                    println!("runners:    {}", config.runners);
+                    match &config.seed_dir {
+                        Some(dir) => println!("seed_dir:   {}", dir.display()),
+                        None => println!("seed_dir:   (empty corpus)"),
+                    }
+                    println!("output_dir: {}", config.output_dir.display());
+                    println!("sharedir:   {}", config.sharedir.display());
+                    println!("image:      {}", config.image_tag());
+                    for (key, val) in &config.afl_env {
+                        println!("afl_env:    {key}={val}");
+                    }
+                    for flag in &config.afl_flags {
+                        println!("afl_flags:  {flag}");
+                    }
+                    for error in &errors {
+                        eprintln!("error: {error}");
+                    }
+                }
+                valid
+            }
+            Err(e) => {
+                if args.json {
+                    let report = ConfigErrorReport {
+                        error: e.to_string(),
+                        valid: false,
+                    };
+                    let json = serde_json::to_string_pretty(&report)
+                        .expect("ConfigErrorReport is always serializable");
+                    println!("{json}");
+                } else {
+                    eprintln!("error: {e}");
+                }
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_report_json_is_machine_readable() {
+        let report = ConfigReport {
+            target: "lnd".to_string(),
+            scenario: "encrypted_bytes".to_string(),
+            aflpp_path: "/home/user/AFLplusplus".to_string(),
+            smite_dir: ".".to_string(),
+            runners: 8,
+            seed_dir: Some("/tmp/seeds".to_string()),
+            output_dir: "/tmp/out".to_string(),
+            sharedir: "/tmp/nyx".to_string(),
+            image: "smite-lnd-encrypted_bytes".to_string(),
+            afl_env: HashMap::from([("AFL_KEEP_TIMEOUTS".to_string(), "1".to_string())]),
+            afl_flags: vec!["-t".to_string(), "1000+".to_string()],
+            errors: vec!["aflpp_path does not exist: /home/user/AFLplusplus".to_string()],
+            valid: false,
+        };
+
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["target"], "lnd");
+        assert_eq!(parsed["runners"], 8);
+        assert_eq!(parsed["valid"], false);
+        assert_eq!(parsed["seed_dir"], "/tmp/seeds");
+        assert_eq!(parsed["afl_env"]["AFL_KEEP_TIMEOUTS"], "1");
+        assert_eq!(parsed["afl_flags"][0], "-t");
+        assert_eq!(
+            parsed["errors"][0],
+            "aflpp_path does not exist: /home/user/AFLplusplus"
+        );
+    }
+
+    #[test]
+    fn config_error_report_json_is_machine_readable() {
+        let report = ConfigErrorReport {
+            error: "failed to parse config.toml".to_string(),
+            valid: false,
+        };
+
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["valid"], false);
+        assert!(parsed["error"].is_string());
+    }
+}

--- a/smitebot/src/config.rs
+++ b/smitebot/src/config.rs
@@ -1,0 +1,413 @@
+//! Campaign configuration file parsing and validation.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::ValueEnum;
+use serde::Deserialize;
+
+/// A parsed and validated smitebot campaign configuration.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CampaignConfig {
+    /// Workload target implementation to fuzz.
+    pub target: Target,
+    /// Scenario binary selected by the workload Dockerfile.
+    pub scenario: String,
+    /// Path to AFL++ source tree.
+    pub aflpp_path: PathBuf,
+    /// Path to the smite repository root.
+    pub smite_dir: PathBuf,
+    /// Number of parallel AFL++ instances to launch.
+    pub runners: u16,
+    /// Directory containing seed inputs; omit to start from an empty corpus.
+    pub seed_dir: Option<PathBuf>,
+    /// AFL++ output directory for findings and stats.
+    pub output_dir: PathBuf,
+    /// Nyx shared directory path; created automatically by `smitebot start`.
+    pub sharedir: PathBuf,
+    /// Docker image tag override; derived from target and scenario when absent.
+    pub image: Option<String>,
+    /// Extra environment variables passed to AFL++ instances.
+    #[serde(default)]
+    pub afl_env: HashMap<String, String>,
+    /// Extra CLI flags appended to the `afl-fuzz` command.
+    #[serde(default)]
+    pub afl_flags: Vec<String>,
+}
+
+/// Lightning Network implementation to target.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum Target {
+    /// Lightning Network Daemon.
+    Lnd,
+    /// Core Lightning.
+    Cln,
+    /// LDK Node.
+    Ldk,
+    /// Eclair.
+    Eclair,
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lnd => write!(f, "lnd"),
+            Self::Cln => write!(f, "cln"),
+            Self::Ldk => write!(f, "ldk"),
+            Self::Eclair => write!(f, "eclair"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read {}: {source}", path.display())]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse {}: {source}", path.display())]
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+    #[error("runners must be at least 1")]
+    InvalidRunners,
+    #[error("scenario must not be empty")]
+    EmptyScenario,
+    #[error("image must not be empty when specified")]
+    EmptyImage,
+}
+
+impl CampaignConfig {
+    /// Loads and validates a campaign configuration from a TOML file.
+    pub fn load(path: &Path) -> Result<Self, ConfigError> {
+        let contents = fs::read_to_string(path).map_err(|source| ConfigError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let config: Self = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Returns the Docker image tag, using the Smite convention as the default.
+    #[must_use]
+    pub fn image_tag(&self) -> String {
+        self.image
+            .clone()
+            .unwrap_or_else(|| format!("smite-{}-{}", self.target, self.scenario))
+    }
+
+    /// Checks that referenced filesystem paths exist and are usable.
+    ///
+    /// Returns a list of error descriptions. An empty list means all paths are
+    /// valid.
+    #[must_use]
+    pub fn check_paths(&self) -> Vec<String> {
+        let mut errors = Vec::new();
+        if !self.aflpp_path.exists() {
+            errors.push(format!(
+                "aflpp_path does not exist: {}",
+                self.aflpp_path.display()
+            ));
+        }
+        if !self.smite_dir.exists() {
+            errors.push(format!(
+                "smite_dir does not exist: {}",
+                self.smite_dir.display()
+            ));
+        }
+        if let Some(dir) = &self.seed_dir {
+            if !dir.exists() {
+                errors.push(format!("seed_dir does not exist: {}", dir.display()));
+            } else if dir.read_dir().map_or(true, |mut d| d.next().is_none()) {
+                errors.push(format!("seed_dir is empty: {}", dir.display()));
+            }
+        }
+        errors
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.runners == 0 {
+            return Err(ConfigError::InvalidRunners);
+        }
+        if self.scenario.is_empty() {
+            return Err(ConfigError::EmptyScenario);
+        }
+        if self.image.as_ref().is_some_and(String::is_empty) {
+            return Err(ConfigError::EmptyImage);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_config(dir: &Path, content: &str) -> PathBuf {
+        let path = dir.join("campaign.toml");
+        let mut file = fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        path
+    }
+
+    const VALID_CONFIG: &str = r#"
+target = "lnd"
+scenario = "encrypted_bytes"
+aflpp_path = "/home/user/AFLplusplus"
+smite_dir = "."
+runners = 8
+seed_dir = "/tmp/smite-seeds"
+output_dir = "/tmp/smite-out"
+sharedir = "/tmp/smite-nyx"
+"#;
+
+    #[test]
+    fn load_parses_valid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), VALID_CONFIG);
+
+        let config = CampaignConfig::load(&path).unwrap();
+
+        assert_eq!(config.target, Target::Lnd);
+        assert_eq!(config.scenario, "encrypted_bytes");
+        assert_eq!(config.aflpp_path, PathBuf::from("/home/user/AFLplusplus"));
+        assert_eq!(config.smite_dir, PathBuf::from("."));
+        assert_eq!(config.runners, 8);
+        assert_eq!(
+            config.seed_dir.as_deref(),
+            Some(Path::new("/tmp/smite-seeds"))
+        );
+        assert_eq!(config.output_dir, PathBuf::from("/tmp/smite-out"));
+        assert_eq!(config.sharedir, PathBuf::from("/tmp/smite-nyx"));
+        assert!(config.image.is_none());
+    }
+
+    #[test]
+    fn load_rejects_missing_required_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "target = \"lnd\"\nscenario = \"noise\"\n");
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_rejects_invalid_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = VALID_CONFIG.replace("\"lnd\"", "\"btcd\"");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_rejects_zero_runners() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = VALID_CONFIG.replace("runners = 8", "runners = 0");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidRunners));
+    }
+
+    #[test]
+    fn load_rejects_empty_scenario() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = VALID_CONFIG.replace("scenario = \"encrypted_bytes\"", "scenario = \"\"");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::EmptyScenario));
+    }
+
+    #[test]
+    fn load_reports_missing_file() {
+        let err = CampaignConfig::load(Path::new("/no/such/config.toml")).unwrap_err();
+        assert!(matches!(err, ConfigError::Read { .. }));
+    }
+
+    #[test]
+    fn image_tag_derives_default_from_target_and_scenario() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), VALID_CONFIG);
+
+        let config = CampaignConfig::load(&path).unwrap();
+
+        assert_eq!(config.image_tag(), "smite-lnd-encrypted_bytes");
+    }
+
+    #[test]
+    fn image_tag_uses_override_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}image = \"my-image:latest\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let config = CampaignConfig::load(&path).unwrap();
+
+        assert_eq!(config.image_tag(), "my-image:latest");
+    }
+
+    #[test]
+    fn load_accepts_all_targets() {
+        for target in ["lnd", "cln", "ldk", "eclair"] {
+            let dir = tempfile::tempdir().unwrap();
+            let content = VALID_CONFIG.replace("\"lnd\"", &format!("\"{target}\""));
+            let path = write_config(dir.path(), &content);
+
+            let config = CampaignConfig::load(&path).unwrap();
+            assert_eq!(config.target.to_string(), target);
+        }
+    }
+
+    #[test]
+    fn load_accepts_missing_seed_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = VALID_CONFIG.replace("seed_dir = \"/tmp/smite-seeds\"\n", "");
+        let path = write_config(dir.path(), &content);
+
+        let config = CampaignConfig::load(&path).unwrap();
+        assert!(config.seed_dir.is_none());
+    }
+
+    #[test]
+    fn load_rejects_empty_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}image = \"\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::EmptyImage));
+    }
+
+    #[test]
+    fn load_defaults_afl_env_and_flags_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), VALID_CONFIG);
+
+        let config = CampaignConfig::load(&path).unwrap();
+
+        assert!(config.afl_env.is_empty());
+        assert!(config.afl_flags.is_empty());
+    }
+
+    #[test]
+    fn load_parses_afl_env_and_flags() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!(
+            "{VALID_CONFIG}\nafl_flags = [\"-t\", \"1000+\"]\n\n[afl_env]\nAFL_KEEP_TIMEOUTS = \"1\"\n"
+        );
+        let path = write_config(dir.path(), &content);
+
+        let config = CampaignConfig::load(&path).unwrap();
+
+        assert_eq!(config.afl_env.get("AFL_KEEP_TIMEOUTS").unwrap(), "1");
+        assert_eq!(config.afl_flags, vec!["-t", "1000+"]);
+    }
+
+    #[test]
+    fn load_rejects_unknown_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}extra_field = true\n");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn check_paths_reports_missing_aflpp_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-aflpp");
+        let content =
+            VALID_CONFIG.replace("/home/user/AFLplusplus", &missing.display().to_string());
+        let path = write_config(dir.path(), &content);
+        let config = CampaignConfig::load(&path).unwrap();
+
+        let errors = config.check_paths();
+        assert!(errors.iter().any(|e| e.contains("aflpp_path")));
+    }
+
+    #[test]
+    fn check_paths_reports_missing_seed_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-seeds");
+        let content = VALID_CONFIG.replace("/tmp/smite-seeds", &missing.display().to_string());
+        let path = write_config(dir.path(), &content);
+        let config = CampaignConfig::load(&path).unwrap();
+
+        let errors = config.check_paths();
+        assert!(errors.iter().any(|e| e.contains("seed_dir")));
+    }
+
+    #[test]
+    fn check_paths_reports_empty_seed_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let seed = dir.path().join("seeds");
+        fs::create_dir(&seed).unwrap();
+        let content = VALID_CONFIG.replace("/tmp/smite-seeds", &seed.display().to_string());
+        let path = write_config(dir.path(), &content);
+        let config = CampaignConfig::load(&path).unwrap();
+
+        let errors = config.check_paths();
+        assert!(errors.iter().any(|e| e.contains("seed_dir is empty")));
+    }
+
+    #[test]
+    fn check_paths_accepts_non_empty_seed_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let seed = dir.path().join("seeds");
+        fs::create_dir(&seed).unwrap();
+        fs::write(seed.join("input0"), b"\x00").unwrap();
+        let content = VALID_CONFIG
+            .replace("/tmp/smite-seeds", &seed.display().to_string())
+            .replace("/home/user/AFLplusplus", &dir.path().display().to_string())
+            .replace(
+                "smite_dir = \".\"",
+                &format!("smite_dir = \"{}\"", dir.path().display()),
+            );
+        let path = write_config(dir.path(), &content);
+        let config = CampaignConfig::load(&path).unwrap();
+
+        let errors = config.check_paths();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn check_paths_skips_seed_dir_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = VALID_CONFIG
+            .replace("seed_dir = \"/tmp/smite-seeds\"\n", "")
+            .replace("/home/user/AFLplusplus", &dir.path().display().to_string())
+            .replace(
+                "smite_dir = \".\"",
+                &format!("smite_dir = \"{}\"", dir.path().display()),
+            );
+        let path = write_config(dir.path(), &content);
+        let config = CampaignConfig::load(&path).unwrap();
+
+        let errors = config.check_paths();
+        assert!(!errors.iter().any(|e| e.contains("seed_dir")));
+    }
+
+    #[test]
+    fn config_error_messages_include_file_path() {
+        let err = CampaignConfig::load(Path::new("/tmp/bad.toml")).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("/tmp/bad.toml"),
+            "error should include path: {msg}"
+        );
+    }
+}

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -1,13 +1,14 @@
 //! `smitebot` command-line interface.
 
 mod commands;
+mod config;
 mod utils;
 
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 
-use commands::{BuildArgs, BuildCommand, DoctorArgs, DoctorCommand};
+use commands::{BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, DoctorArgs, DoctorCommand};
 
 #[derive(Debug, Parser)]
 #[command(name = "smitebot", version, about = "Smite campaign manager")]
@@ -20,6 +21,8 @@ struct Cli {
 enum Commands {
     /// Build Smite workload Docker images.
     Build(BuildArgs),
+    /// Validate a campaign configuration file.
+    Config(ConfigArgs),
     /// Validate host prerequisites for running Smite campaigns.
     Doctor(DoctorArgs),
 }
@@ -30,6 +33,7 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
     let success = match cli.command {
         Commands::Build(args) => BuildCommand::execute(&args),
+        Commands::Config(args) => ConfigCommand::execute(&args),
         Commands::Doctor(args) => DoctorCommand::execute(&args),
     };
 


### PR DESCRIPTION
## Summary
 
 Adds the campaign configuration layer that `start`/`stop`/`status` will consume. Addresses the sample config request.
 
  - `smitebot/src/config.rs` — `CampaignConfig` struct, `Target` enum, TOML parsing with `deny_unknown_fields`, validation (runners ≥ 1, non-empty scenario)
  - `smitebot/src/commands/config.rs` — `smitebot config <path>` subcommand to validate configs before launching campaigns
  - `smitebot/examples/lnd-encrypted-bytes.toml` — annotated sample config
  - corresponding README updates for `smitebot config` command
 
 Ref. #70 

