### PR TITLE
smite-ir: implement `BuildFundingCreated` and `SendFundingCreated` operation 

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -231,6 +231,9 @@ impl ProgramBuilder {
             VariableType::SentOpenChannel => {
                 panic!("cannot generate fresh SentOpenChannel: affine type")
             }
+            VariableType::SentFundingCreated => {
+                panic!("cannot generate fresh SentFundingCreated: affine type")
+            }
         }
     }
 

--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -219,6 +219,9 @@ impl ProgramBuilder {
             VariableType::OpenChannelMessage => {
                 panic!("cannot generate fresh OpenChannelMessage: requires composed inputs")
             }
+            VariableType::FundingCreatedMessage => {
+                panic!("cannot generate fresh FundingCreatedMessage: requires composed inputs")
+            }
             VariableType::AcceptChannel => {
                 panic!("cannot generate fresh AcceptChannel: requires protocol interaction")
             }

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -106,6 +106,7 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::BuildChannelUpdate
         | Operation::SendMessage
         | Operation::SendOpenChannel
+        | Operation::SendFundingCreated
         | Operation::RecvAcceptChannel
         | Operation::BroadcastTransaction => {
             unreachable!("is_param_mutable returned true for {op:?}")

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -101,6 +101,7 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::LoadTargetPubkeyFromContext
         | Operation::LoadChainHashFromContext
         | Operation::BuildOpenChannel
+        | Operation::BuildFundingCreated
         | Operation::BuildChannelAnnouncement
         | Operation::BuildChannelUpdate
         | Operation::SendMessage

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -188,6 +188,10 @@ pub enum Operation {
     /// Produces a `SentOpenChannel` variable.
     /// Input: `OpenChannelMessage`.
     SendOpenChannel,
+    /// Send a `funding_created` message over the connection.
+    /// Produces a `SentFundingCreated` variable.
+    /// Input: `FundingCreatedMessage`.
+    SendFundingCreated,
     /// Receive and parse an `accept_channel` response.
     /// Produces an `AcceptChannel` compound variable.
     RecvAcceptChannel,
@@ -644,6 +648,7 @@ impl fmt::Display for Operation {
             Self::BuildChannelUpdate => write!(f, "BuildChannelUpdate"),
             Self::SendMessage => write!(f, "SendMessage"),
             Self::SendOpenChannel => write!(f, "SendOpenChannel"),
+            Self::SendFundingCreated => write!(f, "SendFundingCreated"),
         }
     }
 }
@@ -677,6 +682,7 @@ impl Operation {
             | Self::BuildChannelUpdate => Some(VariableType::Message),
             Self::SendMessage | Self::MineBlocks(_) | Self::BroadcastTransaction => None,
             Self::SendOpenChannel => Some(VariableType::SentOpenChannel),
+            Self::SendFundingCreated => Some(VariableType::SentFundingCreated),
             Self::RecvAcceptChannel => Some(VariableType::AcceptChannel),
         }
     }
@@ -714,6 +720,7 @@ impl Operation {
             ],
             Self::SendMessage => vec![VariableType::Message],
             Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
+            Self::SendFundingCreated => vec![VariableType::FundingCreatedMessage],
             Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
             Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
 
