### PR TITLE
smite: add NyxLogger for debugging in Nyx mode

### DIFF
--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -19,6 +19,8 @@ pub mod bitcoin;
 pub mod bolt;
 pub mod channel_tx;
 pub mod noise;
+#[cfg(feature = "nyx")]
+pub mod nyx_log;
 pub mod oracles;
 pub mod process;
 pub mod runners;

--- a/smite/src/nyx_log.rs
+++ b/smite/src/nyx_log.rs
@@ -1,0 +1,60 @@
+//! Logger that forwards `log` records to the Nyx host via `nyx_println`.
+//!
+//! In Nyx mode the guest's stdout/stderr is discarded, so `simple_logger`
+//! output never reaches the host. This logger instead routes each record
+//! through `nyx_println` for debugging. Honors the `RUST_LOG` log level.
+//!
+//! This logger is only installed when the `nyx` feature is active and both
+//! `SMITE_NYX` and `SMITE_NYX_LOG` are set.
+
+use std::ffi::c_char;
+
+use log::{LevelFilter, Log, Metadata, Record};
+
+struct NyxLogger {
+    level: LevelFilter,
+}
+
+impl Log for NyxLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let line = format!(
+            "{:<5} [{}] {}",
+            record.level(),
+            record.target(),
+            record.args()
+        );
+        // SAFETY: The line.len() bytes at the line pointer are valid for the
+        // duration of the call.
+        unsafe {
+            smite_nyx_sys::nyx_println(line.as_ptr().cast::<c_char>(), line.len());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Reads the desired level from `RUST_LOG` (default `info`).
+fn level_from_env() -> LevelFilter {
+    std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(LevelFilter::Info)
+}
+
+/// Installs the Nyx logger as the global `log` logger.
+///
+/// # Panics
+///
+/// Panics if a global logger has already been set.
+pub fn init() {
+    let level = level_from_env();
+    log::set_boxed_logger(Box::new(NyxLogger { level })).expect("logger not already set");
+    log::set_max_level(level);
+}

--- a/smite/src/scenarios.rs
+++ b/smite/src/scenarios.rs
@@ -84,6 +84,19 @@ pub trait Scenario: Sized {
     fn run(&mut self, input: &[u8]) -> ScenarioResult;
 }
 
+/// Installs the global `log` logger.
+///
+/// Defaults to `simple_logger`. When the `nyx` feature is enabled and both
+/// `SMITE_NYX` and `SMITE_NYX_LOG` are set, `nyx_log` is installed instead.
+fn init_logging() {
+    #[cfg(feature = "nyx")]
+    if std::env::var("SMITE_NYX").is_ok() && std::env::var("SMITE_NYX_LOG").is_ok() {
+        crate::nyx_log::init();
+        return;
+    }
+    simple_logger::init_with_env().expect("logger not already set");
+}
+
 /// Run a scenario with the standard runner.
 ///
 /// This is the main entry point for smite scenario binaries. It initializes
@@ -98,7 +111,7 @@ pub fn smite_run<S: Scenario>() -> std::process::ExitCode {
 
     use crate::runners::{Runner, StdRunner};
 
-    simple_logger::init_with_env().expect("Failed to initialize logger");
+    init_logging();
 
     // Install a panic hook so that panics in the scenario itself (e.g., failed
     // expect() calls) are reported as crashes rather than silent timeouts.


### PR DESCRIPTION
Enables scenario output to be printed in Nyx mode when `SMITE_NYX_LOG` is enabled.

This was helpful for debugging a timing difference when running in Nyx vs Docker.