### PR TITLE
smitebot: add `smitebot start` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ firefox ./$TARGET-$SCENARIO-coverage-report/html/index.html
 
 ```
 smite/              # Core Rust library (runners, scenarios, noise protocol, BOLT messages)
-smitebot/           # Automation CLI (doctor and upcoming campaign orchestration commands)
+smitebot/           # Automation CLI for fuzzing campaign orchestration 
 smite-ir/           # IR types, generators, and mutators for structured fuzzing programs
 smite-ir-mutator/   # AFL++ custom mutator cdylib for IR programs
 smite-nyx-sys/      # Nyx FFI bindings

--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -37,6 +37,18 @@ Campaign settings are stored in a TOML file. See [`sample-campaign.toml`](sample
 
 ## Commands
 
+### smitebot start
+
+`smitebot start` launches a fuzzing campaign in the background. It builds the Docker image, sets up the Nyx sharedir, and spawns parallel AFL++ instances.
+
+```bash
+smitebot start campaign.toml
+```
+
+For IR scenarios (scenario names starting with `ir`), the required AFL++ custom mutator environment variables are injected automatically.
+
+Campaign state is saved to `~/.smitebot/runs/<campaign-id>/state.json` for use by future `stop` and `status` commands.
+
 ### smitebot config
 
 `smitebot config` validates a campaign configuration file, reports the resolved settings, and checks that referenced paths exist on disk.

--- a/smitebot/src/commands.rs
+++ b/smitebot/src/commands.rs
@@ -1,7 +1,9 @@
 pub mod build;
 pub mod config;
 pub mod doctor;
+pub mod start;
 
 pub use build::{BuildArgs, BuildCommand};
 pub use config::{ConfigArgs, ConfigCommand};
 pub use doctor::{DoctorArgs, DoctorCommand};
+pub use start::{StartArgs, StartCommand};

--- a/smitebot/src/commands/build.rs
+++ b/smitebot/src/commands/build.rs
@@ -6,7 +6,7 @@ use std::process::{Command, ExitStatus};
 
 use clap::Args;
 
-use crate::config::Target;
+use crate::config::{CampaignConfig, Target};
 
 /// Command handler for `smitebot build`.
 pub struct BuildCommand;
@@ -36,20 +36,35 @@ pub struct BuildArgs {
 
 /// Fully resolved Docker build inputs.
 #[derive(Debug, PartialEq, Eq)]
-struct BuildInputs {
+pub struct BuildInputs {
     /// Docker image tag to produce.
-    image: String,
+    pub image: String,
     /// Workload Dockerfile selected from `--target` and `--coverage`.
-    dockerfile: PathBuf,
+    pub dockerfile: PathBuf,
     /// Smite repository root used as the Docker build context.
-    smite_dir: PathBuf,
+    pub smite_dir: PathBuf,
     /// Scenario passed to Docker as `--build-arg SCENARIO=...`.
-    scenario: String,
+    pub scenario: String,
     /// Whether Docker should rebuild without using its layer cache.
-    no_cache: bool,
+    pub no_cache: bool,
 }
 
 impl BuildInputs {
+    /// Resolves Docker build inputs from a campaign configuration.
+    pub fn from_config(config: &CampaignConfig, image: &str) -> Self {
+        Self {
+            image: image.to_string(),
+            dockerfile: config
+                .smite_dir
+                .join("workloads")
+                .join(config.target.to_string())
+                .join("Dockerfile"),
+            smite_dir: config.smite_dir.clone(),
+            scenario: config.scenario.clone(),
+            no_cache: false,
+        }
+    }
+
     /// Resolves Docker build inputs from parsed CLI arguments.
     fn from_args(args: &BuildArgs) -> Self {
         let dockerfile_name = if args.coverage {
@@ -78,33 +93,39 @@ impl BuildCommand {
     /// Builds the requested Smite Docker image and returns whether Docker succeeded.
     pub fn execute(args: &BuildArgs) -> bool {
         let inputs = BuildInputs::from_args(args);
-        if !inputs.dockerfile.exists() {
-            log::error!("Dockerfile not found: {}", inputs.dockerfile.display());
-            return false;
-        }
-
         log::info!(
             "building {} with {}",
             inputs.image,
             inputs.dockerfile.display()
         );
+        run_build(&inputs)
+    }
+}
 
-        let status = match run_docker_build(&inputs) {
-            Ok(status) => status,
-            Err(e) => {
-                log::error!("failed to run docker build: {e}");
-                return false;
-            }
-        };
+/// Checks that the Dockerfile exists, runs `docker build`, and reports success.
+///
+/// Shared by `smitebot build` and `smitebot start`.
+pub fn run_build(inputs: &BuildInputs) -> bool {
+    if !inputs.dockerfile.exists() {
+        log::error!("Dockerfile not found: {}", inputs.dockerfile.display());
+        return false;
+    }
 
-        if !status.success() {
-            log::error!("docker build failed with {status}");
+    let status = match run_docker_build(inputs) {
+        Ok(status) => status,
+        Err(e) => {
+            log::error!("failed to run docker build: {e}");
             return false;
         }
+    };
 
-        log::info!("built {}", inputs.image);
-        true
+    if !status.success() {
+        log::error!("docker build failed with {status}");
+        return false;
     }
+
+    log::info!("built {}", inputs.image);
+    true
 }
 
 /// Returns the default image tag used by Smite's manual Docker build flow.

--- a/smitebot/src/commands/start.rs
+++ b/smitebot/src/commands/start.rs
@@ -1,0 +1,631 @@
+//! Campaign launch orchestration.
+//!
+//! Builds the Docker image, prepares the Nyx sharedir, spawns parallel
+//! `afl-fuzz` processes in the background, and persists campaign state so
+//! that `stop` and `status` can manage the running campaign later.
+
+use std::fs;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use clap::Args;
+
+use crate::commands::build::{BuildInputs, run_build};
+use crate::config::CampaignConfig;
+use crate::state::{CampaignState, RunnerState, Status};
+
+/// Maximum time to wait for all runners to report non-zero `execs_per_sec`.
+const STARTUP_TIMEOUT: Duration = Duration::from_mins(5);
+
+/// How often to poll `fuzzer_stats` files during startup verification.
+const STARTUP_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Command handler for `smitebot start`.
+pub struct StartCommand;
+
+/// CLI arguments for `smitebot start`.
+#[derive(Debug, Args)]
+pub struct StartArgs {
+    /// Path to the campaign configuration TOML file.
+    path: PathBuf,
+}
+
+impl StartCommand {
+    /// Launches a fuzzing campaign from the given configuration.
+    pub fn execute(args: &StartArgs) -> bool {
+        let config = match CampaignConfig::load(&args.path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::error!("{e}");
+                return false;
+            }
+        };
+
+        let path_errors = config.check_paths();
+        if !path_errors.is_empty() {
+            for err in &path_errors {
+                log::error!("{err}");
+            }
+            return false;
+        }
+
+        let image = config.image_tag();
+
+        log::info!("building Docker image {image}");
+        let inputs = BuildInputs::from_config(&config, &image);
+        if !run_build(&inputs) {
+            return false;
+        }
+
+        if config.scenario.starts_with("ir") && !build_ir_mutator(&config.smite_dir) {
+            return false;
+        }
+
+        log::info!("setting up Nyx sharedir at {}", config.sharedir.display());
+        if !setup_nyx(&config, &image) {
+            return false;
+        }
+
+        let seed_dir = match ensure_seed_dir(&config) {
+            Ok(dir) => dir,
+            Err(e) => {
+                log::error!("failed to prepare seed directory: {e}");
+                return false;
+            }
+        };
+
+        let campaign_id = config.campaign_id();
+        let Some(runs_dir) = CampaignState::runs_dir() else {
+            log::error!("unable to determine home directory");
+            return false;
+        };
+
+        let state_path = runs_dir.join(&campaign_id).join("state.json");
+
+        let Some(git_hash) = smite_git_hash(&config.smite_dir) else {
+            log::error!("could not determine smite git hash");
+            return false;
+        };
+        let Some(image_digest) = docker_image_id(&image) else {
+            log::error!("could not determine Docker image digest for {image}");
+            return false;
+        };
+
+        let mut state = CampaignState::new(campaign_id, &config, image, image_digest, git_hash);
+
+        if let Err(e) = state.save(&state_path) {
+            log::error!("{e}");
+            return false;
+        }
+
+        if !launch_runners(&config, &seed_dir, &mut state, &state_path) {
+            return false;
+        }
+        if let Err(e) = state.save(&state_path) {
+            log::error!("{e}");
+            return false;
+        }
+
+        log::info!("campaign {} is running", state.id);
+        log::info!("state saved to {}", state_path.display());
+        true
+    }
+}
+
+/// Runs `scripts/setup-nyx.sh` to prepare the Nyx sharedir.
+fn setup_nyx(config: &CampaignConfig, image: &str) -> bool {
+    let script = config.smite_dir.join("scripts").join("setup-nyx.sh");
+    if !script.exists() {
+        log::error!("setup-nyx.sh not found: {}", script.display());
+        return false;
+    }
+
+    let status = match Command::new(&script)
+        .arg(&config.sharedir)
+        .arg(image)
+        .arg(&config.aflpp_path)
+        .status()
+    {
+        Ok(status) => status,
+        Err(e) => {
+            log::error!("failed to run setup-nyx.sh: {e}");
+            return false;
+        }
+    };
+
+    if !status.success() {
+        log::error!("setup-nyx.sh failed with {status}");
+        return false;
+    }
+
+    log::info!("Nyx sharedir ready at {}", config.sharedir.display());
+    true
+}
+
+/// Spawns all runners, verifies they reach non-zero `execs_per_sec`, and updates
+/// campaign state. Runner PIDs are persisted so `smitebot stop` can terminate them.
+fn launch_runners(
+    config: &CampaignConfig,
+    seed_dir: &Path,
+    state: &mut CampaignState,
+    state_path: &Path,
+) -> bool {
+    log::info!("starting {} runners", config.runners);
+
+    let mut runners = Vec::new();
+    let mut children = Vec::new();
+    for id in 0..config.runners {
+        match spawn_runner(config, id, seed_dir) {
+            Ok((runner, child)) => {
+                log::info!("spawned runner {id} (pid {})", runner.pid);
+                runners.push(runner);
+                children.push(child);
+            }
+            Err(e) => {
+                log::error!("failed to spawn runner {id}: {e}");
+                kill_runners(&runners);
+                state.status = Status::Failed;
+                state.runners = runners;
+                if let Err(e) = state.save(state_path) {
+                    log::warn!("failed to save state: {e}");
+                }
+                return false;
+            }
+        }
+    }
+
+    state.runners = runners;
+
+    // Persist PIDs before the lengthy verify_startup poll so smitebot stop
+    // can find the runners if we crash during verification.
+    if let Err(e) = state.save(state_path) {
+        log::warn!("failed to save state: {e}");
+    }
+
+    log::info!("waiting for runners to initialize");
+    if !verify_startup(&config.output_dir, &state.runners, &mut children) {
+        log::error!("not all runners started within the timeout");
+        kill_runners(&state.runners);
+        state.status = Status::Failed;
+        if let Err(e) = state.save(state_path) {
+            log::warn!("failed to save state: {e}");
+        }
+        return false;
+    }
+
+    state.status = Status::Running;
+    true
+}
+
+/// Ensures a seed directory exists for AFL++, creating a minimal corpus if needed.
+///
+/// When the user omits `seed_dir` from the config, AFL++ still requires `-i`
+/// pointing to a non-empty directory.
+fn ensure_seed_dir(config: &CampaignConfig) -> std::io::Result<PathBuf> {
+    if let Some(dir) = &config.seed_dir {
+        return Ok(dir.clone());
+    }
+    let seed_dir = config.output_dir.join(".seeds");
+    fs::create_dir_all(&seed_dir)?;
+    if seed_dir.read_dir()?.next().is_none() {
+        fs::write(seed_dir.join("seed0"), b"\x00")?;
+    }
+    Ok(seed_dir)
+}
+
+/// Spawns a single `afl-fuzz` process in its own process group.
+///
+/// The child is intentionally orphaned so the campaign outlives the `smitebot`
+/// process. The `stop` command uses the persisted PID to terminate it later.
+fn spawn_runner(
+    config: &CampaignConfig,
+    id: u16,
+    seed_dir: &Path,
+) -> std::io::Result<(RunnerState, Child)> {
+    let afl_fuzz = config.aflpp_path.join("afl-fuzz");
+    let name = id.to_string();
+
+    let mut cmd = Command::new(&afl_fuzz);
+    cmd.arg("-Y");
+    cmd.arg("-i").arg(seed_dir);
+    cmd.arg("-o").arg(&config.output_dir);
+
+    // Runner 0 is the primary (-M), all others are secondaries (-S).
+    if id == 0 {
+        cmd.arg("-M").arg(&name);
+    } else {
+        cmd.arg("-S").arg(&name);
+    }
+
+    for flag in &config.afl_flags {
+        cmd.arg(flag);
+    }
+
+    cmd.arg("--").arg(&config.sharedir);
+
+    // IR mutator defaults first so user afl_env can override them.
+    for (key, val) in ir_mutator_envs(config) {
+        cmd.env(key, val);
+    }
+
+    for (key, val) in &config.afl_env {
+        cmd.env(key, val);
+    }
+
+    cmd.process_group(0);
+
+    let child = cmd.spawn()?;
+    let state = RunnerState {
+        id,
+        pid: child.id(),
+    };
+    Ok((state, child))
+}
+
+/// Polls for `fuzzer_stats` files to confirm all runners have started executing.
+///
+/// AFL++ creates `<output_dir>/<runner_name>/fuzzer_stats` once fuzzing begins.
+/// We verify `execs_per_sec` is non-zero to confirm actual execution, not just
+/// file creation.
+fn verify_startup(output_dir: &Path, runners: &[RunnerState], children: &mut [Child]) -> bool {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+
+    while Instant::now() < deadline {
+        let all_started = runners
+            .iter()
+            .all(|r| has_nonzero_execs(&output_dir.join(r.name()).join("fuzzer_stats")));
+
+        if all_started {
+            return true;
+        }
+
+        for (child, runner) in children.iter_mut().zip(runners.iter()) {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    log::error!(
+                        "runner {} (pid {}) died during startup",
+                        runner.id,
+                        runner.pid
+                    );
+                    return false;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    log::error!(
+                        "failed to check runner {} (pid {}): {e}",
+                        runner.id,
+                        runner.pid
+                    );
+                    return false;
+                }
+            }
+        }
+
+        thread::sleep(STARTUP_POLL_INTERVAL);
+    }
+
+    for runner in runners {
+        let stats = output_dir.join(runner.name()).join("fuzzer_stats");
+        if !has_nonzero_execs(&stats) {
+            log::error!(
+                "runner {} (pid {}) did not reach non-zero execs_per_sec",
+                runner.id,
+                runner.pid
+            );
+        }
+    }
+
+    false
+}
+
+/// Returns true if the `fuzzer_stats` file exists and reports non-zero `execs_per_sec`.
+fn has_nonzero_execs(path: &Path) -> bool {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    contents.lines().any(|line| {
+        line.trim_start().starts_with("execs_per_sec")
+            && line
+                .split(':')
+                .nth(1)
+                .and_then(|v| v.trim().parse::<f64>().ok())
+                .is_some_and(|n| n > 0.0)
+    })
+}
+
+/// Kills all runner process groups via SIGKILL.
+fn kill_runners(runners: &[RunnerState]) {
+    for runner in runners {
+        let pgid = format!("-{}", runner.pid);
+        match Command::new("kill").args(["-9", &pgid]).status() {
+            Ok(status) if status.success() => {
+                log::info!("killed runner {} (pgid {})", runner.id, runner.pid);
+            }
+            _ => {
+                log::warn!("failed to kill runner {} (pgid {})", runner.id, runner.pid);
+            }
+        }
+    }
+}
+
+/// Returns the environment variables needed for the smite-ir custom mutator.
+///
+/// For IR scenarios, these set up AFL++ to use the custom mutator library and
+/// disable built-in mutators. Returns an empty vec for non-IR scenarios.
+fn ir_mutator_envs(config: &CampaignConfig) -> Vec<(&'static str, String)> {
+    if !config.scenario.starts_with("ir") {
+        return Vec::new();
+    }
+    vec![
+        (
+            "AFL_CUSTOM_MUTATOR_LIBRARY",
+            config.ir_mutator_path().to_string_lossy().into_owned(),
+        ),
+        ("AFL_CUSTOM_MUTATOR_ONLY", "1".to_string()),
+        ("AFL_FRAMESHIFT_DISABLE", "1".to_string()),
+    ]
+}
+
+/// Builds the smite-ir-mutator shared library in release mode.
+fn build_ir_mutator(smite_dir: &Path) -> bool {
+    log::info!("building IR mutator library");
+    let status = match Command::new("cargo")
+        .args(["build", "--release", "-p", "smite-ir-mutator"])
+        .current_dir(smite_dir)
+        .status()
+    {
+        Ok(status) => status,
+        Err(e) => {
+            log::error!("failed to run cargo build: {e}");
+            return false;
+        }
+    };
+
+    if !status.success() {
+        log::error!("cargo build for smite-ir-mutator failed with {status}");
+        return false;
+    }
+
+    true
+}
+
+/// Runs a command and returns its trimmed stdout on success.
+fn command_stdout(cmd: &mut Command) -> Option<String> {
+    let output = cmd.output().ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Returns the smite repository git hash, or `None` if not a git repo.
+fn smite_git_hash(smite_dir: &Path) -> Option<String> {
+    command_stdout(
+        Command::new("git")
+            .arg("-C")
+            .arg(smite_dir)
+            .args(["rev-parse", "HEAD"]),
+    )
+}
+
+/// Returns the Docker image ID hash for a locally built image.
+fn docker_image_id(image: &str) -> Option<String> {
+    command_stdout(
+        Command::new("docker")
+            .args(["inspect", "--format={{.Id}}"])
+            .arg(image),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn verify_startup_detects_fuzzer_stats() {
+        let dir = tempfile::tempdir().unwrap();
+        let runners = vec![
+            RunnerState { id: 0, pid: 100 },
+            RunnerState { id: 1, pid: 101 },
+        ];
+
+        let stats_content = "start_time        : 1718000000\nexecs_per_sec     : 531.23\n";
+        for runner in &runners {
+            let runner_dir = dir.path().join(runner.name());
+            fs::create_dir_all(&runner_dir).unwrap();
+            fs::write(runner_dir.join("fuzzer_stats"), stats_content).unwrap();
+        }
+
+        let mut children: Vec<Child> = (0..2)
+            .map(|_| Command::new("sleep").arg("60").spawn().unwrap())
+            .collect();
+
+        assert!(verify_startup(dir.path(), &runners, &mut children));
+
+        for mut child in children {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    #[test]
+    fn verify_startup_detects_dead_runner() {
+        let dir = tempfile::tempdir().unwrap();
+        let runners = vec![RunnerState { id: 0, pid: 100 }];
+
+        // No fuzzer_stats file — runner hasn't started yet.
+        // Child exits immediately, so try_wait should detect death.
+        let mut children = vec![Command::new("false").spawn().unwrap()];
+
+        // Give the process a moment to exit.
+        thread::sleep(Duration::from_millis(50));
+
+        assert!(!verify_startup(dir.path(), &runners, &mut children));
+    }
+
+    #[test]
+    fn has_nonzero_execs_rejects_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let stats = dir.path().join("fuzzer_stats");
+        fs::write(
+            &stats,
+            "start_time        : 1718000000\nexecs_per_sec     : 0.00\n",
+        )
+        .unwrap();
+        assert!(!has_nonzero_execs(&stats));
+    }
+
+    #[test]
+    fn has_nonzero_execs_rejects_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!has_nonzero_execs(&dir.path().join("missing")));
+    }
+
+    #[test]
+    fn has_nonzero_execs_accepts_positive_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let stats = dir.path().join("fuzzer_stats");
+        fs::write(
+            &stats,
+            "start_time        : 1718000000\nexecs_per_sec     : 531.23\n",
+        )
+        .unwrap();
+        assert!(has_nonzero_execs(&stats));
+    }
+
+    #[test]
+    fn ensure_seed_dir_returns_user_path_when_specified() {
+        let dir = tempfile::tempdir().unwrap();
+        let seed = dir.path().join("my-seeds");
+        fs::create_dir(&seed).unwrap();
+        fs::write(seed.join("input0"), b"\x00").unwrap();
+
+        let config_path = dir.path().join("campaign.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+target = "lnd"
+scenario = "encrypted_bytes"
+aflpp_path = "{}"
+smite_dir = "{}"
+runners = 1
+seed_dir = "{}"
+output_dir = "{}"
+sharedir = "{}"
+"#,
+                dir.path().display(),
+                dir.path().display(),
+                seed.display(),
+                dir.path().join("out").display(),
+                dir.path().join("nyx").display(),
+            ),
+        )
+        .unwrap();
+        let config = CampaignConfig::load(&config_path).unwrap();
+
+        let result = ensure_seed_dir(&config).unwrap();
+        assert_eq!(result, seed);
+    }
+
+    #[test]
+    fn ensure_seed_dir_creates_minimal_corpus_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_dir = dir.path().join("out");
+        fs::create_dir(&output_dir).unwrap();
+
+        let config_path = dir.path().join("campaign.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+target = "lnd"
+scenario = "encrypted_bytes"
+aflpp_path = "{}"
+smite_dir = "{}"
+runners = 1
+output_dir = "{}"
+sharedir = "{}"
+"#,
+                dir.path().display(),
+                dir.path().display(),
+                output_dir.display(),
+                dir.path().join("nyx").display(),
+            ),
+        )
+        .unwrap();
+        let config = CampaignConfig::load(&config_path).unwrap();
+
+        let result = ensure_seed_dir(&config).unwrap();
+        assert_eq!(result, output_dir.join(".seeds"));
+        assert!(result.join("seed0").exists());
+    }
+
+    #[test]
+    fn ir_mutator_envs_sets_vars_for_ir_scenario() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("campaign.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+target = "lnd"
+scenario = "ir_bytes"
+aflpp_path = "{}"
+smite_dir = "{}"
+runners = 1
+output_dir = "{}"
+sharedir = "{}"
+"#,
+                dir.path().display(),
+                dir.path().display(),
+                dir.path().join("out").display(),
+                dir.path().join("nyx").display(),
+            ),
+        )
+        .unwrap();
+        let config = CampaignConfig::load(&config_path).unwrap();
+
+        let envs = ir_mutator_envs(&config);
+
+        assert_eq!(envs.len(), 3);
+        assert_eq!(envs[0].0, "AFL_CUSTOM_MUTATOR_LIBRARY");
+        assert!(envs[0].1.ends_with("libsmite_ir_mutator.so"));
+        assert_eq!(envs[1], ("AFL_CUSTOM_MUTATOR_ONLY", "1".to_string()));
+        assert_eq!(envs[2], ("AFL_FRAMESHIFT_DISABLE", "1".to_string()));
+    }
+
+    #[test]
+    fn ir_mutator_envs_empty_for_non_ir_scenario() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("campaign.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+target = "lnd"
+scenario = "encrypted_bytes"
+aflpp_path = "{}"
+smite_dir = "{}"
+runners = 1
+output_dir = "{}"
+sharedir = "{}"
+"#,
+                dir.path().display(),
+                dir.path().display(),
+                dir.path().join("out").display(),
+                dir.path().join("nyx").display(),
+            ),
+        )
+        .unwrap();
+        let config = CampaignConfig::load(&config_path).unwrap();
+
+        assert!(ir_mutator_envs(&config).is_empty());
+    }
+}

--- a/smitebot/src/config.rs
+++ b/smitebot/src/config.rs
@@ -6,7 +6,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::ValueEnum;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+use crate::utils;
 
 /// A parsed and validated smitebot campaign configuration.
 #[derive(Debug, Deserialize)]
@@ -39,7 +41,7 @@ pub struct CampaignConfig {
 }
 
 /// Lightning Network implementation to target.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, ValueEnum)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum Target {
     /// Lightning Network Daemon.
@@ -98,12 +100,28 @@ impl CampaignConfig {
         Ok(config)
     }
 
+    /// Returns a unique campaign ID from the target, scenario, and current time.
+    #[must_use]
+    pub fn campaign_id(&self) -> String {
+        let epoch_secs = utils::epoch_secs();
+        format!("{}-{}-{epoch_secs}", self.target, self.scenario)
+    }
+
     /// Returns the Docker image tag, using the Smite convention as the default.
     #[must_use]
     pub fn image_tag(&self) -> String {
         self.image
             .clone()
             .unwrap_or_else(|| format!("smite-{}-{}", self.target, self.scenario))
+    }
+
+    /// Returns the path to the smite-ir custom mutator shared library.
+    #[must_use]
+    pub fn ir_mutator_path(&self) -> PathBuf {
+        self.smite_dir
+            .join("target")
+            .join("release")
+            .join("libsmite_ir_mutator.so")
     }
 
     /// Checks that referenced filesystem paths exist and are usable.
@@ -236,6 +254,20 @@ sharedir = "/tmp/smite-nyx"
     fn load_reports_missing_file() {
         let err = CampaignConfig::load(Path::new("/no/such/config.toml")).unwrap_err();
         assert!(matches!(err, ConfigError::Read { .. }));
+    }
+
+    #[test]
+    fn campaign_id_contains_target_and_scenario() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), VALID_CONFIG);
+        let config = CampaignConfig::load(&path).unwrap();
+
+        let id = config.campaign_id();
+
+        assert!(
+            id.starts_with("lnd-encrypted_bytes-"),
+            "id should start with target-scenario: {id}"
+        );
     }
 
     #[test]

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -2,13 +2,17 @@
 
 mod commands;
 mod config;
+mod state;
 mod utils;
 
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 
-use commands::{BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, DoctorArgs, DoctorCommand};
+use commands::{
+    BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, DoctorArgs, DoctorCommand, StartArgs,
+    StartCommand,
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "smitebot", version, about = "Smite campaign manager")]
@@ -25,6 +29,8 @@ enum Commands {
     Config(ConfigArgs),
     /// Validate host prerequisites for running Smite campaigns.
     Doctor(DoctorArgs),
+    /// Launch a fuzzing campaign.
+    Start(StartArgs),
 }
 
 fn main() -> ExitCode {
@@ -35,6 +41,7 @@ fn main() -> ExitCode {
         Commands::Build(args) => BuildCommand::execute(&args),
         Commands::Config(args) => ConfigCommand::execute(&args),
         Commands::Doctor(args) => DoctorCommand::execute(&args),
+        Commands::Start(args) => StartCommand::execute(&args),
     };
 
     if success {

--- a/smitebot/src/state.rs
+++ b/smitebot/src/state.rs
@@ -1,0 +1,260 @@
+//! Campaign state persistence.
+//!
+//! Each running campaign writes its state to a JSON file under
+//! `~/.smitebot/runs/<campaign-id>/state.json`. The `stop` and `status`
+//! commands read this file to locate and manage running campaigns.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::{CampaignConfig, Target};
+use crate::utils;
+
+/// Persisted state for a running fuzzing campaign.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CampaignState {
+    /// Unique campaign identifier (<target>-<scenario>-<timestamp>).
+    pub id: String,
+    /// Current lifecycle status.
+    pub status: Status,
+    /// Lightning implementation being fuzzed.
+    pub target: Target,
+    /// Scenario binary name.
+    pub scenario: String,
+    /// Docker image tag used for this campaign.
+    pub image: String,
+    /// Docker image digest (image ID hash for locally built images).
+    pub image_digest: String,
+    /// AFL++ output directory containing runner findings and stats.
+    pub output_dir: PathBuf,
+    /// Path to the Nyx sharedir.
+    pub sharedir: PathBuf,
+    /// Smite repository git hash at campaign start.
+    pub smite_git_hash: String,
+    /// Unix timestamp (seconds since epoch) when the campaign started.
+    pub start_time: u64,
+    /// State of each AFL++ runner process.
+    pub runners: Vec<RunnerState>,
+}
+
+/// Lifecycle status of a campaign.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    /// Runners are being spawned.
+    Starting,
+    /// All runners confirmed alive.
+    Running,
+    /// One or more runners failed to start.
+    Failed,
+}
+
+/// State of a single AFL++ runner process.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunnerState {
+    /// Runner index (0 = primary, 1..N = secondary).
+    pub id: u16,
+    /// Process ID of the afl-fuzz instance.
+    pub pid: u32,
+}
+
+impl RunnerState {
+    /// Returns the AFL++ runner name for this runner.
+    ///
+    /// Nyx parallel mode (`-Y`) requires numeric names: `0` for the primary
+    /// runner and `N` (N >= 1) for secondaries.
+    pub fn name(&self) -> String {
+        self.id.to_string()
+    }
+}
+
+/// Errors that can occur during state persistence.
+#[derive(Debug, thiserror::Error)]
+pub enum StateError {
+    #[error("failed to create state directory {}: {source}", path.display())]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to write state to {}: {source}", path.display())]
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl CampaignState {
+    /// Creates a new campaign state in the `Starting` phase.
+    pub fn new(
+        id: String,
+        config: &CampaignConfig,
+        image: String,
+        image_digest: String,
+        smite_git_hash: String,
+    ) -> Self {
+        Self {
+            id,
+            status: Status::Starting,
+            target: config.target,
+            scenario: config.scenario.clone(),
+            image,
+            image_digest,
+            output_dir: config.output_dir.clone(),
+            sharedir: config.sharedir.clone(),
+            smite_git_hash,
+            start_time: utils::epoch_secs(),
+            runners: Vec::new(),
+        }
+    }
+
+    /// Returns the base directory for all campaign state: `~/.smitebot/runs`.
+    ///
+    /// Returns `None` if the home directory cannot be determined.
+    pub fn runs_dir() -> Option<PathBuf> {
+        std::env::home_dir().map(|home| home.join(".smitebot").join("runs"))
+    }
+
+    /// Saves the campaign state as JSON, using an atomic write to prevent
+    /// corruption if the process is interrupted.
+    pub fn save(&self, path: &Path) -> Result<(), StateError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| StateError::CreateDir {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let json =
+            serde_json::to_string_pretty(self).expect("CampaignState is always serializable");
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, &json).map_err(|source| StateError::Write {
+            path: tmp.clone(),
+            source,
+        })?;
+        // rename(2) is atomic on the same filesystem, so readers never see a partial file.
+        fs::rename(&tmp, path).map_err(|source| StateError::Write {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_state() -> CampaignState {
+        CampaignState {
+            id: "lnd-encrypted_bytes-1_749_465_600".to_string(),
+            status: Status::Running,
+            target: Target::Lnd,
+            scenario: "encrypted_bytes".to_string(),
+            image: "smite-lnd-encrypted_bytes".to_string(),
+            image_digest: "sha256:abc123".to_string(),
+            output_dir: PathBuf::from("/tmp/smite-out"),
+            sharedir: PathBuf::from("/tmp/smite-nyx"),
+            smite_git_hash: "deadbeef".to_string(),
+            start_time: 1_749_465_600,
+            runners: vec![
+                RunnerState { id: 0, pid: 1234 },
+                RunnerState { id: 1, pid: 1235 },
+            ],
+        }
+    }
+
+    #[test]
+    fn save_round_trips_through_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let state = sample_state();
+
+        state.save(&path).unwrap();
+
+        let contents = fs::read_to_string(&path).unwrap();
+        let loaded: CampaignState = serde_json::from_str(&contents).unwrap();
+
+        assert_eq!(loaded.id, state.id);
+        assert_eq!(loaded.status, Status::Running);
+        assert_eq!(loaded.target, Target::Lnd);
+        assert_eq!(loaded.scenario, "encrypted_bytes");
+        assert_eq!(loaded.runners.len(), 2);
+        assert_eq!(loaded.runners[0].name(), "0");
+        assert_eq!(loaded.runners[1].pid, 1235);
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("deep").join("state.json");
+        let state = sample_state();
+
+        state.save(&path).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_removes_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let state = sample_state();
+
+        state.save(&path).unwrap();
+
+        let tmp = path.with_extension("json.tmp");
+        assert!(!tmp.exists());
+    }
+
+    #[test]
+    fn new_initializes_starting_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("campaign.toml");
+        fs::write(
+            &config_path,
+            r#"
+target = "lnd"
+scenario = "encrypted_bytes"
+aflpp_path = "/home/user/AFLplusplus"
+smite_dir = "."
+runners = 4
+output_dir = "/tmp/out"
+sharedir = "/tmp/nyx"
+"#,
+        )
+        .unwrap();
+        let config = CampaignConfig::load(&config_path).unwrap();
+
+        let state = CampaignState::new(
+            "lnd-encrypted_bytes-1_749_465_600".to_string(),
+            &config,
+            "smite-lnd-encrypted_bytes".to_string(),
+            "sha256:abc123".to_string(),
+            "deadbeef".to_string(),
+        );
+
+        assert_eq!(state.status, Status::Starting);
+        assert_eq!(state.target, Target::Lnd);
+        assert_eq!(state.scenario, "encrypted_bytes");
+        assert_eq!(state.image, "smite-lnd-encrypted_bytes");
+        assert_eq!(state.image_digest, "sha256:abc123");
+        assert_eq!(state.smite_git_hash, "deadbeef");
+        assert!(state.runners.is_empty());
+    }
+
+    #[test]
+    fn status_serializes_as_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&Status::Starting).unwrap(),
+            "\"starting\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Status::Running).unwrap(),
+            "\"running\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Status::Failed).unwrap(),
+            "\"failed\""
+        );
+    }
+}

--- a/smitebot/src/utils.rs
+++ b/smitebot/src/utils.rs
@@ -1,8 +1,17 @@
-//! Small filesystem helpers shared across smitebot commands.
+//! Small helpers shared across smitebot commands.
 
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Returns the current Unix timestamp in seconds.
+pub fn epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before Unix epoch")
+        .as_secs()
+}
 
 /// Returns true if `path` exists and has at least one executable bit set.
 pub fn is_executable(path: &Path) -> bool {


### PR DESCRIPTION

  ## Summary

  - Adds `smitebot start` command that orchestrates a full fuzzing campaign- builds the Docker image, prepares the Nyx sharedir, spawns parallel `afl-fuzz` processes in the background, and persists campaign state for future `stop`/`status` commands.
  - Adds `CampaignState` persistence module with atomic JSON writes to `~/.smitebot/runs/<campaign-id>/state.json`.
  - Refactors `run_docker_build` to `pub(crate)` for reuse by `start`.
  - Adds `Serialize` to `Target` for state serialization.

  ### Key context behind implementation

  - **Background mode**: runners are orphaned via `process_group(0)` + `drop(child)` so campaigns outlive the terminal. `stop` will use persisted PIDs to `killpg` later.
  - **Nyx parallel mode (`-Y`)**: AFL++ requires numeric runner names — `-M 0`  for primary, `-S N` for secondaries.
  - **IR auto-injection**: scenarios starting with `ir` automatically get  `AFL_CUSTOM_MUTATOR_LIBRARY`, `AFL_CUSTOM_MUTATOR_ONLY`,  `AFL_FRAMESHIFT_DISABLE`, `AFL_DISABLE_TRIM` - set before `afl_env` so user
  overrides take precedence.
  - **Seed dir**: when `seed_dir` is omitted, creates `<output_dir>/.seeds/seed0` with a null byte (AFL++ requires `-i` pointing to a non-empty directory).
  - **Startup verification**: polls for `fuzzer_stats` files with a 5 minute timeout to confirm runners are alive.
  
  Ref. #70 