### PR TITLE
smite-ir: implement BuildChannelReady operation

### DIFF
--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -83,6 +83,12 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
             true
         }
         Operation::ExtractAcceptChannel(field) => mutate_extract_field(field, rng),
+        Operation::BuildChannelReady { include_alias } => {
+            // Toggle the SCID alias TLV. Flipping always changes the value;
+            // a random bool could repeat it and waste the mutation.
+            *include_alias = !*include_alias;
+            true
+        }
         Operation::BuildNodeAnnouncement { rgb_color, alias } => {
             // Randomly mutate rgb_color or alias bytes in place; never change
             // their lengths (array types prevent it).

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -131,6 +131,24 @@ pub enum Operation {
     ///  18: `opener_per_commitment_point` (`Point`)
     ///  19: `acceptor_per_commitment_point` (`Point`)
     BuildFundingCreated,
+    /// Build a `channel_ready` message (BOLT 2, type 36).
+    ///
+    /// The alias TLV is optional in `channel_ready`. Since every `u64` is a
+    /// valid `ShortChannelId`, presence is controlled by `include_alias`
+    /// rather than a sentinel value. When `false`, the alias TLV is omitted
+    /// and input 2 is ignored. The `ShortChannelId` is used directly by
+    /// `channel_update`, so the alias type must match it in order to exercise
+    /// both valid and invalid alias SCID cases.
+    ///
+    /// Inputs (3):
+    ///   0: `channel_id` (`ChannelId`)
+    ///   1: `second_per_commitment_point` (`Point`)
+    ///   2: `short_channel_id` (`ShortChannelId`) -- the alias SCID
+    BuildChannelReady {
+        /// Whether to include the alias `short_channel_id` TLV from input 2.
+        /// If `false`, the TLV is omitted and input 2 is ignored.
+        include_alias: bool,
+    },
     /// Build a `channel_announcement` message (BOLT 7, type 256).
     ///
     /// All four `PrivateKey` inputs are used to sign the body.
@@ -657,6 +675,9 @@ impl fmt::Display for Operation {
             Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
             Self::BuildFundingCreated => write!(f, "BuildFundingCreated"),
+            Self::BuildChannelReady { include_alias } => {
+                write!(f, "BuildChannelReady{{include_alias={include_alias}}}")
+            }
             Self::BuildChannelAnnouncement => write!(f, "BuildChannelAnnouncement"),
             Self::BuildNodeAnnouncement { rgb_color, alias } => write!(
                 f,
@@ -700,7 +721,8 @@ impl Operation {
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
             Self::BuildOpenChannel => Some(VariableType::OpenChannelMessage),
             Self::BuildFundingCreated => Some(VariableType::FundingCreatedMessage),
-            Self::BuildChannelAnnouncement
+            Self::BuildChannelReady { .. }
+            | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
             | Self::BuildAnnouncementSignatures => Some(VariableType::Message),
@@ -795,6 +817,12 @@ impl Operation {
                 VariableType::Point,              // acceptor_per_commitment_point
             ],
 
+            Self::BuildChannelReady { .. } => vec![
+                VariableType::ChannelId,      // channel_id
+                VariableType::Point,          // second_per_commitment_point
+                VariableType::ShortChannelId, // short_channel_id (alias)
+            ],
+
             Self::BuildChannelAnnouncement => vec![
                 VariableType::Features,       // features
                 VariableType::ChainHash,      // chain_hash
@@ -868,6 +896,7 @@ impl Operation {
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
             | Self::BuildFundingCreated
+            | Self::BuildChannelReady { .. }
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
@@ -920,6 +949,7 @@ impl Operation {
             | Self::ExtractAcceptChannel(_)
             | Self::BuildOpenChannel
             | Self::BuildFundingCreated
+            | Self::BuildChannelReady { .. }
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
             | Self::BuildAnnouncementSignatures => false,
@@ -946,6 +976,7 @@ impl Operation {
             | Self::LoadShutdownScript(_)
             | Self::LoadChannelType(_)
             | Self::ExtractAcceptChannel(_)
+            | Self::BuildChannelReady { .. }
             | Self::BuildNodeAnnouncement { .. }
             | Self::MineBlocks(_) => true,
 

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -500,6 +500,58 @@ fn display_build_announcement_signatures_program() {
 }
 
 #[test]
+fn display_build_channel_ready_program() {
+    let scid = ShortChannelId::new(936_450, 1_346, 5);
+    let instructions = vec![
+        Instruction {
+            operation: Operation::LoadChannelId([0xcd; 32]),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::LoadPrivateKey(key(1)),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::DerivePoint,
+            inputs: vec![1],
+        },
+        Instruction {
+            operation: Operation::LoadShortChannelId(scid.as_u64()),
+            inputs: vec![],
+        },
+        Instruction {
+            operation: Operation::BuildChannelReady {
+                include_alias: true,
+            },
+            inputs: vec![0, 2, 3],
+        },
+        Instruction {
+            operation: Operation::SendMessage,
+            inputs: vec![4],
+        },
+    ];
+
+    let program = Program { instructions };
+    let text = program.to_string();
+    let lines: Vec<&str> = text.lines().collect();
+
+    let cid_hex = "cd".repeat(32);
+    let z31 = "00".repeat(31);
+    let expected: Vec<String> = vec![
+        format!("v0 = LoadChannelId(0x{cid_hex})"),
+        format!("v1 = LoadPrivateKey(0x{z31}01)"),
+        "v2 = DerivePoint(v1)".into(),
+        format!("v3 = LoadShortChannelId({scid})"),
+        "v4 = BuildChannelReady{include_alias=true}(v0, v2, v3)".into(),
+        "SendMessage(v4)".into(),
+    ];
+    assert_eq!(lines.len(), expected.len(), "line count mismatch");
+    for (i, (got, want)) in lines.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(got, want, "line {i} mismatch");
+    }
+}
+
+#[test]
 fn postcard_roundtrip() {
     let program = Program {
         instructions: vec![

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -8,9 +8,9 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::{OutPoint, ScriptBuf};
 use smite::bitcoin::{BitcoinCli, Utxo};
 use smite::bolt::{
-    AcceptChannel, AnnouncementSignatures, ChannelAnnouncement, ChannelId, ChannelUpdate,
-    FundingCreated, FundingSigned, Message, NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong,
-    ShortChannelId, msg_type,
+    AcceptChannel, AnnouncementSignatures, ChannelAnnouncement, ChannelId, ChannelReady,
+    ChannelReadyTlvs, ChannelUpdate, FundingCreated, FundingSigned, Message, NodeAnnouncement,
+    OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, msg_type,
 };
 use smite::channel_tx::{
     ChannelConfig, ChannelPartyConfig, ChannelState, FundingTransaction, HolderIdentity, Side,
@@ -274,6 +274,17 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                         build_funding_created(&variables, &instr.inputs, &mut self.channel_states)?;
                     let encoded = Message::FundingCreated(fc).encode();
                     Some(Variable::FundingCreatedMessage(encoded))
+                }
+
+                Operation::BuildChannelReady { include_alias } => {
+                    let cr = build_channel_ready(
+                        &variables,
+                        &instr.inputs,
+                        *include_alias,
+                        &mut self.channel_states,
+                    );
+                    let encoded = Message::ChannelReady(cr).encode();
+                    Some(Variable::Message(encoded))
                 }
 
                 Operation::BuildChannelAnnouncement => {
@@ -736,6 +747,39 @@ fn build_funding_created(
         funding_output_index,
         signature,
     })
+}
+
+/// Builds a `ChannelReady` from 3 input variables (wire order).
+fn build_channel_ready(
+    variables: &[Option<Variable>],
+    inputs: &[usize],
+    include_alias: bool,
+    channel_states: &mut HashMap<ChannelId, ChannelState>,
+) -> ChannelReady {
+    let channel_id = resolve_channel_id(variables, inputs[0]);
+    let second_per_commitment_point = resolve_pubkey(variables, inputs[1]);
+    let short_channel_id = include_alias.then(|| resolve_short_channel_id(variables, inputs[2]));
+
+    // Record the holder's next per-commitment point from the first locally-sent
+    // `channel_ready`'s `second_per_commitment_point`. We only do so when the
+    // channel is tracked, the commitment number is still 0, and the point is not
+    // yet recorded: `channel_ready` may be resent, but BOLT peers ignore
+    // redundant ones, so recording a resend would leave us with the wrong point
+    // and make us reject a valid received commitment signature as invalid.
+    if let Some(state) = channel_states.get_mut(&channel_id)
+        && state.commitment.commitment_number == 0
+    {
+        let next_point = state.next_holder_per_commitment_point_mut();
+        if next_point.is_none() {
+            *next_point = Some(second_per_commitment_point);
+        }
+    }
+
+    ChannelReady {
+        channel_id,
+        second_per_commitment_point,
+        tlvs: ChannelReadyTlvs { short_channel_id },
+    }
 }
 
 /// Builds a signed `ChannelAnnouncement` from 7 input variables.
@@ -2547,6 +2591,108 @@ mod tests {
             err,
             ExecuteError::InvalidCounterpartySignature(id) if id == channel_id
         ));
+    }
+
+    #[test]
+    fn execute_build_channel_ready() {
+        let channel_id = ChannelId::v1_from_funding_outpoint(OutPoint {
+            txid: "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
+                .parse()
+                .unwrap(),
+            vout: 0,
+        });
+        let alias = ShortChannelId::new(538_532, 845, 1);
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+
+        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
+        instrs.extend([
+            Instruction {
+                operation: Operation::LoadShortChannelId(alias.as_u64()),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::BuildChannelReady {
+                    include_alias: false,
+                },
+                inputs: vec![17, 1, 18],
+            },
+            Instruction {
+                operation: Operation::SendMessage,
+                inputs: vec![19],
+            },
+            Instruction {
+                operation: Operation::BuildChannelReady {
+                    include_alias: true,
+                },
+                inputs: vec![17, 3, 18],
+            },
+            Instruction {
+                operation: Operation::SendMessage,
+                inputs: vec![21],
+            },
+        ]);
+
+        let program = Program {
+            instructions: instrs,
+        };
+
+        // We also need to send this `funding_signed`, since the instructions reused
+        // by this test expect one to be present in the executor's receive queue.
+        // The expected signature here was computed using LDK as the source of
+        // truth.
+        let fs_bytes = Message::FundingSigned(FundingSigned {
+            channel_id,
+            signature: "304402203dbf3dbf337b042a72576488c1fb019086089d8d790a47f652346cff2511b6e70220395fdf700cb82b0abfcfe8e0b7c822181f2ee72409c82c3ff8e04e36593662c7".parse().unwrap(),
+        })
+        .encode();
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor.conn.queue_recv(fs_bytes);
+        executor
+            .execute(&program, std::time::Instant::now())
+            .unwrap();
+
+        // The instructions send 1 `funding_created` and 2 `channel_ready` messages.
+        assert_eq!(executor.conn.sent.len(), 3);
+
+        // The first channel_ready was built with include_alias = false, so it must
+        // not carry the short_channel_id TLV.
+        let cr1 = match Message::decode(&executor.conn.sent[1]).expect("valid message") {
+            Message::ChannelReady(cr) => cr,
+            other => panic!("expected ChannelReady, got type {}", other.msg_type()),
+        };
+        let expected_pcp1 = PublicKey::from_str(
+            "023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb",
+        )
+        .unwrap();
+        assert_eq!(cr1.channel_id, channel_id);
+        assert_eq!(cr1.second_per_commitment_point, expected_pcp1);
+        assert!(cr1.tlvs.short_channel_id.is_none());
+
+        // The second channel_ready was built with include_alias = true, so it must
+        // carry the alias SCID we loaded in its short_channel_id TLV.
+        let cr2 = match Message::decode(&executor.conn.sent[2]).expect("valid message") {
+            Message::ChannelReady(cr) => cr,
+            other => panic!("expected ChannelReady, got type {}", other.msg_type()),
+        };
+        let expected_pcp2 = PublicKey::from_str(
+            "030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c1",
+        )
+        .unwrap();
+        assert_eq!(cr2.channel_id, channel_id);
+        assert_eq!(cr2.second_per_commitment_point, expected_pcp2);
+        assert_eq!(cr2.tlvs.short_channel_id, Some(alias));
+
+        // The holder's next per-commitment point must hold the first
+        // `channel_ready`'s point, not any subsequent one.
+        let state = executor.channel_states.get_mut(&channel_id).unwrap();
+        assert_eq!(
+            *state.next_holder_per_commitment_point(),
+            Some(expected_pcp1)
+        );
     }
 
     // -- extract_field tests --

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -728,11 +728,7 @@ fn build_funding_created(
     // has already been established (and possibly advanced).
     channel_states
         .entry(channel_id)
-        .or_insert_with(|| ChannelState {
-            config,
-            holder,
-            commitment: state,
-        });
+        .or_insert_with(|| ChannelState::new(config, holder, state));
 
     Ok(FundingCreated {
         temporary_channel_id,

--- a/smite/src/bolt/channel_ready.rs
+++ b/smite/src/bolt/channel_ready.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::ChannelId;
+use super::types::{ChannelId, ShortChannelId};
 use super::wire::WireFormat;
 use bitcoin::secp256k1::PublicKey;
 
@@ -28,7 +28,7 @@ pub struct ChannelReady {
 pub struct ChannelReadyTlvs {
     /// An alias SCID for this channel, used for forwarding before confirmation
     /// and for private channels instead of the real `short_channel_id`.
-    pub short_channel_id: Option<u64>,
+    pub short_channel_id: Option<ShortChannelId>,
 }
 
 impl ChannelReady {
@@ -82,7 +82,7 @@ impl ChannelReadyTlvs {
     ///
     /// Returns a `BoltError` if the short channel ID TLV has invalid length.
     fn from_stream(stream: &TlvStream) -> Result<Self, BoltError> {
-        let short_channel_id = stream.get_as::<u64>(TLV_SHORT_CHANNEL_ID)?;
+        let short_channel_id = stream.get_as::<ShortChannelId>(TLV_SHORT_CHANNEL_ID)?;
         Ok(Self { short_channel_id })
     }
 }
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn roundtrip_with_tlvs() {
         let original = sample_channel_ready(Some(ChannelReadyTlvs {
-            short_channel_id: Some(1_029_637_663_919_046_661),
+            short_channel_id: Some(ShortChannelId::from_u64(1_029_637_663_919_046_661)),
         }));
 
         let encoded = original.encode();
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn encode_with_short_channel_id() {
         let msg = sample_channel_ready(Some(ChannelReadyTlvs {
-            short_channel_id: Some(1_029_637_663_919_046_661),
+            short_channel_id: Some(ShortChannelId::from_u64(1_029_637_663_919_046_661)),
         }));
 
         let encoded = msg.encode();
@@ -180,7 +180,7 @@ mod tests {
         let decoded = ChannelReady::decode(&encoded).unwrap();
         assert_eq!(
             decoded.tlvs.short_channel_id,
-            Some(1_029_637_663_919_046_661)
+            Some(ShortChannelId::from_u64(1_029_637_663_919_046_661))
         );
     }
 

--- a/smite/src/channel_tx/commitment.rs
+++ b/smite/src/channel_tx/commitment.rs
@@ -122,6 +122,14 @@ pub struct ChannelState {
     /// Current commitment state, updated as commitments are exchanged and
     /// revoked.
     pub commitment: CommitmentState,
+    /// Opener's next per-commitment point used to build its next commitment,
+    /// revealed by `channel_ready` and then each `revoke_and_ack`. `None` until
+    /// known.
+    pub opener_next_per_commitment_point: Option<PublicKey>,
+    /// Acceptor's next per-commitment point used to build its next commitment,
+    /// revealed by `channel_ready` and then each `revoke_and_ack`. `None` until
+    /// known.
+    pub acceptor_next_per_commitment_point: Option<PublicKey>,
 }
 
 impl Side {
@@ -139,6 +147,55 @@ impl HolderIdentity {
     #[must_use]
     fn counterparty_side(&self) -> &Side {
         self.side.other()
+    }
+}
+
+impl ChannelState {
+    /// Constructs a channel state with both next per-commitment points unknown.
+    #[must_use]
+    pub fn new(config: ChannelConfig, holder: HolderIdentity, commitment: CommitmentState) -> Self {
+        Self {
+            config,
+            holder,
+            commitment,
+            opener_next_per_commitment_point: None,
+            acceptor_next_per_commitment_point: None,
+        }
+    }
+
+    /// Returns the holder's next per-commitment point.
+    #[must_use]
+    pub fn next_holder_per_commitment_point(&self) -> &Option<PublicKey> {
+        match self.holder.side {
+            Side::Opener => &self.opener_next_per_commitment_point,
+            Side::Acceptor => &self.acceptor_next_per_commitment_point,
+        }
+    }
+
+    /// Returns a mutable reference to the holder's next per-commitment point.
+    pub fn next_holder_per_commitment_point_mut(&mut self) -> &mut Option<PublicKey> {
+        match self.holder.side {
+            Side::Opener => &mut self.opener_next_per_commitment_point,
+            Side::Acceptor => &mut self.acceptor_next_per_commitment_point,
+        }
+    }
+
+    /// Returns the counterparty's next per-commitment point.
+    #[must_use]
+    pub fn next_counterparty_per_commitment_point(&self) -> &Option<PublicKey> {
+        match self.holder.side.other() {
+            Side::Opener => &self.opener_next_per_commitment_point,
+            Side::Acceptor => &self.acceptor_next_per_commitment_point,
+        }
+    }
+
+    /// Returns a mutable reference to the counterparty's next per-commitment
+    /// point.
+    pub fn next_counterparty_per_commitment_point_mut(&mut self) -> &mut Option<PublicKey> {
+        match self.holder.side.other() {
+            Side::Opener => &mut self.opener_next_per_commitment_point,
+            Side::Acceptor => &mut self.acceptor_next_per_commitment_point,
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds:

* Optional `opener_next_per_commitment_point` and `acceptor_next_per_commitment_point` fields to `ChannelState`, initialized from `channel_ready` and updated on each `revoke_and_ack`. When a `commitment_signed` is sent or received, the stored next point is absorbed into the current commitment state and cleared. This lays the groundwork for draining messages only when no next per-commitment point is available (ref: https://github.com/morehouse/smite/issues/111#issuecomment-4702876811).
* A `BuildChannelReady` operation that constructs `channel_ready` once the funding transaction reaches the required confirmation depth. It also adds an `include_alias` flag to control alias TLV inclusion. To avoid unnecessary updates, the next per-commitment point is only recorded when the commitment number is 0 and no point is already known.