### PR TITLE
smite-ir: Add `GeneratorInsertionMutator`

### DIFF
--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -37,15 +37,16 @@ use std::os::raw::{c_char, c_uint, c_void};
 use std::slice;
 
 use rand::rngs::SmallRng;
-use rand::{RngExt, SeedableRng};
+use rand::{RngExt, SeedableRng, seq::IteratorRandom};
 
 use smite_ir::generators::{
-    ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
+    AnyGenerator, ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
     OpenChannelGenerator,
 };
 use smite_ir::minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use smite_ir::mutators::{
-    InputSwapMutator, InstructionDeleteMutator, InstructionReorderMutator, OperationParamMutator,
+    GeneratorInsertionMutator, InputSwapMutator, InstructionDeleteMutator,
+    InstructionReorderMutator, OperationParamMutator,
 };
 use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
 
@@ -100,7 +101,7 @@ impl MutatorState {
         let stack = 1u32 << self.rng.random_range(0..=4);
         for _ in 0..stack {
             // Uniform pick between the available mutators.
-            let name = match self.rng.random_range(0..4) {
+            let name = match self.rng.random_range(0..5) {
                 0 => {
                     OperationParamMutator.mutate(program, &mut self.rng);
                     "op-param"
@@ -116,6 +117,15 @@ impl MutatorState {
                 3 => {
                     InstructionReorderMutator.mutate(program, &mut self.rng);
                     "instr-reorder"
+                }
+                4 => {
+                    let generator = *AnyGenerator::ALL
+                        .iter()
+                        .choose(&mut self.rng)
+                        .expect("AnyGenerator::ALL is non-empty");
+                    let mutator = GeneratorInsertionMutator::new(generator);
+                    mutator.mutate(program, &mut self.rng);
+                    "gen-insert"
                 }
                 _ => unreachable!("random_range() bound out of sync with match arms"),
             };
@@ -557,7 +567,8 @@ mod tests {
                     name == "op-param"
                         || name == "input-swap"
                         || name == "instr-delete"
-                        || name == "instr-reorder",
+                        || name == "instr-reorder"
+                        || name == "gen-insert",
                     "unexpected mutator name in description: {name:?} (full: {s:?})",
                 );
             }

--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -39,10 +39,7 @@ use std::slice;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng, seq::IteratorRandom};
 
-use smite_ir::generators::{
-    AnyGenerator, ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
-    OpenChannelGenerator,
-};
+use smite_ir::generators::AnyGenerator;
 use smite_ir::minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use smite_ir::mutators::{
     GeneratorInsertionMutator, InputSwapMutator, InstructionDeleteMutator,
@@ -79,13 +76,11 @@ impl MutatorState {
     /// the registered generators.
     fn generate_fresh(&mut self) -> Program {
         let mut builder = ProgramBuilder::new();
-        match self.rng.random_range(0..4) {
-            0 => OpenChannelGenerator.generate(&mut builder, &mut self.rng),
-            1 => ChannelAnnouncementGenerator.generate(&mut builder, &mut self.rng),
-            2 => NodeAnnouncementGenerator.generate(&mut builder, &mut self.rng),
-            3 => ChannelUpdateGenerator.generate(&mut builder, &mut self.rng),
-            _ => unreachable!("random_range() bound out of sync with match arms"),
-        }
+        AnyGenerator::ALL
+            .iter()
+            .choose(&mut self.rng)
+            .expect("AnyGenerator::ALL is non-empty")
+            .generate(&mut builder, &mut self.rng);
         self.last_sequence.clear();
         self.last_sequence.push("fresh");
         builder.build()
@@ -421,6 +416,7 @@ pub unsafe extern "C" fn afl_custom_describe(
 
 #[cfg(test)]
 mod tests {
+    use smite_ir::generators::OpenChannelGenerator;
     use std::ffi::CStr;
     use std::ptr;
 

--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -256,6 +256,12 @@ impl ProgramBuilder {
             } => self.append(operation, &[compound_idx]),
         }
     }
+
+    /// Returns the current number of instructions.
+    #[must_use]
+    pub fn instructions_len(&self) -> usize {
+        self.instructions.len()
+    }
 }
 
 impl Default for ProgramBuilder {

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -24,3 +24,34 @@ pub trait Generator {
     /// Emits instructions for this generator's protocol interaction.
     fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng);
 }
+
+/// A list of all the available generators. Any generators included
+/// here may be used by the custom mutator library.
+#[derive(Clone, Copy)]
+pub enum AnyGenerator {
+    ChannelAnnouncement(ChannelAnnouncementGenerator),
+    ChannelUpdate(ChannelUpdateGenerator),
+    NodeAnnouncement(NodeAnnouncementGenerator),
+    OpenChannel(OpenChannelGenerator),
+}
+
+impl AnyGenerator {
+    /// All variants. Keep in sync with the enum definition.
+    pub const ALL: &[Self] = &[
+        Self::ChannelAnnouncement(ChannelAnnouncementGenerator),
+        Self::ChannelUpdate(ChannelUpdateGenerator),
+        Self::NodeAnnouncement(NodeAnnouncementGenerator),
+        Self::OpenChannel(OpenChannelGenerator),
+    ];
+}
+
+impl Generator for AnyGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        match self {
+            Self::ChannelAnnouncement(generator) => generator.generate(builder, rng),
+            Self::ChannelUpdate(generator) => generator.generate(builder, rng),
+            Self::NodeAnnouncement(generator) => generator.generate(builder, rng),
+            Self::OpenChannel(generator) => generator.generate(builder, rng),
+        }
+    }
+}

--- a/smite-ir/src/generators/channel_announcement.rs
+++ b/smite-ir/src/generators/channel_announcement.rs
@@ -7,6 +7,7 @@ use crate::builder::ProgramBuilder;
 use crate::{Operation, VariableType};
 
 /// Generates an unsolicited `channel_announcement` send.
+#[derive(Clone, Copy)]
 pub struct ChannelAnnouncementGenerator;
 
 impl Generator for ChannelAnnouncementGenerator {

--- a/smite-ir/src/generators/channel_update.rs
+++ b/smite-ir/src/generators/channel_update.rs
@@ -12,6 +12,7 @@ use crate::{Operation, VariableType};
 /// signing key, chain hash, and short channel id are drawn via
 /// `pick_variable` so they can be shared with other gossip messages (e.g. a
 /// preceding `channel_announcement`) when generators are composed.
+#[derive(Clone, Copy)]
 pub struct ChannelUpdateGenerator;
 
 impl Generator for ChannelUpdateGenerator {

--- a/smite-ir/src/generators/node_announcement.rs
+++ b/smite-ir/src/generators/node_announcement.rs
@@ -7,6 +7,7 @@ use crate::builder::ProgramBuilder;
 use crate::{Operation, VariableType};
 
 /// Generates an unsolicited `node_announcement` send.
+#[derive(Clone, Copy)]
 pub struct NodeAnnouncementGenerator;
 
 impl Generator for NodeAnnouncementGenerator {

--- a/smite-ir/src/generators/open_channel.rs
+++ b/smite-ir/src/generators/open_channel.rs
@@ -14,6 +14,7 @@ use crate::{Operation, VariableType};
 /// 1. Generate channel parameters
 /// 2. Build and send `open_channel`
 /// 3. Receive and parse `accept_channel`
+#[derive(Clone, Copy)]
 pub struct OpenChannelGenerator;
 
 impl Generator for OpenChannelGenerator {

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -3,11 +3,13 @@
 //! Mutators transform programs to explore new protocol states while preserving
 //! structural validity. Each mutator makes a small, targeted change.
 
+mod generator_insert;
 mod input_swap;
 mod instruction_delete;
 mod instruction_reorder;
 mod operation_param;
 
+pub use generator_insert::GeneratorInsertionMutator;
 pub use input_swap::InputSwapMutator;
 pub use instruction_delete::InstructionDeleteMutator;
 pub use instruction_reorder::InstructionReorderMutator;

--- a/smite-ir/src/mutators/generator_insert.rs
+++ b/smite-ir/src/mutators/generator_insert.rs
@@ -1,0 +1,47 @@
+//! Mutator that inserts generated programs.
+
+use rand::{Rng, RngExt};
+
+use super::Mutator;
+use crate::{Generator, Program, ProgramBuilder};
+
+/// Inserts a generated program at a random point in the given program.
+pub struct GeneratorInsertionMutator<G: Generator> {
+    generator: G,
+}
+
+impl<G: Generator> GeneratorInsertionMutator<G> {
+    pub fn new(generator: G) -> Self {
+        Self { generator }
+    }
+}
+
+impl<G: Generator> Mutator for GeneratorInsertionMutator<G> {
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool {
+        let insert_idx = rng.random_range(0..=program.instructions.len());
+        let mut builder = ProgramBuilder::new();
+        let mut iter = std::mem::take(&mut program.instructions).into_iter();
+
+        // Consume and append the pre-insertion instructions.
+        for instr in iter.by_ref().take(insert_idx) {
+            builder.append(instr.operation, &instr.inputs);
+        }
+
+        // Generate and insert a new program.
+        self.generator.generate(&mut builder, rng);
+        let offset = builder.instructions_len() - insert_idx;
+
+        // Consume, shift, and append the post-insertion instructions.
+        for mut instr in iter {
+            for input in &mut instr.inputs {
+                if *input >= insert_idx {
+                    *input += offset;
+                }
+            }
+            builder.append(instr.operation, &instr.inputs);
+        }
+        *program = builder.build();
+
+        true
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1,18 +1,19 @@
 //! Tests for IR types.
 
-use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use rand::{Rng, RngExt};
 use smite::bolt::{MAX_MESSAGE_SIZE, ShortChannelId};
 
 use super::*;
 use generators::{
-    ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
+    AnyGenerator, ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
     OpenChannelGenerator,
 };
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use mutators::{
-    InputSwapMutator, InstructionDeleteMutator, InstructionReorderMutator, OperationParamMutator,
+    GeneratorInsertionMutator, InputSwapMutator, InstructionDeleteMutator,
+    InstructionReorderMutator, OperationParamMutator,
 };
 use operation::{AcceptChannelField, ChannelTypeVariant, ShutdownScriptVariant};
 
@@ -827,6 +828,23 @@ fn accept_channel_field_all_is_complete() {
         AcceptChannelField::ALL.len(),
         variant_count(AcceptChannelField::ALL[0]),
     );
+}
+
+// Ensure AnyGenerator and AnyGenerator::ALL stay in sync. The exhaustive
+// match in this test will fail to compile if a variant is added without
+// updating it, and the assertion will fail if the match is updated
+// without updating AnyGenerator::ALL.
+#[test]
+fn any_generator_all_is_complete() {
+    let variant_count = |f: AnyGenerator| -> usize {
+        match f {
+            AnyGenerator::ChannelAnnouncement(_)
+            | AnyGenerator::ChannelUpdate(_)
+            | AnyGenerator::NodeAnnouncement(_)
+            | AnyGenerator::OpenChannel(_) => 4,
+        }
+    };
+    assert_eq!(AnyGenerator::ALL.len(), variant_count(AnyGenerator::ALL[0]));
 }
 
 // -- ShutdownScriptVariant tests --
@@ -2146,6 +2164,150 @@ fn instr_reorder_preserves_well_formedness() {
         },
     ]);
     assert_mutator_preserves_well_formedness(&InstructionReorderMutator, &original);
+}
+
+// -- GeneratorInsertionMutator tests --
+
+// A test generator that doesn't use RNG, ensuring its operations are always predictable.
+struct DummyGenerator;
+impl Generator for DummyGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, _rng: &mut impl Rng) {
+        // Emit fully static operations.
+        builder.append(Operation::LoadBlockHeight(100), &[]);
+        builder.append(Operation::LoadFeeratePerKw(253), &[]);
+        builder.append(Operation::LoadPrivateKey(key(1)), &[]);
+        builder.append(Operation::DerivePoint, &[2]);
+    }
+}
+
+fn generate_dummy_program(seed: u64) -> Program {
+    let mut builder = ProgramBuilder::new();
+    let mut rng = SmallRng::seed_from_u64(seed);
+    DummyGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+#[test]
+fn generator_insertion_does_not_drop_instructions() {
+    let mut program = generate_open_channel_program(0);
+    let original_program_len = program.instructions.len();
+    let dummy_program = generate_dummy_program(0);
+    let dummy_program_len = dummy_program.instructions.len();
+
+    // DummyGenerator emits static instructions (never calls `pick_variable`).
+    // Inserting it in a program deterministically increases instructions count.
+    let mutator = GeneratorInsertionMutator::new(DummyGenerator);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    mutator.mutate(&mut program, &mut rng);
+    assert_eq!(
+        original_program_len + dummy_program_len,
+        program.instructions.len()
+    );
+}
+
+#[test]
+fn generator_insertion_returns_generated_on_empty_program() {
+    let mut program = Program {
+        instructions: vec![],
+    };
+    let dummy_program = generate_dummy_program(0);
+    let mutator = GeneratorInsertionMutator::new(DummyGenerator);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    mutator.mutate(&mut program, &mut rng);
+    assert_eq!(
+        program, dummy_program,
+        "GeneratorInsertionMutator didn't insert generated program"
+    );
+}
+
+#[test]
+fn generator_insertion_preserves_generated() {
+    let mut program = generate_open_channel_program(0);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    let dummy_program = generate_dummy_program(0);
+    let mutator = GeneratorInsertionMutator::new(DummyGenerator);
+    mutator.mutate(&mut program, &mut rng);
+
+    let inserted_correctly = program
+        .instructions
+        .windows(dummy_program.instructions.len())
+        .any(|window| {
+            window
+                .iter()
+                .zip(dummy_program.instructions.iter())
+                .all(|(a, b)| a.operation == b.operation)
+        });
+
+    assert!(
+        inserted_correctly,
+        "Generated sequence not found intact in mutated program"
+    );
+}
+
+#[test]
+fn generator_insertion_shifts_correctly() {
+    let original = generate_open_channel_program(0);
+    let mut program = original.clone();
+
+    let mutator = GeneratorInsertionMutator::new(OpenChannelGenerator);
+    let mut rng = SmallRng::seed_from_u64(0);
+    mutator.mutate(&mut program, &mut rng);
+
+    // Find the exact insert_point chosen by the RNG.
+    let mut insert_point = original.instructions.len();
+    for i in 0..original.instructions.len() {
+        if program.instructions[i].operation != original.instructions[i].operation {
+            insert_point = i;
+            break;
+        }
+    }
+
+    // The length of the generated program.
+    let offset = program.instructions.len() - original.instructions.len();
+
+    for mut_idx in (insert_point + offset)..program.instructions.len() {
+        let orig_idx = mut_idx - offset;
+        let mut_instr = &program.instructions[mut_idx];
+        let orig_instr = &original.instructions[orig_idx];
+
+        // Ensure the operations align perfectly.
+        assert_eq!(mut_instr.operation, orig_instr.operation);
+        assert_eq!(mut_instr.inputs.len(), orig_instr.inputs.len());
+
+        for (i, (&mut_in, &orig_in)) in mut_instr
+            .inputs
+            .iter()
+            .zip(orig_instr.inputs.iter())
+            .enumerate()
+        {
+            if orig_in < insert_point {
+                // If it pointed to something BEFORE the cut, the index should not change.
+                assert_eq!(
+                    mut_in, orig_in,
+                    "Instruction {mut_idx} input {i} shifted, but it points BEFORE the insertion point",
+                );
+            } else {
+                // If it pointed to something AT or AFTER the cut, the index must shift by the offset.
+                assert_eq!(
+                    mut_in,
+                    orig_in + offset,
+                    "Instruction {mut_idx} input {i} failed to shift by exactly {offset}",
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn generator_insertion_preserves_well_formedness() {
+    let original = generate_open_channel_program(0);
+    for &generator in AnyGenerator::ALL {
+        let mutator = GeneratorInsertionMutator::new(generator);
+        assert_mutator_preserves_well_formedness(&mutator, &original);
+    }
 }
 
 // -- DeadCodeEliminator tests --

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1995,15 +1995,7 @@ fn instr_delete_redirects_affine_consumer() {
 #[test]
 fn instr_delete_maintains_validity() {
     let original = generate_open_channel_program(0);
-    let mutator = InstructionDeleteMutator;
-    let mut rng = SmallRng::seed_from_u64(0);
-
-    for _ in 0..100 {
-        let mut program = original.clone();
-        if mutator.mutate(&mut program, &mut rng) {
-            assert_well_formed(&program);
-        }
-    }
+    assert_mutator_preserves_well_formedness(&InstructionDeleteMutator, &original);
 }
 
 // -- InstructionReorderMutator tests --


### PR DESCRIPTION
Add `GeneratorInsertionMutator` for smite-IR. Mutates a given program by inserting a generated program at a random point in the said program.