@@ -830,6 +837,7 @@ impl Operation {
             | Self::BuildChannelUpdate
             | Self::SendMessage
             | Self::SendOpenChannel
+            | Self::SendFundingCreated
             | Self::MineBlocks(_)
             | Self::BroadcastTransaction => vec![],
 
@@ -847,6 +855,7 @@ impl Operation {
         match self {
             Self::SendMessage
             | Self::SendOpenChannel
+            | Self::SendFundingCreated
             | Self::RecvAcceptChannel
             | Self::MineBlocks(_)
             | Self::CreateFundingTransaction
@@ -910,6 +919,7 @@ impl Operation {
             | Self::BuildChannelUpdate
             | Self::SendMessage
             | Self::SendOpenChannel
+            | Self::SendFundingCreated
             | Self::RecvAcceptChannel
             | Self::BroadcastTransaction => false,
         }

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -107,6 +107,30 @@ pub enum Operation {
     ///  18: `upfront_shutdown_script` (`Bytes`, empty = omit TLV)
     ///  19: `channel_type` (`Features`, empty = omit TLV)
     BuildOpenChannel,
+    /// Build a `funding_created` message (BOLT 2, type 34).
+    ///
+    /// Inputs (20):
+    ///   0: `funding_transaction` (`FundingTransaction`)
+    ///   1: `funding_satoshis` (`Amount`)
+    ///   2: `channel_type` (`Features`)
+    ///   3: `opener_funding_privkey` (`PrivateKey`)
+    ///   4: `opener_payment_basepoint` (`Point`)
+    ///   5: `opener_revocation_basepoint` (`Point`)
+    ///   6: `opener_delayed_payment_basepoint` (`Point`)
+    ///   7: `opener_dust_limit_satoshis` (`Amount`)
+    ///   8: `opener_to_self_delay` (`U16`)
+    ///   9: `acceptor_funding_pubkey` (`Point`)
+    ///  10: `acceptor_payment_basepoint` (`Point`)
+    ///  11: `acceptor_revocation_basepoint` (`Point`)
+    ///  12: `acceptor_delayed_payment_basepoint` (`Point`)
+    ///  13: `acceptor_dust_limit_satoshis` (`Amount`)
+    ///  14: `acceptor_to_self_delay` (`U16`)
+    ///  15: `temporary_channel_id` (`ChannelId`)
+    ///  16: `push_msat` (`Amount`)
+    ///  17: `feerate_per_kw` (`FeeratePerKw`)
+    ///  18: `opener_per_commitment_point` (`Point`)
+    ///  19: `acceptor_per_commitment_point` (`Point`)
+    BuildFundingCreated,
     /// Build a `channel_announcement` message (BOLT 7, type 256).
     ///
     /// All four `PrivateKey` inputs are used to sign the body.
@@ -609,6 +633,7 @@ impl fmt::Display for Operation {
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
             Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
+            Self::BuildFundingCreated => write!(f, "BuildFundingCreated"),
             Self::BuildChannelAnnouncement => write!(f, "BuildChannelAnnouncement"),
             Self::BuildNodeAnnouncement { rgb_color, alias } => write!(
                 f,
@@ -646,6 +671,7 @@ impl Operation {
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
             Self::BuildOpenChannel => Some(VariableType::OpenChannelMessage),
+            Self::BuildFundingCreated => Some(VariableType::FundingCreatedMessage),
             Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate => Some(VariableType::Message),
@@ -657,6 +683,7 @@ impl Operation {
 
     /// Returns the expected variable types for each input position.
     #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn input_types(&self) -> Vec<VariableType> {
         match self {
             Self::LoadAmount(_)
@@ -711,6 +738,29 @@ impl Operation {
                 VariableType::U8,           // channel_flags
                 VariableType::Bytes,        // upfront_shutdown_script
                 VariableType::Features,     // channel_type
+            ],
+
+            Self::BuildFundingCreated => vec![
+                VariableType::FundingTransaction, // funding_transaction
+                VariableType::Amount,             // funding_satoshis
+                VariableType::Features,           // channel_type
+                VariableType::PrivateKey,         // opener_funding_privkey
+                VariableType::Point,              // opener_payment_basepoint
+                VariableType::Point,              // opener_revocation_basepoint
+                VariableType::Point,              // opener_delayed_payment_basepoint
+                VariableType::Amount,             // opener_dust_limit_satoshis
+                VariableType::U16,                // opener_to_self_delay
+                VariableType::Point,              // acceptor_funding_pubkey
+                VariableType::Point,              // acceptor_payment_basepoint
+                VariableType::Point,              // acceptor_revocation_basepoint
+                VariableType::Point,              // acceptor_delayed_payment_basepoint
+                VariableType::Amount,             // acceptor_dust_limit_satoshis
+                VariableType::U16,                // acceptor_to_self_delay
+                VariableType::ChannelId,          // temporary_channel_id
+                VariableType::Amount,             // push_msat
+                VariableType::FeeratePerKw,       // feerate_per_kw
+                VariableType::Point,              // opener_per_commitment_point
+                VariableType::Point,              // acceptor_per_commitment_point
             ],
 
             Self::BuildChannelAnnouncement => vec![
@@ -774,6 +824,7 @@ impl Operation {
             | Self::ExtractAcceptChannel(_)
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
+            | Self::BuildFundingCreated
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
@@ -820,6 +871,7 @@ impl Operation {
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
             | Self::BuildOpenChannel
+            | Self::BuildFundingCreated
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate => false,
         }
@@ -853,6 +905,7 @@ impl Operation {
             | Self::DerivePoint
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
+            | Self::BuildFundingCreated
             | Self::BuildChannelAnnouncement
             | Self::BuildChannelUpdate
             | Self::SendMessage

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -461,7 +461,7 @@ fn postcard_roundtrip() {
             },
             Instruction {
                 operation: Operation::DerivePoint,
-                inputs: vec![7],
+                inputs: vec![8],
             },
             Instruction {
                 operation: Operation::LoadFeeratePerKw(15_000),
@@ -469,11 +469,11 @@ fn postcard_roundtrip() {
             },
             Instruction {
                 operation: Operation::CreateFundingTransaction,
-                inputs: vec![1, 8, 4, 9],
+                inputs: vec![1, 9, 5, 10],
             },
             Instruction {
                 operation: Operation::BroadcastTransaction,
-                inputs: vec![10],
+                inputs: vec![11],
             },
             Instruction {
                 operation: Operation::LoadU16(144),
@@ -482,12 +482,13 @@ fn postcard_roundtrip() {
             Instruction {
                 operation: Operation::BuildFundingCreated,
                 inputs: vec![
-                    10, 4, 5, 0, 1, 1, 1, 4, 12, 1, 1, 1, 1, 4, 12, 3, 5, 10, 1, 1,
+                    11, 5, 6, 0, 1, 1, 1, 5, 13, 9, 9, 9, 9, 5, 13, 3, 5, 10, 1, 9,
                 ],
             },
         ],
     };
 
+    assert_well_formed(&program);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);
@@ -596,7 +597,7 @@ fn displays_create_and_broadcast_tx_program() {
 }
 
 #[test]
-fn displays_build_funding_created_program() {
+fn displays_build_and_send_funding_created_program() {
     let instructions = vec![
         // Funding transaction.
         Instruction {
@@ -667,6 +668,11 @@ fn displays_build_funding_created_program() {
                 4, 2, 5, 0, 7, 7, 7, 8, 9, 11, 11, 11, 11, 8, 9, 12, 13, 14, 7, 11,
             ],
         },
+        // Send funding_created.
+        Instruction {
+            operation: Operation::SendFundingCreated,
+            inputs: vec![15],
+        },
     ];
 
     let program = Program { instructions };
@@ -693,6 +699,7 @@ fn displays_build_funding_created_program() {
         "v13 = LoadAmount(0)".into(),
         "v14 = LoadFeeratePerKw(253)".into(),
         "v15 = BuildFundingCreated(v4, v2, v5, v0, v7, v7, v7, v8, v9, v11, v11, v11, v11, v8, v9, v12, v13, v14, v7, v11)".into(),
+        "v16 = SendFundingCreated(v15)".into(),
     ];
 
     assert_eq!(lines.len(), expected.len(), "line count mismatch");

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -475,6 +475,16 @@ fn postcard_roundtrip() {
                 operation: Operation::BroadcastTransaction,
                 inputs: vec![10],
             },
+            Instruction {
+                operation: Operation::LoadU16(144),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::BuildFundingCreated,
+                inputs: vec![
+                    10, 4, 5, 0, 1, 1, 1, 4, 12, 1, 1, 1, 1, 4, 12, 3, 5, 10, 1, 1,
+                ],
+            },
         ],
     };
 
@@ -583,6 +593,112 @@ fn displays_create_and_broadcast_tx_program() {
         "BroadcastTransaction(v6)".into(),
     ];
     assert_eq!(lines, expected);
+}
+
+#[test]
+fn displays_build_funding_created_program() {
+    let instructions = vec![
+        // Funding transaction.
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(1)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![0],
+        },
+        Instruction {
+            operation: Operation::LoadAmount(10_000_000),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadFeeratePerKw(15_000),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::CreateFundingTransaction,
+            inputs: vec![1, 1, 2, 3],
+        },
+        // funding_created parameters.
+        Instruction {
+            operation: Operation::LoadFeatures(vec![0x01, 0x02]),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(2)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![6],
+        },
+        Instruction {
+            operation: Operation::LoadAmount(546),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadU16(144),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(3)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![10],
+        },
+        Instruction {
+            operation: Operation::LoadChannelId([0xbb; 32]),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadAmount(0),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadFeeratePerKw(253),
+            inputs: vec![],
+        },
+        // Build funding_created.
+        Instruction {
+            operation: Operation::BuildFundingCreated,
+            inputs: vec![
+                4, 2, 5, 0, 7, 7, 7, 8, 9, 11, 11, 11, 11, 8, 9, 12, 13, 14, 7, 11,
+            ],
+        },
+    ];
+
+    let program = Program { instructions };
+    let text = program.to_string();
+    let lines: Vec<&str> = text.lines().collect();
+
+    let z31 = "00".repeat(31);
+    let b32 = "bb".repeat(32);
+
+    let expected: Vec<String> = vec![
+        format!("v0 = LoadPrivateKey(0x{z31}01)"),
+        "v1 = DerivePoint(v0)".into(),
+        "v2 = LoadAmount(10000000)".into(),
+        "v3 = LoadFeeratePerKw(15000)".into(),
+        "v4 = CreateFundingTransaction(v1, v1, v2, v3)".into(),
+        "v5 = LoadFeatures(0x0102)".into(),
+        format!("v6 = LoadPrivateKey(0x{z31}02)"),
+        "v7 = DerivePoint(v6)".into(),
+        "v8 = LoadAmount(546)".into(),
+        "v9 = LoadU16(144)".into(),
+        format!("v10 = LoadPrivateKey(0x{z31}03)"),
+        "v11 = DerivePoint(v10)".into(),
+        format!("v12 = LoadChannelId(0x{b32})"),
+        "v13 = LoadAmount(0)".into(),
+        "v14 = LoadFeeratePerKw(253)".into(),
+        "v15 = BuildFundingCreated(v4, v2, v5, v0, v7, v7, v7, v8, v9, v11, v11, v11, v11, v8, v9, v12, v13, v14, v7, v11)".into(),
+    ];
+
+    assert_eq!(lines.len(), expected.len(), "line count mismatch");
+    for (i, (got, want)) in lines.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(got, want, "line {i} mismatch");
+    }
 }
 
 // Ensure AcceptChannelField and AcceptChannelField::ALL stay in sync. The

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -58,6 +58,8 @@ pub enum Variable {
     // Affine (single-use) variables
     /// `open_channel` has been sent, so `accept_channel` may now be received.
     SentOpenChannel,
+    /// `funding_created` has been sent, so `funding_signed` may now be received.
+    SentFundingCreated,
 }
 
 impl Variable {
@@ -85,6 +87,7 @@ impl Variable {
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
             Self::FundingTransaction(_) => VariableType::FundingTransaction,
             Self::SentOpenChannel => VariableType::SentOpenChannel,
+            Self::SentFundingCreated => VariableType::SentFundingCreated,
         }
     }
 }
@@ -113,13 +116,14 @@ pub enum VariableType {
     AcceptChannel,
     FundingTransaction,
     SentOpenChannel,
+    SentFundingCreated,
 }
 
 impl VariableType {
     #[must_use]
     pub fn is_affine(&self) -> bool {
         match self {
-            Self::SentOpenChannel => true,
+            Self::SentOpenChannel | Self::SentFundingCreated => true,
 
             Self::Bytes
             | Self::ChainHash

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -48,6 +48,8 @@ pub enum Variable {
     Message(Vec<u8>),
     /// Encoded BOLT `open_channel` message with type 32 prefix, ready to send.
     OpenChannelMessage(Vec<u8>),
+    /// Encoded BOLT `funding_created` message with type 34 prefix, ready to send.
+    FundingCreatedMessage(Vec<u8>),
     /// Parsed `accept_channel` response.
     AcceptChannel(AcceptChannel),
     /// Constructed funding transaction with funding output index.
@@ -79,6 +81,7 @@ impl Variable {
             Self::Features(_) => VariableType::Features,
             Self::Message(_) => VariableType::Message,
             Self::OpenChannelMessage(_) => VariableType::OpenChannelMessage,
+            Self::FundingCreatedMessage(_) => VariableType::FundingCreatedMessage,
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
             Self::FundingTransaction(_) => VariableType::FundingTransaction,
             Self::SentOpenChannel => VariableType::SentOpenChannel,
@@ -106,6 +109,7 @@ pub enum VariableType {
     Features,
     Message,
     OpenChannelMessage,
+    FundingCreatedMessage,
     AcceptChannel,
     FundingTransaction,
     SentOpenChannel,
@@ -132,6 +136,7 @@ impl VariableType {
             | Self::Features
             | Self::Message
             | Self::OpenChannelMessage
+            | Self::FundingCreatedMessage
             | Self::AcceptChannel
             | Self::ShortChannelId
             | Self::FundingTransaction => false,

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -291,6 +291,17 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     Some(Variable::SentOpenChannel)
                 }
 
+                Operation::SendFundingCreated => {
+                    let bytes = resolve_funding_created_message(&variables, instr.inputs[0]);
+                    log::debug!(
+                        "[{:?}] SendFundingCreated: {} bytes",
+                        start.elapsed(),
+                        bytes.len(),
+                    );
+                    self.conn.send_message(bytes)?;
+                    Some(Variable::SentFundingCreated)
+                }
+
                 Operation::RecvAcceptChannel => {
                     consume_sent_open_channel(&mut variables, instr.inputs[0]);
                     log::debug!("[{:?}] RecvAcceptChannel: waiting", start.elapsed());
@@ -479,6 +490,16 @@ fn resolve_open_channel_message(variables: &[Option<Variable>], index: usize) ->
         other => panic!(
             "variable {index}: expected OpenChannelMessage, got {:?}",
             other.var_type()
+        ),
+    }
+}
+
+fn resolve_funding_created_message(variables: &[Option<Variable>], index: usize) -> &[u8] {
+    match resolve(variables, index) {
+        Variable::FundingCreatedMessage(v) => v,
+        other => panic!(
+            "variable {index}: expected FundingCreatedMessage, got {:?}",
+            other.var_type(),
         ),
     }
 }
@@ -1930,7 +1951,7 @@ mod tests {
         assert_eq!(funds_err.required, Amount::from_sat(10_007_290));
     }
 
-    fn build_funding_created_instructions() -> Vec<Instruction> {
+    fn build_and_send_funding_created_instructions() -> Vec<Instruction> {
         let mut instrs = create_and_broadcast_tx_instructions();
         instrs.extend(vec![
             Instruction {
@@ -1967,32 +1988,50 @@ mod tests {
                     6, 4, 8, 0, 1, 1, 1, 9, 10, 3, 3, 3, 3, 9, 10, 11, 12, 13, 1, 3,
                 ],
             },
+            Instruction {
+                operation: Operation::SendFundingCreated,
+                inputs: vec![15],
+            },
         ]);
         instrs
     }
 
     #[test]
-    fn execute_build_funding_created() {
+    fn execute_build_and_send_funding_created() {
         let mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],
             change_spk: sample_change_spk(),
             ..Default::default()
         };
-        Executor::new(MockConnection::new(), mock_cli, sample_context())
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
             .execute(
                 &Program {
-                    instructions: build_funding_created_instructions(),
+                    instructions: build_and_send_funding_created_instructions(),
                 },
                 std::time::Instant::now(),
             )
-            .expect("BuildFundingCreated execution should succeed");
+            .unwrap();
+
+        assert_eq!(executor.conn.sent.len(), 1);
+        let fc = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
+            Message::FundingCreated(fc) => fc,
+            other => panic!("expected FundingCreated, got type {}", other.msg_type()),
+        };
+
+        assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(
+            fc.funding_txid.to_string(),
+            "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
+        );
+        assert_eq!(fc.funding_output_index, 0);
     }
 
     #[test]
     fn execute_build_funding_created_push_exceeds_funding() {
         // push_msat (v12) larger than the funding amount surfaces the commitment
         // construction error.
-        let mut instrs = build_funding_created_instructions();
+        let mut instrs = build_and_send_funding_created_instructions();
         instrs[12] = Instruction {
             operation: Operation::LoadAmount(20_000_000_000),
             inputs: vec![],
@@ -2020,7 +2059,7 @@ mod tests {
     fn execute_build_funding_created_funding_msat_overflow() {
         // Re-point funding_satoshis (input index 1) to the u64::MAX amount (v14)
         // so converting it to millisatoshis overflows.
-        let mut instrs = build_funding_created_instructions();
+        let mut instrs = build_and_send_funding_created_instructions();
         instrs[15].inputs[1] = 14;
         let mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -12,12 +12,13 @@ use smite::bolt::{
     NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, msg_type,
 };
 use smite::channel_tx::{
-    ChannelConfig, ChannelPartyConfig, FundingTransaction, HolderIdentity, Side,
+    ChannelConfig, ChannelPartyConfig, ChannelState, FundingTransaction, HolderIdentity, Side,
     build_funding_transaction,
 };
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable};
+use std::collections::HashMap;
 
 /// Abstraction over bitcoin-cli operations, allowing mock implementations in tests.
 pub trait BitcoinRpc {
@@ -129,16 +130,22 @@ pub struct Executor<C, B> {
     bitcoin_cli: B,
     /// Immutable state captured during snapshot setup.
     context: ProgramContext,
+    /// Channel states maintained implicitly across program execution, keyed by
+    /// `ChannelId`. Created by the funding flow and initialized with the
+    /// channel's static configuration and initial commitment state, then
+    /// updated as commitments are exchanged and revoked.
+    channel_states: HashMap<ChannelId, ChannelState>,
 }
 
 impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
     /// Creates an executor with the given connection, bitcoin-cli handle, and
-    /// program context.
+    /// program context. Channel state starts empty.
     pub fn new(conn: C, bitcoin_cli: B, context: ProgramContext) -> Self {
         Self {
             conn,
             bitcoin_cli,
             context,
+            channel_states: HashMap::new(),
         }
     }
 
@@ -244,7 +251,8 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 }
 
                 Operation::BuildFundingCreated => {
-                    let fc = build_funding_created(&variables, &instr.inputs)?;
+                    let fc =
+                        build_funding_created(&variables, &instr.inputs, &mut self.channel_states)?;
                     let encoded = Message::FundingCreated(fc).encode();
                     Some(Variable::FundingCreatedMessage(encoded))
                 }
@@ -607,6 +615,7 @@ fn build_open_channel(variables: &[Option<Variable>], inputs: &[usize]) -> OpenC
 fn build_funding_created(
     variables: &[Option<Variable>],
     inputs: &[usize],
+    channel_states: &mut HashMap<ChannelId, ChannelState>,
 ) -> Result<FundingCreated, ExecuteError> {
     let funding_tx = resolve_funding_transaction(variables, inputs[0]);
     let funding_outpoint = OutPoint {
@@ -666,6 +675,17 @@ fn build_funding_created(
 
     let funding_output_index = u16::try_from(funding_outpoint.vout)
         .expect("funding output index of a funding tx must fit in u16");
+    let channel_id = ChannelId::v1_from_funding_outpoint(config.funding_outpoint);
+
+    // Building the same message again must not clobber a channel whose state
+    // has already been established (and possibly advanced).
+    channel_states
+        .entry(channel_id)
+        .or_insert_with(|| ChannelState {
+            config,
+            holder,
+            commitment: state,
+        });
 
     Ok(FundingCreated {
         temporary_channel_id,
@@ -2025,6 +2045,26 @@ mod tests {
             "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
         );
         assert_eq!(fc.funding_output_index, 0);
+
+        // Verify the signature sent by the opener on the acceptor side.
+        let channel_id = ChannelId::v1_from_funding_outpoint(OutPoint {
+            txid: fc.funding_txid,
+            vout: u32::from(fc.funding_output_index),
+        });
+        let state = executor.channel_states.get(&channel_id).unwrap();
+        let holder = HolderIdentity {
+            side: Side::Acceptor,
+            funding_privkey: SecretKey::from_str(
+                "1552dfba4f6cf29a62a0af13c8d6981d36d0ef8d61ba10fb0fe90da7634d7e13",
+            )
+            .unwrap(),
+        };
+
+        assert!(state.config.verify_counterparty_signature(
+            &state.commitment,
+            &holder,
+            &fc.signature
+        ));
     }
 
     #[test]

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -3,15 +3,18 @@
 //! Executes an IR program against a target node over an established connection,
 //! producing side effects (sending/receiving messages).
 
-use bitcoin::ScriptBuf;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use bitcoin::{OutPoint, ScriptBuf};
 use smite::bitcoin::{BitcoinCli, Utxo};
 use smite::bolt::{
-    AcceptChannel, ChannelAnnouncement, ChannelId, ChannelUpdate, Message, NodeAnnouncement,
-    OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, msg_type,
+    AcceptChannel, ChannelAnnouncement, ChannelId, ChannelUpdate, FundingCreated, Message,
+    NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, msg_type,
 };
-use smite::channel_tx::{FundingTransaction, build_funding_transaction};
+use smite::channel_tx::{
+    ChannelConfig, ChannelPartyConfig, FundingTransaction, HolderIdentity, Side,
+    build_funding_transaction,
+};
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable};
@@ -112,6 +115,10 @@ pub enum ExecuteError {
     /// Wallet UTXOs could not cover the funding amount and fees.
     #[error("funding: {0}")]
     InsufficientFunds(#[from] smite::channel_tx::InsufficientFunds),
+
+    /// Failed to construct the initial commitment state.
+    #[error("commitment: {0}")]
+    Commitment(#[from] smite::channel_tx::CommitmentError),
 }
 
 /// Executes IR programs against a target over an established connection.
@@ -145,8 +152,9 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
     /// # Errors
     ///
     /// Returns an error on a connection/send/receive failure, a decode failure of
-    /// a received message, an unexpected message type from the target, or when
-    /// wallet funds are insufficient to perform a channel operation.
+    /// a received message, an unexpected message type from the target, when
+    /// wallet funds are insufficient to perform a channel operation, or when the
+    /// initial commitment transaction cannot be constructed.
     ///
     /// # Panics
     ///
@@ -233,6 +241,12 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     let oc = build_open_channel(&variables, &instr.inputs);
                     let encoded = Message::OpenChannel(oc).encode();
                     Some(Variable::OpenChannelMessage(encoded))
+                }
+
+                Operation::BuildFundingCreated => {
+                    let fc = build_funding_created(&variables, &instr.inputs)?;
+                    let encoded = Message::FundingCreated(fc).encode();
+                    Some(Variable::FundingCreatedMessage(encoded))
                 }
 
                 Operation::BuildChannelAnnouncement => {
@@ -568,6 +582,78 @@ fn build_open_channel(variables: &[Option<Variable>], inputs: &[usize]) -> OpenC
     }
 }
 
+/// Builds a `funding_created` message from 20 input variables.
+fn build_funding_created(
+    variables: &[Option<Variable>],
+    inputs: &[usize],
+) -> Result<FundingCreated, ExecuteError> {
+    let funding_tx = resolve_funding_transaction(variables, inputs[0]);
+    let funding_outpoint = OutPoint {
+        txid: funding_tx.tx.compute_txid(),
+        vout: funding_tx.vout,
+    };
+
+    let funding_satoshis = resolve_amount(variables, inputs[1]);
+    let channel_type = resolve_features(variables, inputs[2]).to_vec();
+    let opener_funding_privkey_bytes = resolve_private_key(variables, inputs[3]);
+    let opener_funding_privkey =
+        SecretKey::from_slice(&opener_funding_privkey_bytes).expect("valid private key");
+    let secp = Secp256k1::new();
+    let opener_funding_pubkey = PublicKey::from_secret_key(&secp, &opener_funding_privkey);
+
+    let opener = ChannelPartyConfig {
+        funding_pubkey: opener_funding_pubkey,
+        payment_basepoint: resolve_pubkey(variables, inputs[4]),
+        revocation_basepoint: resolve_pubkey(variables, inputs[5]),
+        delayed_payment_basepoint: resolve_pubkey(variables, inputs[6]),
+        dust_limit_satoshis: resolve_amount(variables, inputs[7]),
+        to_self_delay: resolve_u16(variables, inputs[8]),
+    };
+    let acceptor = ChannelPartyConfig {
+        funding_pubkey: resolve_pubkey(variables, inputs[9]),
+        payment_basepoint: resolve_pubkey(variables, inputs[10]),
+        revocation_basepoint: resolve_pubkey(variables, inputs[11]),
+        delayed_payment_basepoint: resolve_pubkey(variables, inputs[12]),
+        dust_limit_satoshis: resolve_amount(variables, inputs[13]),
+        to_self_delay: resolve_u16(variables, inputs[14]),
+    };
+    let config = ChannelConfig {
+        funding_outpoint,
+        funding_satoshis,
+        channel_type,
+        opener,
+        acceptor,
+    };
+
+    let temporary_channel_id = resolve_channel_id(variables, inputs[15]);
+    let push_msat = resolve_amount(variables, inputs[16]);
+    let feerate_per_kw = resolve_feerate(variables, inputs[17]);
+    let opener_per_commitment_point = resolve_pubkey(variables, inputs[18]);
+    let acceptor_per_commitment_point = resolve_pubkey(variables, inputs[19]);
+
+    let state = config.new_initial_commitment(
+        push_msat,
+        feerate_per_kw,
+        opener_per_commitment_point,
+        acceptor_per_commitment_point,
+    )?;
+    let holder = HolderIdentity {
+        side: Side::Opener,
+        funding_privkey: opener_funding_privkey,
+    };
+    let signature = config.sign_counterparty_commitment(&state, &holder);
+
+    let funding_output_index = u16::try_from(funding_outpoint.vout)
+        .expect("funding output index of a funding tx must fit in u16");
+
+    Ok(FundingCreated {
+        temporary_channel_id,
+        funding_txid: funding_outpoint.txid,
+        funding_output_index,
+        signature,
+    })
+}
+
 /// Builds a signed `ChannelAnnouncement` from 7 input variables.
 fn build_channel_announcement(
     variables: &[Option<Variable>],
@@ -755,7 +841,7 @@ mod tests {
 
     use super::*;
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
-    use bitcoin::{Amount, OutPoint, Transaction};
+    use bitcoin::{Amount, Transaction};
     use smite::bolt::{AcceptChannelTlvs, Init, Ping};
     use smite_ir::Instruction;
 
@@ -1842,6 +1928,117 @@ mod tests {
         };
         assert_eq!(funds_err.available, Amount::from_sat(1_000));
         assert_eq!(funds_err.required, Amount::from_sat(10_007_290));
+    }
+
+    fn build_funding_created_instructions() -> Vec<Instruction> {
+        let mut instrs = create_and_broadcast_tx_instructions();
+        instrs.extend(vec![
+            Instruction {
+                operation: Operation::LoadFeatures(vec![]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(546),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadU16(144),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadChannelId([0xbb; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(3_000_000_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadFeeratePerKw(15_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(u64::MAX),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::BuildFundingCreated,
+                inputs: vec![
+                    6, 4, 8, 0, 1, 1, 1, 9, 10, 3, 3, 3, 3, 9, 10, 11, 12, 13, 1, 3,
+                ],
+            },
+        ]);
+        instrs
+    }
+
+    #[test]
+    fn execute_build_funding_created() {
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        Executor::new(MockConnection::new(), mock_cli, sample_context())
+            .execute(
+                &Program {
+                    instructions: build_funding_created_instructions(),
+                },
+                std::time::Instant::now(),
+            )
+            .expect("BuildFundingCreated execution should succeed");
+    }
+
+    #[test]
+    fn execute_build_funding_created_push_exceeds_funding() {
+        // push_msat (v12) larger than the funding amount surfaces the commitment
+        // construction error.
+        let mut instrs = build_funding_created_instructions();
+        instrs[12] = Instruction {
+            operation: Operation::LoadAmount(20_000_000_000),
+            inputs: vec![],
+        };
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        let err = Executor::new(MockConnection::new(), mock_cli, sample_context())
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ExecuteError::Commitment(smite::channel_tx::CommitmentError::PushExceedsFunding)
+        ));
+    }
+
+    #[test]
+    fn execute_build_funding_created_funding_msat_overflow() {
+        // Re-point funding_satoshis (input index 1) to the u64::MAX amount (v14)
+        // so converting it to millisatoshis overflows.
+        let mut instrs = build_funding_created_instructions();
+        instrs[15].inputs[1] = 14;
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        let err = Executor::new(MockConnection::new(), mock_cli, sample_context())
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ExecuteError::Commitment(smite::channel_tx::CommitmentError::FundingMsatOverflow)
+        ));
     }
 
     // -- extract_field tests --

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -85,6 +85,12 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
                 // the available UTXOs can't cover. Not a bug in the target.
                 log::debug!("[{:?}] insufficient funds: {e}", start.elapsed());
             }
+            Err(ExecuteError::Commitment(e)) => {
+                // The mutator generated a funding amount/push_msat combination
+                // that can't form a valid initial commitment transaction. Not a
+                // bug in the target.
+                log::debug!("[{:?}] invalid commitment: {e}", start.elapsed());
+            }
         }
 
         // Ping-pong sync to ensure the target has at least done the initial

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -1,5 +1,7 @@
 //! Fundamental types for BOLT message encoding.
 
+use bitcoin::OutPoint;
+use bitcoin::hashes::Hash;
 use std::fmt;
 
 /// Maximum Lightning message size (2-byte length prefix limit).
@@ -27,7 +29,7 @@ pub const PUBLIC_KEY_SIZE: usize = 33;
 pub const SHORT_CHANNEL_ID_SIZE: usize = 8;
 
 /// A 32-byte channel identifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub struct ChannelId(pub [u8; CHANNEL_ID_SIZE]);
 
 impl ChannelId {
@@ -45,6 +47,15 @@ impl ChannelId {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8; CHANNEL_ID_SIZE] {
         &self.0
+    }
+
+    /// Create _v1_ channel ID from a funding tx outpoint
+    #[must_use]
+    pub fn v1_from_funding_outpoint(outpoint: OutPoint) -> Self {
+        let mut res = outpoint.txid.to_byte_array();
+        res[30] ^= ((outpoint.vout >> 8) & 0xff) as u8;
+        res[31] ^= (outpoint.vout & 0xff) as u8;
+        Self(res)
     }
 }
 
@@ -166,6 +177,8 @@ impl BigSize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::hex::DisplayHex;
+    use bitcoin::{OutPoint, Txid};
 
     #[test]
     fn bigsize_new() {
@@ -197,6 +210,18 @@ mod tests {
     #[test]
     fn channel_id_default_is_all() {
         assert_eq!(ChannelId::default(), ChannelId::ALL);
+    }
+
+    #[test]
+    fn channel_id_from_funding_outpoint_xors_last_two_bytes() {
+        let funding_outpoint = OutPoint {
+            txid: Txid::from_byte_array([2; 32]),
+            vout: 1,
+        };
+        let expected = "0202020202020202020202020202020202020202020202020202020202020203";
+        let channel_id = ChannelId::v1_from_funding_outpoint(funding_outpoint);
+
+        assert_eq!(channel_id.0.as_hex().to_string(), expected);
     }
 
     #[test]

--- a/smite/src/channel_tx.rs
+++ b/smite/src/channel_tx.rs
@@ -7,7 +7,7 @@ mod commitment;
 mod funding;
 
 pub use commitment::{
-    ChannelConfig, ChannelPartyConfig, CommitmentError, CommitmentPartyState, CommitmentState,
-    HolderIdentity, Side,
+    ChannelConfig, ChannelPartyConfig, ChannelState, CommitmentError, CommitmentPartyState,
+    CommitmentState, HolderIdentity, Side,
 };
 pub use funding::{FundingTransaction, InsufficientFunds, build_funding_transaction};

--- a/smite/src/channel_tx/commitment.rs
+++ b/smite/src/channel_tx/commitment.rs
@@ -110,6 +110,20 @@ pub struct CommitmentState {
     // to correctly compute balances and construct HTLC outputs in the commitment transaction.
 }
 
+/// State of a single channel, including its static configuration, holder
+/// identity, and current commitment state.
+pub struct ChannelState {
+    /// Channel configuration established at channel creation and unchanged
+    /// for the lifetime of the channel.
+    pub config: ChannelConfig,
+    /// Holder-specific identity data (channel side and funding secret) used to
+    /// sign commitment transactions and verify the counterparty's signatures.
+    pub holder: HolderIdentity,
+    /// Current commitment state, updated as commitments are exchanged and
+    /// revoked.
+    pub commitment: CommitmentState,
+}
+
 impl Side {
     /// Returns the counterparty side.
     fn other(&self) -> &Self {


### PR DESCRIPTION
Depends-on: #117 

This PR adds the `BuildFundingCreated` and `SendFundingCreated` IR operations, which build and send a `funding_created` message to the target peer.

It also adds a new `channel_states` field to the `Executor` struct. This field is used to store the `channel_state` while building the `funding_created` message and is subsequently used to verify the received `funding_signed` signature.