### PR TITLE
smite: add `announcement_signatures` codec

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -5,6 +5,7 @@
 
 mod accept_channel;
 mod accept_channel2;
+mod announcement_signatures;
 mod attribution_data;
 mod channel_announcement;
 mod channel_ready;
@@ -37,6 +38,7 @@ mod wire;
 
 pub use accept_channel::{AcceptChannel, AcceptChannelTlvs};
 pub use accept_channel2::{AcceptChannel2, AcceptChannel2Tlvs};
+pub use announcement_signatures::AnnouncementSignatures;
 pub use attribution_data::{AttributionData, TruncatedHmac};
 pub use channel_announcement::ChannelAnnouncement;
 pub use channel_ready::{ChannelReady, ChannelReadyTlvs};
@@ -168,6 +170,8 @@ pub mod msg_type {
     pub const NODE_ANNOUNCEMENT: u16 = 257;
     /// `channel_update` message (BOLT 7).
     pub const CHANNEL_UPDATE: u16 = 258;
+    /// `announcement_signatures` message (BOLT 7).
+    pub const ANNOUNCEMENT_SIGNATURES: u16 = 259;
     /// Gossip timestamp filter message (BOLT 7).
     pub const GOSSIP_TIMESTAMP_FILTER: u16 = 265;
 }
@@ -228,6 +232,8 @@ pub enum Message {
     NodeAnnouncement(NodeAnnouncement),
     /// `channel_update` message (type 258).
     ChannelUpdate(ChannelUpdate),
+    /// `announcement_signatures` message (type 259).
+    AnnouncementSignatures(AnnouncementSignatures),
     /// Gossip timestamp filter message (type 265).
     GossipTimestampFilter(GossipTimestampFilter),
     /// Unknown message type.
@@ -273,6 +279,7 @@ impl Message {
             Self::ChannelAnnouncement(_) => msg_type::CHANNEL_ANNOUNCEMENT,
             Self::NodeAnnouncement(_) => msg_type::NODE_ANNOUNCEMENT,
             Self::ChannelUpdate(_) => msg_type::CHANNEL_UPDATE,
+            Self::AnnouncementSignatures(_) => msg_type::ANNOUNCEMENT_SIGNATURES,
             Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => *msg_type,
         }
@@ -310,6 +317,7 @@ impl Message {
             Self::ChannelAnnouncement(m) => out.extend(m.encode()),
             Self::NodeAnnouncement(m) => out.extend(m.encode()),
             Self::ChannelUpdate(m) => out.extend(m.encode()),
+            Self::AnnouncementSignatures(m) => out.extend(m.encode()),
             Self::GossipTimestampFilter(m) => out.extend(m.encode()),
             Self::Unknown { payload, .. } => out.extend(payload),
         }
@@ -362,6 +370,9 @@ impl Message {
                 Ok(Self::NodeAnnouncement(NodeAnnouncement::decode(cursor)?))
             }
             msg_type::CHANNEL_UPDATE => Ok(Self::ChannelUpdate(ChannelUpdate::decode(cursor)?)),
+            msg_type::ANNOUNCEMENT_SIGNATURES => Ok(Self::AnnouncementSignatures(
+                AnnouncementSignatures::decode(cursor)?,
+            )),
             msg_type::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
                 GossipTimestampFilter::decode(cursor)?,
             )),
@@ -903,6 +914,29 @@ mod tests {
         assert_eq!(decoded, Message::ChannelUpdate(cu));
     }
 
