### PR TITLE
workloads: patch CLN to remove 5s delay on disconnect

### DIFF
--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -73,6 +73,33 @@ RUN git clone --depth 1 --branch ${CLN_VERSION} --recurse-submodules \
     https://github.com/ElementsProject/lightning.git /cln
 WORKDIR /cln
 RUN pip3 install --break-system-packages mako
+# Patch connectd to remove a 5s delay that occurs when disconnecting from peers.
+# This delay causes CLN to become unresponsive on the connection for 5s, which
+# kills our fuzzing speed when it occurs.
+#
+# The 5s timeout we need to remove occurs before connectd calls
+# close_subd_timeout, which is the function that force-closes the subdaemon fd
+# after an error message has been queued to the peer. In some cases the
+# subdaemon does not exit on its own (e.g., openingd will not exit if it's in
+# the middle of a funding flow), and we have to wait for the full 5s timeout
+# before close_subd_timeout is called. The only benefit of waiting is to give
+# the subdaemon time to queue any additional messages it wants to send after the
+# error message. But for our fuzzing purposes, we don't care about messages
+# after the error message -- once we receive the error we stop execution anyway.
+#
+# There's a separate 5s timeout that occurs before connectd force-closes the
+# connection socket via close_peer_io_timeout. We do *not* want to remove that
+# timeout since then the connection might get closed before we have a chance to
+# read the messages leading up to the error message. The sed command below is
+# designed to remove all of the relevant 5s timeouts while skipping the
+# close_peer_io_timeout one that we want to retain.
+#
+# If CLN changes this code significantly in the future, we will need to update
+# these commands accordingly.
+RUN sed -i '/peer->to_peer/!s/time_from_sec(5)/time_from_sec(0)/' connectd/multiplex.c && \
+    test "$(grep -c 'time_from_sec(0)' connectd/multiplex.c)" -eq 3 && \
+    test "$(grep -c 'time_from_sec(5)' connectd/multiplex.c)" -eq 1 && \
+    grep -A1 'time_from_sec(5)' connectd/multiplex.c | grep -q close_peer_io_timeout
 # AFL_UBSAN_VERBOSE=1 gives us helpful UBSan reports instead of simply SIGILL.
 ENV AFL_UBSAN_VERBOSE=1
 RUN CC=afl-clang-lto ./configure --prefix=/usr/local --disable-rust \


### PR DESCRIPTION
While testing the new `GeneratorInsertionMutator`, I discovered that CLN would "hang" whenever a program was executed that attempted to open two channels simultaneously on the same connection.  It turns out that CLN doesn't support multiple in-flight channel opens and will send an error message and close the connection if a peer attempts to do this. But before disconnection, CLN waits up to 5s for the subdaemon to finish sending any final messages and shut down gracefully. Because openingd refuses to shut down when it's in the middle of a funding flow, we would have to wait the full 5s, which would register as a hang.

The workaround is to remove CLN's wait entirely, since we don't actually care about any messages after the error message.

For reference, the 5s timeout locations patched by this change are here:

https://github.com/ElementsProject/lightning/blob/daa3b06b95deb3aac717bca501e0c19aba9c3858/connectd/multiplex.c#L130-L132

https://github.com/ElementsProject/lightning/blob/daa3b06b95deb3aac717bca501e0c19aba9c3858/connectd/multiplex.c#L1340-L1342

https://github.com/ElementsProject/lightning/blob/daa3b06b95deb3aac717bca501e0c19aba9c3858/connectd/multiplex.c#L1417-L1419

The one location we specifically avoid patching is here:

https://github.com/ElementsProject/lightning/blob/daa3b06b95deb3aac717bca501e0c19aba9c3858/connectd/multiplex.c#L112-L114