+    /// Valid `AnnouncementSignatures` message for testing.
+    fn sample_announcement_signatures() -> AnnouncementSignatures {
+        let secp = Secp256k1::new();
+        let node_sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
+        let bitcoin_sk = SecretKey::from_slice(&[0x22; 32]).expect("valid secret");
+        let digest = secp256k1::Message::from_digest([0xab; 32]);
+
+        AnnouncementSignatures {
+            channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
+            short_channel_id: ShortChannelId::new(539_268, 845, 1),
+            node_signature: secp.sign_ecdsa(&digest, &node_sk),
+            bitcoin_signature: secp.sign_ecdsa(&digest, &bitcoin_sk),
+        }
+    }
+
+    #[test]
+    fn message_announcement_signatures_roundtrip() {
+        let ann_sigs = sample_announcement_signatures();
+        let encoded = Message::AnnouncementSignatures(ann_sigs.clone()).encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::AnnouncementSignatures(ann_sigs));
+    }
+
     #[test]
     fn message_gossip_timestamp_filter_roundtrip() {
         let chain_hash = [0x6f; 32];
@@ -1060,6 +1094,10 @@ mod tests {
         assert_eq!(
             Message::ChannelUpdate(sample_channel_update()).msg_type(),
             msg_type::CHANNEL_UPDATE
+        );
+        assert_eq!(
+            Message::AnnouncementSignatures(sample_announcement_signatures()).msg_type(),
+            msg_type::ANNOUNCEMENT_SIGNATURES
         );
         assert_eq!(
             Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),

--- a/smite/src/bolt/announcement_signatures.rs
+++ b/smite/src/bolt/announcement_signatures.rs
@@ -1,0 +1,191 @@
+//! BOLT 7 announcement signatures message.
+
+use super::BoltError;
+use super::types::{ChannelId, ShortChannelId};
+use super::wire::WireFormat;
+use bitcoin::secp256k1::ecdsa::Signature;
+
+/// BOLT 7 `announcement_signatures` message (type 259).
+///
+/// A direct (non-gossip) message between the two endpoints of a channel.
+/// Each peer sends their `node_signature` and `bitcoin_signature` over the
+/// `channel_announcement` body, allowing the counterparty to assemble and
+/// broadcast the fully-signed `channel_announcement`.
+///
+/// Wire layout (per [BOLT 7]):
+///
+/// ```text
+/// [channel_id:32]
+/// [short_channel_id:8]
+/// [signature:64]    // node_signature
+/// [signature:64]    // bitcoin_signature
+/// ```
+///
+/// [BOLT 7]: https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#the-announcement_signatures-message
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnouncementSignatures {
+    /// The channel ID of the channel being announced.
+    pub channel_id: ChannelId,
+    /// Reference to the funding transaction.
+    pub short_channel_id: ShortChannelId,
+    /// Sender's signature with its `node_id` over the `channel_announcement` body.
+    pub node_signature: Signature,
+    /// Sender's signature with its `bitcoin_key` over the `channel_announcement` body.
+    pub bitcoin_signature: Signature,
+}
+
+impl AnnouncementSignatures {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+        self.short_channel_id.write(&mut out);
+        self.node_signature.write(&mut out);
+        self.bitcoin_signature.write(&mut out);
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short for any fixed field, or
+    /// `InvalidSignature` if either signature is not a valid compact ECDSA
+    /// signature.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+
+        let channel_id = WireFormat::read(&mut cursor)?;
+        let short_channel_id = WireFormat::read(&mut cursor)?;
+        let node_signature = WireFormat::read(&mut cursor)?;
+        let bitcoin_signature = WireFormat::read(&mut cursor)?;
+
+        Ok(Self {
+            channel_id,
+            short_channel_id,
+            node_signature,
+            bitcoin_signature,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, SHORT_CHANNEL_ID_SIZE};
+    use super::*;
+    use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
+
+    /// Valid `AnnouncementSignatures` message for testing.
+    fn sample_announcement_signatures() -> AnnouncementSignatures {
+        let secp = Secp256k1::new();
+        let node_sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret");
+        let bitcoin_sk = SecretKey::from_slice(&[0x22; 32]).expect("valid secret");
+        // The signatures here would normally cover the channel_announcement
+        // body; for codec tests any well-formed digest suffices.
+        let digest = Message::from_digest([0xab; 32]);
+
+        AnnouncementSignatures {
+            channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
+            short_channel_id: ShortChannelId::new(539_268, 845, 1),
+            node_signature: secp.sign_ecdsa(&digest, &node_sk),
+            bitcoin_signature: secp.sign_ecdsa(&digest, &bitcoin_sk),
+        }
+    }
+
+    #[test]
+    fn encode_fixed_field_size() {
+        let msg = sample_announcement_signatures();
+        let encoded = msg.encode();
+        // 32 (channel_id) + 8 (scid) + 64 (node_sig) + 64 (bitcoin_sig) = 168
+        assert_eq!(encoded.len(), 168);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = sample_announcement_signatures();
+        let encoded = original.encode();
+        let decoded = AnnouncementSignatures::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        // 10 bytes — short of the 32 needed for channel_id.
+        assert_eq!(
+            AnnouncementSignatures::decode(&[0u8; 10]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_short_channel_id() {
+        // channel_id(32) + 5 bytes of scid (need 8)
+        let encoded = sample_announcement_signatures().encode();
+        let data = &encoded[..CHANNEL_ID_SIZE + 5];
+        assert_eq!(
+            AnnouncementSignatures::decode(data),
+            Err(BoltError::Truncated {
+                expected: SHORT_CHANNEL_ID_SIZE,
+                actual: 5,
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_node_signature() {
+        // channel_id(32) + scid(8) + 10 bytes of node_signature (need 64)
+        let encoded = sample_announcement_signatures().encode();
+        let data = &encoded[..CHANNEL_ID_SIZE + SHORT_CHANNEL_ID_SIZE + 10];
+        assert_eq!(
+            AnnouncementSignatures::decode(data),
+            Err(BoltError::Truncated {
+                expected: COMPACT_SIGNATURE_SIZE,
+                actual: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn decode_truncated_bitcoin_signature() {
+        // channel_id(32) + scid(8) + node_signature(64) + 10 bytes of bitcoin_signature (need 64)
+        let encoded = sample_announcement_signatures().encode();
+        let data =
+            &encoded[..CHANNEL_ID_SIZE + SHORT_CHANNEL_ID_SIZE + COMPACT_SIGNATURE_SIZE + 10];
+        assert_eq!(
+            AnnouncementSignatures::decode(data),
+            Err(BoltError::Truncated {
+                expected: COMPACT_SIGNATURE_SIZE,
+                actual: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn decode_invalid_node_signature() {
+        let mut encoded = sample_announcement_signatures().encode();
+        // r and s are both above curve order.
+        let bad_sig = [0xff; COMPACT_SIGNATURE_SIZE];
+        let offset = CHANNEL_ID_SIZE + SHORT_CHANNEL_ID_SIZE;
+        encoded[offset..offset + COMPACT_SIGNATURE_SIZE].copy_from_slice(&bad_sig);
+        assert_eq!(
+            AnnouncementSignatures::decode(&encoded),
+            Err(BoltError::InvalidSignature(bad_sig))
+        );
+    }
+
+    #[test]
+    fn decode_invalid_bitcoin_signature() {
+        let mut encoded = sample_announcement_signatures().encode();
+        let bad_sig = [0xff; COMPACT_SIGNATURE_SIZE];
+        let offset = CHANNEL_ID_SIZE + SHORT_CHANNEL_ID_SIZE + COMPACT_SIGNATURE_SIZE;
+        encoded[offset..offset + COMPACT_SIGNATURE_SIZE].copy_from_slice(&bad_sig);
+        assert_eq!(
+            AnnouncementSignatures::decode(&encoded),
+            Err(BoltError::InvalidSignature(bad_sig))
+        );
+    }
+}


### PR DESCRIPTION
Implements the BOLT 7 announcement_signatures message (type 259).
A direct (non-gossip) message between the two endpoints of a channel that conveys each peer's node_signature and bitcoin_signature over the channel_announcement body, allowing the counterparty to assemble and broadcast the fully-signed channel_announcement.

Wire layout:
[channel_id:32]
[short_channel_id:8]
[signature:64]    // node_signature
[signature:64]    // bitcoin_signature

Codec only -- encode/decode and roundtrip tests; signing/verification happens at a higher layer (the IR `BuildAnnouncementSignatures` operation, in a follow-up PR) since the digest is over a different message.



Ref: #71