### PR TITLE
multi: record channel negotiation state and fold build/send operations

### DIFF
--- a/smite-ir/src/builder.rs
+++ b/smite-ir/src/builder.rs
@@ -219,9 +219,6 @@ impl ProgramBuilder {
             VariableType::OpenChannelMessage => {
                 panic!("cannot generate fresh OpenChannelMessage: requires composed inputs")
             }
-            VariableType::FundingCreatedMessage => {
-                panic!("cannot generate fresh FundingCreatedMessage: requires composed inputs")
-            }
             VariableType::AcceptChannel => {
                 panic!("cannot generate fresh AcceptChannel: requires protocol interaction")
             }

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -83,12 +83,6 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
             true
         }
         Operation::ExtractAcceptChannel(field) => mutate_extract_field(field, rng),
-        Operation::BuildChannelReady { include_alias } => {
-            // Toggle the SCID alias TLV. Flipping always changes the value;
-            // a random bool could repeat it and waste the mutation.
-            *include_alias = !*include_alias;
-            true
-        }
         Operation::BuildNodeAnnouncement { rgb_color, alias } => {
             // Randomly mutate rgb_color or alias bytes in place; never change
             // their lengths (array types prevent it).
@@ -97,6 +91,12 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
             } else {
                 mutate_fixed_bytes(alias, rng);
             }
+            true
+        }
+        Operation::SendChannelReady { include_alias } => {
+            // Toggle the SCID alias TLV. Flipping always changes the value;
+            // a random bool could repeat it and waste the mutation.
+            *include_alias = !*include_alias;
             true
         }
 

--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -107,7 +107,6 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::LoadTargetPubkeyFromContext
         | Operation::LoadChainHashFromContext
         | Operation::BuildOpenChannel
-        | Operation::BuildFundingCreated
         | Operation::BuildChannelAnnouncement
         | Operation::BuildChannelUpdate
         | Operation::BuildAnnouncementSignatures

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -107,24 +107,6 @@ pub enum Operation {
     ///  18: `upfront_shutdown_script` (`Bytes`, empty = omit TLV)
     ///  19: `channel_type` (`Features`, empty = omit TLV)
     BuildOpenChannel,
-    /// Build a `channel_ready` message (BOLT 2, type 36).
-    ///
-    /// The alias TLV is optional in `channel_ready`. Since every `u64` is a
-    /// valid `ShortChannelId`, presence is controlled by `include_alias`
-    /// rather than a sentinel value. When `false`, the alias TLV is omitted
-    /// and input 2 is ignored. The `ShortChannelId` is used directly by
-    /// `channel_update`, so the alias type must match it in order to exercise
-    /// both valid and invalid alias SCID cases.
-    ///
-    /// Inputs (3):
-    ///   0: `channel_id` (`ChannelId`)
-    ///   1: `second_per_commitment_point` (`Point`)
-    ///   2: `short_channel_id` (`ShortChannelId`) -- the alias SCID
-    BuildChannelReady {
-        /// Whether to include the alias `short_channel_id` TLV from input 2.
-        /// If `false`, the TLV is omitted and input 2 is ignored.
-        include_alias: bool,
-    },
     /// Build a `channel_announcement` message (BOLT 7, type 256).
     ///
     /// All four `PrivateKey` inputs are used to sign the body.
@@ -207,6 +189,24 @@ pub enum Operation {
     ///   1: `opener_funding_privkey` (`PrivateKey`)
     ///   2: `temporary_channel_id` (`ChannelId`)
     SendFundingCreated,
+    /// Build and send a `channel_ready` message (BOLT 2, type 36).
+    ///
+    /// The alias TLV is optional in `channel_ready`. Since every `u64` is a
+    /// valid `ShortChannelId`, presence is controlled by `include_alias`
+    /// rather than a sentinel value. When `false`, the alias TLV is omitted
+    /// and input 2 is ignored. The `ShortChannelId` is used directly by
+    /// `channel_update`, so the alias type must match it in order to exercise
+    /// both valid and invalid alias SCID cases.
+    ///
+    /// Inputs (3):
+    ///   0: `channel_id` (`ChannelId`)
+    ///   1: `second_per_commitment_point` (`Point`)
+    ///   2: `short_channel_id` (`ShortChannelId`) -- the alias SCID
+    SendChannelReady {
+        /// Whether to include the alias `short_channel_id` TLV from input 2.
+        /// If `false`, the TLV is omitted and input 2 is ignored.
+        include_alias: bool,
+    },
     /// Receive and parse an `accept_channel` response.
     /// Produces an `AcceptChannel` compound variable.
     RecvAcceptChannel,
@@ -661,9 +661,6 @@ impl fmt::Display for Operation {
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
             Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
-            Self::BuildChannelReady { include_alias } => {
-                write!(f, "BuildChannelReady{{include_alias={include_alias}}}")
-            }
             Self::BuildChannelAnnouncement => write!(f, "BuildChannelAnnouncement"),
             Self::BuildNodeAnnouncement { rgb_color, alias } => write!(
                 f,
@@ -676,6 +673,9 @@ impl fmt::Display for Operation {
             Self::SendMessage => write!(f, "SendMessage"),
             Self::SendOpenChannel => write!(f, "SendOpenChannel"),
             Self::SendFundingCreated => write!(f, "SendFundingCreated"),
+            Self::SendChannelReady { include_alias } => {
+                write!(f, "SendChannelReady{{include_alias={include_alias}}}")
+            }
             Self::RecvAcceptChannel => write!(f, "RecvAcceptChannel"),
             Self::RecvFundingSigned => write!(f, "RecvFundingSigned"),
             Self::RecvChannelReady => write!(f, "RecvChannelReady()"),
@@ -707,12 +707,12 @@ impl Operation {
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
             Self::BuildOpenChannel => Some(VariableType::OpenChannelMessage),
-            Self::BuildChannelReady { .. }
-            | Self::BuildChannelAnnouncement
+            Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
             | Self::BuildAnnouncementSignatures => Some(VariableType::Message),
             Self::SendMessage
+            | Self::SendChannelReady { .. }
             | Self::RecvChannelReady
             | Self::MineBlocks(_)
             | Self::BroadcastTransaction => None,
@@ -761,6 +761,11 @@ impl Operation {
                 VariableType::PrivateKey,         // opener_funding_privkey
                 VariableType::ChannelId,          // temporary_channel_id
             ],
+            Self::SendChannelReady { .. } => vec![
+                VariableType::ChannelId,      // channel_id
+                VariableType::Point,          // second_per_commitment_point
+                VariableType::ShortChannelId, // short_channel_id (alias)
+            ],
             Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
             Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
             Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
@@ -786,12 +791,6 @@ impl Operation {
                 VariableType::U8,           // channel_flags
                 VariableType::Bytes,        // upfront_shutdown_script
                 VariableType::Features,     // channel_type
-            ],
-
-            Self::BuildChannelReady { .. } => vec![
-                VariableType::ChannelId,      // channel_id
-                VariableType::Point,          // second_per_commitment_point
-                VariableType::ShortChannelId, // short_channel_id (alias)
             ],
 
             Self::BuildChannelAnnouncement => vec![
@@ -866,7 +865,6 @@ impl Operation {
             | Self::ExtractAcceptChannel(_)
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
-            | Self::BuildChannelReady { .. }
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
@@ -874,6 +872,7 @@ impl Operation {
             | Self::SendMessage
             | Self::SendOpenChannel
             | Self::SendFundingCreated
+            | Self::SendChannelReady { .. }
             | Self::RecvFundingSigned
             | Self::RecvChannelReady
             | Self::MineBlocks(_)
@@ -894,6 +893,7 @@ impl Operation {
             Self::SendMessage
             | Self::SendOpenChannel
             | Self::SendFundingCreated
+            | Self::SendChannelReady { .. }
             | Self::RecvAcceptChannel
             | Self::RecvFundingSigned
             | Self::RecvChannelReady
@@ -920,7 +920,6 @@ impl Operation {
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
             | Self::BuildOpenChannel
-            | Self::BuildChannelReady { .. }
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
             | Self::BuildAnnouncementSignatures => false,
@@ -947,8 +946,8 @@ impl Operation {
             | Self::LoadShutdownScript(_)
             | Self::LoadChannelType(_)
             | Self::ExtractAcceptChannel(_)
-            | Self::BuildChannelReady { .. }
             | Self::BuildNodeAnnouncement { .. }
+            | Self::SendChannelReady { .. }
             | Self::MineBlocks(_) => true,
 
             Self::LoadTargetPubkeyFromContext

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -107,13 +107,6 @@ pub enum Operation {
     ///  18: `upfront_shutdown_script` (`Bytes`, empty = omit TLV)
     ///  19: `channel_type` (`Features`, empty = omit TLV)
     BuildOpenChannel,
-    /// Build a `funding_created` message (BOLT 2, type 34).
-    ///
-    /// Inputs (3):
-    ///   0: `funding_transaction` (`FundingTransaction`)
-    ///   1: `opener_funding_privkey` (`PrivateKey`)
-    ///   2: `temporary_channel_id` (`ChannelId`)
-    BuildFundingCreated,
     /// Build a `channel_ready` message (BOLT 2, type 36).
     ///
     /// The alias TLV is optional in `channel_ready`. Since every `u64` is a
@@ -206,9 +199,13 @@ pub enum Operation {
     /// Produces a `SentOpenChannel` variable.
     /// Input: `OpenChannelMessage`.
     SendOpenChannel,
-    /// Send a `funding_created` message over the connection.
+    /// Build and send a `funding_created` message (BOLT 2, type 34).
     /// Produces a `SentFundingCreated` variable.
-    /// Input: `FundingCreatedMessage`.
+    ///
+    /// Inputs (3):
+    ///   0: `funding_transaction` (`FundingTransaction`)
+    ///   1: `opener_funding_privkey` (`PrivateKey`)
+    ///   2: `temporary_channel_id` (`ChannelId`)
     SendFundingCreated,
     /// Receive and parse an `accept_channel` response.
     /// Produces an `AcceptChannel` compound variable.
@@ -664,7 +661,6 @@ impl fmt::Display for Operation {
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
             Self::CreateFundingTransaction => write!(f, "CreateFundingTransaction"),
             Self::BuildOpenChannel => write!(f, "BuildOpenChannel"),
-            Self::BuildFundingCreated => write!(f, "BuildFundingCreated"),
             Self::BuildChannelReady { include_alias } => {
                 write!(f, "BuildChannelReady{{include_alias={include_alias}}}")
             }
@@ -711,7 +707,6 @@ impl Operation {
             Self::ExtractAcceptChannel(field) => Some(field.output_type()),
             Self::CreateFundingTransaction => Some(VariableType::FundingTransaction),
             Self::BuildOpenChannel => Some(VariableType::OpenChannelMessage),
-            Self::BuildFundingCreated => Some(VariableType::FundingCreatedMessage),
             Self::BuildChannelReady { .. }
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
@@ -761,7 +756,11 @@ impl Operation {
             ],
             Self::SendMessage => vec![VariableType::Message],
             Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
-            Self::SendFundingCreated => vec![VariableType::FundingCreatedMessage],
+            Self::SendFundingCreated => vec![
+                VariableType::FundingTransaction, // funding_transaction
+                VariableType::PrivateKey,         // opener_funding_privkey
+                VariableType::ChannelId,          // temporary_channel_id
+            ],
             Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
             Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
             Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
@@ -787,12 +786,6 @@ impl Operation {
                 VariableType::U8,           // channel_flags
                 VariableType::Bytes,        // upfront_shutdown_script
                 VariableType::Features,     // channel_type
-            ],
-
-            Self::BuildFundingCreated => vec![
-                VariableType::FundingTransaction, // funding_transaction
-                VariableType::PrivateKey,         // opener_funding_privkey
-                VariableType::ChannelId,          // temporary_channel_id
             ],
 
             Self::BuildChannelReady { .. } => vec![
@@ -873,7 +866,6 @@ impl Operation {
             | Self::ExtractAcceptChannel(_)
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
-            | Self::BuildFundingCreated
             | Self::BuildChannelReady { .. }
             | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
@@ -928,7 +920,6 @@ impl Operation {
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
             | Self::BuildOpenChannel
-            | Self::BuildFundingCreated
             | Self::BuildChannelReady { .. }
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
@@ -965,7 +956,6 @@ impl Operation {
             | Self::DerivePoint
             | Self::CreateFundingTransaction
             | Self::BuildOpenChannel
-            | Self::BuildFundingCreated
             | Self::BuildChannelAnnouncement
             | Self::BuildChannelUpdate
             | Self::BuildAnnouncementSignatures

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -109,27 +109,10 @@ pub enum Operation {
     BuildOpenChannel,
     /// Build a `funding_created` message (BOLT 2, type 34).
     ///
-    /// Inputs (20):
+    /// Inputs (3):
     ///   0: `funding_transaction` (`FundingTransaction`)
-    ///   1: `funding_satoshis` (`Amount`)
-    ///   2: `channel_type` (`Features`)
-    ///   3: `opener_funding_privkey` (`PrivateKey`)
-    ///   4: `opener_payment_basepoint` (`Point`)
-    ///   5: `opener_revocation_basepoint` (`Point`)
-    ///   6: `opener_delayed_payment_basepoint` (`Point`)
-    ///   7: `opener_dust_limit_satoshis` (`Amount`)
-    ///   8: `opener_to_self_delay` (`U16`)
-    ///   9: `acceptor_funding_pubkey` (`Point`)
-    ///  10: `acceptor_payment_basepoint` (`Point`)
-    ///  11: `acceptor_revocation_basepoint` (`Point`)
-    ///  12: `acceptor_delayed_payment_basepoint` (`Point`)
-    ///  13: `acceptor_dust_limit_satoshis` (`Amount`)
-    ///  14: `acceptor_to_self_delay` (`U16`)
-    ///  15: `temporary_channel_id` (`ChannelId`)
-    ///  16: `push_msat` (`Amount`)
-    ///  17: `feerate_per_kw` (`FeeratePerKw`)
-    ///  18: `opener_per_commitment_point` (`Point`)
-    ///  19: `acceptor_per_commitment_point` (`Point`)
+    ///   1: `opener_funding_privkey` (`PrivateKey`)
+    ///   2: `temporary_channel_id` (`ChannelId`)
     BuildFundingCreated,
     /// Build a `channel_ready` message (BOLT 2, type 36).
     ///
@@ -808,25 +791,8 @@ impl Operation {
 
             Self::BuildFundingCreated => vec![
                 VariableType::FundingTransaction, // funding_transaction
-                VariableType::Amount,             // funding_satoshis
-                VariableType::Features,           // channel_type
                 VariableType::PrivateKey,         // opener_funding_privkey
-                VariableType::Point,              // opener_payment_basepoint
-                VariableType::Point,              // opener_revocation_basepoint
-                VariableType::Point,              // opener_delayed_payment_basepoint
-                VariableType::Amount,             // opener_dust_limit_satoshis
-                VariableType::U16,                // opener_to_self_delay
-                VariableType::Point,              // acceptor_funding_pubkey
-                VariableType::Point,              // acceptor_payment_basepoint
-                VariableType::Point,              // acceptor_revocation_basepoint
-                VariableType::Point,              // acceptor_delayed_payment_basepoint
-                VariableType::Amount,             // acceptor_dust_limit_satoshis
-                VariableType::U16,                // acceptor_to_self_delay
                 VariableType::ChannelId,          // temporary_channel_id
-                VariableType::Amount,             // push_msat
-                VariableType::FeeratePerKw,       // feerate_per_kw
-                VariableType::Point,              // opener_per_commitment_point
-                VariableType::Point,              // acceptor_per_commitment_point
             ],
 
             Self::BuildChannelReady { .. } => vec![

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -501,7 +501,7 @@ fn display_build_announcement_signatures_program() {
 }
 
 #[test]
-fn display_build_and_recv_channel_ready_program() {
+fn display_send_and_recv_channel_ready_program() {
     let scid = ShortChannelId::new(936_450, 1_346, 5);
     let instructions = vec![
         Instruction {
@@ -521,14 +521,10 @@ fn display_build_and_recv_channel_ready_program() {
             inputs: vec![],
         },
         Instruction {
-            operation: Operation::BuildChannelReady {
+            operation: Operation::SendChannelReady {
                 include_alias: true,
             },
             inputs: vec![0, 2, 3],
-        },
-        Instruction {
-            operation: Operation::SendMessage,
-            inputs: vec![4],
         },
         Instruction {
             operation: Operation::RecvChannelReady,
@@ -547,8 +543,7 @@ fn display_build_and_recv_channel_ready_program() {
         format!("v1 = LoadPrivateKey(0x{z31}01)"),
         "v2 = DerivePoint(v1)".into(),
         format!("v3 = LoadShortChannelId({scid})"),
-        "v4 = BuildChannelReady{include_alias=true}(v0, v2, v3)".into(),
-        "SendMessage(v4)".into(),
+        "SendChannelReady{include_alias=true}(v0, v2, v3)".into(),
         "RecvChannelReady()".into(),
     ];
     assert_eq!(lines.len(), expected.len(), "line count mismatch");

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -621,9 +621,7 @@ fn postcard_roundtrip() {
             },
             Instruction {
                 operation: Operation::BuildFundingCreated,
-                inputs: vec![
-                    11, 5, 6, 0, 1, 1, 1, 5, 13, 9, 9, 9, 9, 5, 13, 3, 5, 10, 1, 9,
-                ],
+                inputs: vec![11, 0, 3],
             },
         ],
     };
@@ -737,7 +735,6 @@ fn displays_create_and_broadcast_tx_program() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
 fn displays_send_funding_created_recv_funding_signed_program() {
     let instructions = vec![
         // Funding transaction.
@@ -763,61 +760,23 @@ fn displays_send_funding_created_recv_funding_signed_program() {
         },
         // funding_created parameters.
         Instruction {
-            operation: Operation::LoadFeatures(vec![0x01, 0x02]),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::LoadPrivateKey(key(2)),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::DerivePoint,
-            inputs: vec![6],
-        },
-        Instruction {
-            operation: Operation::LoadAmount(546),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::LoadU16(144),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::LoadPrivateKey(key(3)),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::DerivePoint,
-            inputs: vec![10],
-        },
-        Instruction {
             operation: Operation::LoadChannelId([0xbb; 32]),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::LoadAmount(0),
-            inputs: vec![],
-        },
-        Instruction {
-            operation: Operation::LoadFeeratePerKw(253),
             inputs: vec![],
         },
         // Build funding_created.
         Instruction {
             operation: Operation::BuildFundingCreated,
-            inputs: vec![
-                4, 2, 5, 0, 7, 7, 7, 8, 9, 11, 11, 11, 11, 8, 9, 12, 13, 14, 7, 11,
-            ],
+            inputs: vec![4, 0, 5],
         },
         // Send funding_created.
         Instruction {
             operation: Operation::SendFundingCreated,
-            inputs: vec![15],
+            inputs: vec![6],
         },
         // receive funding_signed.
         Instruction {
             operation: Operation::RecvFundingSigned,
-            inputs: vec![16],
+            inputs: vec![7],
         },
     ];
 
@@ -834,19 +793,10 @@ fn displays_send_funding_created_recv_funding_signed_program() {
         "v2 = LoadAmount(10000000)".into(),
         "v3 = LoadFeeratePerKw(15000)".into(),
         "v4 = CreateFundingTransaction(v1, v1, v2, v3)".into(),
-        "v5 = LoadFeatures(0x0102)".into(),
-        format!("v6 = LoadPrivateKey(0x{z31}02)"),
-        "v7 = DerivePoint(v6)".into(),
-        "v8 = LoadAmount(546)".into(),
-        "v9 = LoadU16(144)".into(),
-        format!("v10 = LoadPrivateKey(0x{z31}03)"),
-        "v11 = DerivePoint(v10)".into(),
-        format!("v12 = LoadChannelId(0x{b32})"),
-        "v13 = LoadAmount(0)".into(),
-        "v14 = LoadFeeratePerKw(253)".into(),
-        "v15 = BuildFundingCreated(v4, v2, v5, v0, v7, v7, v7, v8, v9, v11, v11, v11, v11, v8, v9, v12, v13, v14, v7, v11)".into(),
-        "v16 = SendFundingCreated(v15)".into(),
-        "v17 = RecvFundingSigned(v16)".into(),
+        format!("v5 = LoadChannelId(0x{b32})"),
+        "v6 = BuildFundingCreated(v4, v0, v5)".into(),
+        "v7 = SendFundingCreated(v6)".into(),
+        "v8 = RecvFundingSigned(v7)".into(),
     ];
 
     assert_eq!(lines.len(), expected.len(), "line count mismatch");

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -620,7 +620,7 @@ fn postcard_roundtrip() {
                 inputs: vec![],
             },
             Instruction {
-                operation: Operation::BuildFundingCreated,
+                operation: Operation::SendFundingCreated,
                 inputs: vec![11, 0, 3],
             },
         ],
@@ -763,20 +763,15 @@ fn displays_send_funding_created_recv_funding_signed_program() {
             operation: Operation::LoadChannelId([0xbb; 32]),
             inputs: vec![],
         },
-        // Build funding_created.
-        Instruction {
-            operation: Operation::BuildFundingCreated,
-            inputs: vec![4, 0, 5],
-        },
-        // Send funding_created.
+        // Build and send funding_created.
         Instruction {
             operation: Operation::SendFundingCreated,
-            inputs: vec![6],
+            inputs: vec![4, 0, 5],
         },
         // receive funding_signed.
         Instruction {
             operation: Operation::RecvFundingSigned,
-            inputs: vec![7],
+            inputs: vec![6],
         },
     ];
 
@@ -794,9 +789,8 @@ fn displays_send_funding_created_recv_funding_signed_program() {
         "v3 = LoadFeeratePerKw(15000)".into(),
         "v4 = CreateFundingTransaction(v1, v1, v2, v3)".into(),
         format!("v5 = LoadChannelId(0x{b32})"),
-        "v6 = BuildFundingCreated(v4, v0, v5)".into(),
-        "v7 = SendFundingCreated(v6)".into(),
-        "v8 = RecvFundingSigned(v7)".into(),
+        "v6 = SendFundingCreated(v4, v0, v5)".into(),
+        "v7 = RecvFundingSigned(v6)".into(),
     ];
 
     assert_eq!(lines.len(), expected.len(), "line count mismatch");

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -4,7 +4,7 @@
 //! The serialized program stores data only in [`Operation`] literals.
 
 use bitcoin::secp256k1::PublicKey;
-use smite::bolt::{AcceptChannel, ChannelId, ShortChannelId};
+use smite::bolt::{AcceptChannel, ChannelId, OpenChannel, ShortChannelId};
 use smite::channel_tx::FundingTransaction;
 
 const CHAIN_HASH_SIZE: usize = 32;
@@ -46,8 +46,8 @@ pub enum Variable {
     Features(Vec<u8>),
     /// Encoded BOLT message with type prefix, ready to send.
     Message(Vec<u8>),
-    /// Encoded BOLT `open_channel` message with type 32 prefix, ready to send.
-    OpenChannelMessage(Vec<u8>),
+    /// BOLT `open_channel` message, ready to send.
+    OpenChannelMessage(OpenChannel),
     /// Encoded BOLT `funding_created` message with type 34 prefix, ready to send.
     FundingCreatedMessage(Vec<u8>),
     /// Parsed `accept_channel` response.

--- a/smite-ir/src/variable.rs
+++ b/smite-ir/src/variable.rs
@@ -48,8 +48,6 @@ pub enum Variable {
     Message(Vec<u8>),
     /// BOLT `open_channel` message, ready to send.
     OpenChannelMessage(OpenChannel),
-    /// Encoded BOLT `funding_created` message with type 34 prefix, ready to send.
-    FundingCreatedMessage(Vec<u8>),
     /// Parsed `accept_channel` response.
     AcceptChannel(AcceptChannel),
     /// Constructed funding transaction with funding output index.
@@ -83,7 +81,6 @@ impl Variable {
             Self::Features(_) => VariableType::Features,
             Self::Message(_) => VariableType::Message,
             Self::OpenChannelMessage(_) => VariableType::OpenChannelMessage,
-            Self::FundingCreatedMessage(_) => VariableType::FundingCreatedMessage,
             Self::AcceptChannel(_) => VariableType::AcceptChannel,
             Self::FundingTransaction(_) => VariableType::FundingTransaction,
             Self::SentOpenChannel => VariableType::SentOpenChannel,
@@ -112,7 +109,6 @@ pub enum VariableType {
     Features,
     Message,
     OpenChannelMessage,
-    FundingCreatedMessage,
     AcceptChannel,
     FundingTransaction,
     SentOpenChannel,
@@ -140,7 +136,6 @@ impl VariableType {
             | Self::Features
             | Self::Message
             | Self::OpenChannelMessage
-            | Self::FundingCreatedMessage
             | Self::AcceptChannel
             | Self::ShortChannelId
             | Self::FundingTransaction => false,

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -299,17 +299,6 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     Some(Variable::OpenChannelMessage(oc))
                 }
 
-                Operation::BuildChannelReady { include_alias } => {
-                    let cr = build_channel_ready(
-                        &variables,
-                        &instr.inputs,
-                        *include_alias,
-                        &mut self.channel_states,
-                    );
-                    let encoded = Message::ChannelReady(cr).encode();
-                    Some(Variable::Message(encoded))
-                }
-
                 Operation::BuildChannelAnnouncement => {
                     let ca = build_channel_announcement(&variables, &instr.inputs);
                     let encoded = Message::ChannelAnnouncement(ca).encode();
@@ -375,6 +364,23 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     );
                     self.conn.send_message(&encoded)?;
                     Some(Variable::SentFundingCreated)
+                }
+
+                Operation::SendChannelReady { include_alias } => {
+                    let cr = build_channel_ready(
+                        &variables,
+                        &instr.inputs,
+                        *include_alias,
+                        &mut self.channel_states,
+                    );
+                    let encoded = Message::ChannelReady(cr).encode();
+                    log::debug!(
+                        "[{:?}] SendChannelReady: {} bytes",
+                        start.elapsed(),
+                        encoded.len(),
+                    );
+                    self.conn.send_message(&encoded)?;
+                    None
                 }
 
                 Operation::RecvAcceptChannel => {
@@ -3106,7 +3112,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_build_channel_ready() {
+    fn execute_send_channel_ready() {
         let channel_id = ChannelId::v1_from_funding_outpoint(OutPoint {
             txid: "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
                 .parse()
@@ -3127,24 +3133,16 @@ mod tests {
                 inputs: vec![],
             },
             Instruction {
-                operation: Operation::BuildChannelReady {
+                operation: Operation::SendChannelReady {
                     include_alias: false,
                 },
                 inputs: vec![10, 1, 11],
             },
             Instruction {
-                operation: Operation::SendMessage,
-                inputs: vec![12],
-            },
-            Instruction {
-                operation: Operation::BuildChannelReady {
+                operation: Operation::SendChannelReady {
                     include_alias: true,
                 },
                 inputs: vec![10, 3, 11],
-            },
-            Instruction {
-                operation: Operation::SendMessage,
-                inputs: vec![14],
             },
         ]);
 
@@ -3173,7 +3171,7 @@ mod tests {
         // The instructions send 1 `funding_created` and 2 `channel_ready` messages.
         assert_eq!(executor.conn.sent.len(), 3);
 
-        // The first channel_ready was built with include_alias = false, so it must
+        // The first channel_ready was sent with include_alias = false, so it must
         // not carry the short_channel_id TLV.
         let cr1 = match Message::decode(&executor.conn.sent[1]).expect("valid message") {
             Message::ChannelReady(cr) => cr,
@@ -3187,7 +3185,7 @@ mod tests {
         assert_eq!(cr1.second_per_commitment_point, expected_pcp1);
         assert!(cr1.tlvs.short_channel_id.is_none());
 
-        // The second channel_ready was built with include_alias = true, so it must
+        // The second channel_ready was sent with include_alias = true, so it must
         // carry the alias SCID we loaded in its short_channel_id TLV.
         let cr2 = match Message::decode(&executor.conn.sent[2]).expect("valid message") {
             Message::ChannelReady(cr) => cr,

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -300,8 +300,12 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 }
 
                 Operation::BuildFundingCreated => {
-                    let fc =
-                        build_funding_created(&variables, &instr.inputs, &mut self.channel_states)?;
+                    let fc = build_funding_created(
+                        &variables,
+                        &instr.inputs,
+                        &mut self.channel_states,
+                        &mut self.negotiations,
+                    )?;
                     let encoded = Message::FundingCreated(fc).encode();
                     Some(Variable::FundingCreatedMessage(encoded))
                 }
@@ -711,21 +715,54 @@ fn build_open_channel(variables: &[Option<Variable>], inputs: &[usize]) -> OpenC
     }
 }
 
-/// Builds a `funding_created` message from 20 input variables.
+/// Builds a `funding_created` message from 3 input variables.
+///
+/// Channel parameters are read from the negotiated `open_channel` and
+/// `accept_channel` messages recorded in `negotiations`, ensuring the
+/// commitment is built from the negotiated values.
+///
+/// If the negotiation for `temporary_channel_id` is incomplete, emits a
+/// `funding_created` with the derived outpoint and an all-zero signature.
 fn build_funding_created(
     variables: &[Option<Variable>],
     inputs: &[usize],
     channel_states: &mut HashMap<ChannelId, ChannelState>,
+    negotiations: &mut HashMap<ChannelId, PendingChannel>,
 ) -> Result<FundingCreated, ExecuteError> {
     let funding_tx = resolve_funding_transaction(variables, inputs[0]);
+    let opener_funding_privkey_bytes = resolve_private_key(variables, inputs[1]);
+    let temporary_channel_id = resolve_channel_id(variables, inputs[2]);
+
     let funding_outpoint = OutPoint {
         txid: funding_tx.tx.compute_txid(),
         vout: funding_tx.vout,
     };
+    let funding_output_index = u16::try_from(funding_outpoint.vout)
+        .expect("funding output index of a funding tx must fit in u16");
 
-    let funding_satoshis = resolve_amount(variables, inputs[1]);
-    let channel_type = resolve_features(variables, inputs[2]).to_vec();
-    let opener_funding_privkey_bytes = resolve_private_key(variables, inputs[3]);
+    // Without both the recorded `open_channel` and the peer's `accept_channel`
+    // we cannot build the commitment to sign, so fall back to an unsigned
+    // `funding_created` and leave `channel_states` untouched.
+    let Some(pending) = negotiations.get(&temporary_channel_id) else {
+        return Ok(FundingCreated {
+            temporary_channel_id,
+            funding_txid: funding_outpoint.txid,
+            funding_output_index,
+            signature: Signature::from_compact(&[0u8; 64])
+                .expect("zero bytes parse as a signature"),
+        });
+    };
+    let open_channel = &pending.open_channel;
+    let Some(accept_channel) = pending.accept_channel.as_ref() else {
+        return Ok(FundingCreated {
+            temporary_channel_id,
+            funding_txid: funding_outpoint.txid,
+            funding_output_index,
+            signature: Signature::from_compact(&[0u8; 64])
+                .expect("zero bytes parse as a signature"),
+        });
+    };
+
     let opener_funding_privkey =
         SecretKey::from_slice(&opener_funding_privkey_bytes).expect("valid private key");
     let secp = Secp256k1::new();
@@ -733,39 +770,33 @@ fn build_funding_created(
 
     let opener = ChannelPartyConfig {
         funding_pubkey: opener_funding_pubkey,
-        payment_basepoint: resolve_pubkey(variables, inputs[4]),
-        revocation_basepoint: resolve_pubkey(variables, inputs[5]),
-        delayed_payment_basepoint: resolve_pubkey(variables, inputs[6]),
-        dust_limit_satoshis: resolve_amount(variables, inputs[7]),
-        to_self_delay: resolve_u16(variables, inputs[8]),
+        payment_basepoint: open_channel.payment_basepoint,
+        revocation_basepoint: open_channel.revocation_basepoint,
+        delayed_payment_basepoint: open_channel.delayed_payment_basepoint,
+        dust_limit_satoshis: open_channel.dust_limit_satoshis,
+        to_self_delay: open_channel.to_self_delay,
     };
     let acceptor = ChannelPartyConfig {
-        funding_pubkey: resolve_pubkey(variables, inputs[9]),
-        payment_basepoint: resolve_pubkey(variables, inputs[10]),
-        revocation_basepoint: resolve_pubkey(variables, inputs[11]),
-        delayed_payment_basepoint: resolve_pubkey(variables, inputs[12]),
-        dust_limit_satoshis: resolve_amount(variables, inputs[13]),
-        to_self_delay: resolve_u16(variables, inputs[14]),
+        funding_pubkey: accept_channel.funding_pubkey,
+        payment_basepoint: accept_channel.payment_basepoint,
+        revocation_basepoint: accept_channel.revocation_basepoint,
+        delayed_payment_basepoint: accept_channel.delayed_payment_basepoint,
+        dust_limit_satoshis: accept_channel.dust_limit_satoshis,
+        to_self_delay: accept_channel.to_self_delay,
     };
     let config = ChannelConfig {
         funding_outpoint,
-        funding_satoshis,
-        channel_type,
+        funding_satoshis: open_channel.funding_satoshis,
+        channel_type: open_channel.tlvs.channel_type.clone().unwrap_or_default(),
         opener,
         acceptor,
     };
 
-    let temporary_channel_id = resolve_channel_id(variables, inputs[15]);
-    let push_msat = resolve_amount(variables, inputs[16]);
-    let feerate_per_kw = resolve_feerate(variables, inputs[17]);
-    let opener_per_commitment_point = resolve_pubkey(variables, inputs[18]);
-    let acceptor_per_commitment_point = resolve_pubkey(variables, inputs[19]);
-
     let state = config.new_initial_commitment(
-        push_msat,
-        feerate_per_kw,
-        opener_per_commitment_point,
-        acceptor_per_commitment_point,
+        open_channel.push_msat,
+        open_channel.feerate_per_kw,
+        open_channel.first_per_commitment_point,
+        accept_channel.first_per_commitment_point,
     )?;
     let holder = HolderIdentity {
         side: Side::Opener,
@@ -773,8 +804,6 @@ fn build_funding_created(
     };
     let signature = config.sign_counterparty_commitment(&state, &holder);
 
-    let funding_output_index = u16::try_from(funding_outpoint.vout)
-        .expect("funding output index of a funding tx must fit in u16");
     let channel_id = ChannelId::v1_from_funding_outpoint(config.funding_outpoint);
 
     // Building the same message again must not clobber a channel whose state
@@ -782,6 +811,14 @@ fn build_funding_created(
     channel_states
         .entry(channel_id)
         .or_insert_with(|| ChannelState::new(config, holder, state));
+
+    // Mark this negotiation as having built `funding_created`. It is retained
+    // so repeated `funding_created` messages can still be built, but a later
+    // `open_channel` reusing this `temporary_channel_id` starts a fresh
+    // negotiation.
+    if let Some(pending) = negotiations.get_mut(&temporary_channel_id) {
+        pending.funding_built = true;
+    }
 
     Ok(FundingCreated {
         temporary_channel_id,
@@ -2351,6 +2388,48 @@ mod tests {
         assert_eq!(pending.open_channel.funding_satoshis, 100_000);
     }
 
+    #[test]
+    fn execute_records_open_channel_for_duplicate_id_after_funding() {
+        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+
+        // Negotiated open_channel: funding_satoshis = 10_000_000.
+        // Second open_channel: same temporary_channel_id, funding_satoshis = 100_000.
+        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
+        instrs.pop(); // Drop the trailing `RecvFundingSigned` instruction.
+        // The second program's input indices are shifted past the funding
+        // flow's variables.
+        let offset = instrs.len();
+        for mut instr in send_open_channel_instructions() {
+            for input in &mut instr.inputs {
+                *input += offset;
+            }
+            instrs.push(instr);
+        }
+
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .negotiations
+            .insert(temporary_channel_id, sample_funding_negotiation());
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        let pending = executor.negotiations.get(&temporary_channel_id).unwrap();
+        assert_eq!(pending.open_channel.funding_satoshis, 100_000);
+        assert!(pending.accept_channel.is_none());
+        assert!(!pending.funding_built);
+    }
+
     // -- Panic path tests --
 
     #[test]
@@ -2633,50 +2712,79 @@ mod tests {
         assert_eq!(funds_err.required, Amount::from_sat(10_007_290));
     }
 
+    #[allow(clippy::similar_names)]
+    fn sample_funding_negotiation() -> PendingChannel {
+        let secp = Secp256k1::new();
+        let opener_sk =
+            SecretKey::from_str("30ff4956bbdd3222d44cc5e8a1261dab1e07957bdac5ae88fe3261ef321f3749")
+                .unwrap();
+        let acceptor_sk =
+            SecretKey::from_str("1552dfba4f6cf29a62a0af13c8d6981d36d0ef8d61ba10fb0fe90da7634d7e13")
+                .unwrap();
+        let opener_pk = PublicKey::from_secret_key(&secp, &opener_sk);
+        let acceptor_pk = PublicKey::from_secret_key(&secp, &acceptor_sk);
+
+        PendingChannel {
+            open_channel: OpenChannel {
+                chain_hash: [0xcc; 32],
+                temporary_channel_id: ChannelId::new([0xbb; 32]),
+                funding_satoshis: 10_000_000,
+                push_msat: 3_000_000_000,
+                dust_limit_satoshis: 546,
+                max_htlc_value_in_flight_msat: 100_000_000,
+                channel_reserve_satoshis: 10_000,
+                htlc_minimum_msat: 1_000,
+                feerate_per_kw: 15_000,
+                to_self_delay: 144,
+                max_accepted_htlcs: 483,
+                funding_pubkey: opener_pk,
+                revocation_basepoint: opener_pk,
+                payment_basepoint: opener_pk,
+                delayed_payment_basepoint: opener_pk,
+                htlc_basepoint: opener_pk,
+                first_per_commitment_point: opener_pk,
+                channel_flags: 1,
+                tlvs: OpenChannelTlvs::default(),
+            },
+            accept_channel: Some(AcceptChannel {
+                temporary_channel_id: ChannelId::new([0xbb; 32]),
+                dust_limit_satoshis: 546,
+                max_htlc_value_in_flight_msat: 100_000_000,
+                channel_reserve_satoshis: 10_000,
+                htlc_minimum_msat: 1_000,
+                minimum_depth: 6,
+                to_self_delay: 144,
+                max_accepted_htlcs: 483,
+                funding_pubkey: acceptor_pk,
+                revocation_basepoint: acceptor_pk,
+                payment_basepoint: acceptor_pk,
+                delayed_payment_basepoint: acceptor_pk,
+                htlc_basepoint: acceptor_pk,
+                first_per_commitment_point: acceptor_pk,
+                tlvs: AcceptChannelTlvs::default(),
+            }),
+            funding_built: false,
+        }
+    }
+
     fn send_funding_created_and_recv_funding_signed_instructions() -> Vec<Instruction> {
         let mut instrs = create_and_broadcast_tx_instructions();
         instrs.extend(vec![
-            Instruction {
-                operation: Operation::LoadFeatures(vec![]),
-                inputs: vec![],
-            },
-            Instruction {
-                operation: Operation::LoadAmount(546),
-                inputs: vec![],
-            },
-            Instruction {
-                operation: Operation::LoadU16(144),
-                inputs: vec![],
-            },
             Instruction {
                 operation: Operation::LoadChannelId([0xbb; 32]),
                 inputs: vec![],
             },
             Instruction {
-                operation: Operation::LoadAmount(3_000_000_000),
-                inputs: vec![],
-            },
-            Instruction {
-                operation: Operation::LoadFeeratePerKw(15_000),
-                inputs: vec![],
-            },
-            Instruction {
-                operation: Operation::LoadAmount(u64::MAX),
-                inputs: vec![],
-            },
-            Instruction {
                 operation: Operation::BuildFundingCreated,
-                inputs: vec![
-                    6, 4, 8, 0, 1, 1, 1, 9, 10, 3, 3, 3, 3, 9, 10, 11, 12, 13, 1, 3,
-                ],
+                inputs: vec![6, 0, 8],
             },
             Instruction {
                 operation: Operation::SendFundingCreated,
-                inputs: vec![15],
+                inputs: vec![9],
             },
             Instruction {
                 operation: Operation::RecvFundingSigned,
-                inputs: vec![16],
+                inputs: vec![10],
             },
         ]);
         instrs
@@ -2709,6 +2817,9 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
         executor
             .execute(
                 &Program {
@@ -2746,26 +2857,33 @@ mod tests {
             &holder,
             &fc.signature
         ));
+
+        let pending = executor
+            .negotiations
+            .get(&ChannelId::new([0xbb; 32]))
+            .unwrap();
+        assert!(pending.funding_built);
     }
 
     #[test]
     fn execute_build_funding_created_push_exceeds_funding() {
-        // push_msat (v12) larger than the funding amount surfaces the commitment
-        // construction error.
-        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
-        instrs[12] = Instruction {
-            operation: Operation::LoadAmount(20_000_000_000),
-            inputs: vec![],
-        };
+        // A negotiated push_msat larger than the funding amount surfaces the
+        // commitment construction error.
+        let mut negotiation = sample_funding_negotiation();
+        negotiation.open_channel.push_msat = 20_000_000_000;
         let mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],
             change_spk: sample_change_spk(),
             ..Default::default()
         };
-        let err = Executor::new(MockConnection::new(), mock_cli, sample_context())
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), negotiation);
+        let err = executor
             .execute(
                 &Program {
-                    instructions: instrs,
+                    instructions: send_funding_created_and_recv_funding_signed_instructions(),
                 },
                 std::time::Instant::now(),
             )
@@ -2778,19 +2896,23 @@ mod tests {
 
     #[test]
     fn execute_build_funding_created_funding_msat_overflow() {
-        // Re-point funding_satoshis (input index 1) to the u64::MAX amount (v14)
-        // so converting it to millisatoshis overflows.
-        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
-        instrs[15].inputs[1] = 14;
+        // A negotiated funding_satoshis of u64::MAX overflows when converted to
+        // millisatoshis.
+        let mut negotiation = sample_funding_negotiation();
+        negotiation.open_channel.funding_satoshis = u64::MAX;
         let mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],
             change_spk: sample_change_spk(),
             ..Default::default()
         };
-        let err = Executor::new(MockConnection::new(), mock_cli, sample_context())
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), negotiation);
+        let err = executor
             .execute(
                 &Program {
-                    instructions: instrs,
+                    instructions: send_funding_created_and_recv_funding_signed_instructions(),
                 },
                 std::time::Instant::now(),
             )
@@ -2799,6 +2921,85 @@ mod tests {
             err,
             ExecuteError::Commitment(smite::channel_tx::CommitmentError::FundingMsatOverflow)
         ));
+    }
+
+    #[test]
+    fn execute_build_funding_created_no_open_channel() {
+        // No negotiation exists for this temporary_channel_id, so we get a
+        // `funding_created` with an all-zero signature and no recorded channel
+        // state.
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
+        instrs.pop(); // Drop the trailing `RecvFundingSigned` instruction.
+
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        let fc = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
+            Message::FundingCreated(fc) => fc,
+            other => panic!("expected FundingCreated, got type {}", other.msg_type()),
+        };
+        assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(
+            fc.funding_txid.to_string(),
+            "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
+        );
+        assert_eq!(fc.funding_output_index, 0);
+        assert_eq!(fc.signature, Signature::from_compact(&[0u8; 64]).unwrap());
+        assert!(executor.channel_states.is_empty());
+    }
+
+    #[test]
+    fn execute_build_funding_created_no_accept_channel() {
+        // The `accept_channel` has not been received yet, so we get a
+        // `funding_created` with an all-zero signature and no recorded channel
+        // state.
+        let mut negotiation = sample_funding_negotiation();
+        negotiation.accept_channel = None;
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
+        instrs.pop(); // Drop the trailing `RecvFundingSigned` instruction.
+
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), negotiation);
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        let fc = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
+            Message::FundingCreated(fc) => fc,
+            other => panic!("expected FundingCreated, got type {}", other.msg_type()),
+        };
+        assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(
+            fc.funding_txid.to_string(),
+            "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
+        );
+        assert_eq!(fc.funding_output_index, 0);
+        assert_eq!(fc.signature, Signature::from_compact(&[0u8; 64]).unwrap());
+        assert!(executor.channel_states.is_empty());
     }
 
     #[test]
@@ -2821,6 +3022,9 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
         let err = executor
             .execute(
                 &Program {
@@ -2858,15 +3062,18 @@ mod tests {
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
 
-        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
         // Increase the pushed amount so the opener cannot afford the required
         // fee when the commitment is built and funding_signed is received.
-        instrs[12].operation = Operation::LoadAmount(10_000_000_000);
+        let mut negotiation = sample_funding_negotiation();
+        negotiation.open_channel.push_msat = 10_000_000_000;
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), negotiation);
 
         let err = executor
             .execute(
                 &Program {
-                    instructions: instrs,
+                    instructions: send_funding_created_and_recv_funding_signed_instructions(),
                 },
                 std::time::Instant::now(),
             )
@@ -2900,6 +3107,9 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
         let err = executor
             .execute(
                 &Program {
@@ -2939,21 +3149,21 @@ mod tests {
                 operation: Operation::BuildChannelReady {
                     include_alias: false,
                 },
-                inputs: vec![17, 1, 18],
+                inputs: vec![11, 1, 12],
             },
             Instruction {
                 operation: Operation::SendMessage,
-                inputs: vec![19],
+                inputs: vec![13],
             },
             Instruction {
                 operation: Operation::BuildChannelReady {
                     include_alias: true,
                 },
-                inputs: vec![17, 3, 18],
+                inputs: vec![11, 3, 12],
             },
             Instruction {
                 operation: Operation::SendMessage,
-                inputs: vec![21],
+                inputs: vec![15],
             },
         ]);
 
@@ -2972,6 +3182,9 @@ mod tests {
         .encode();
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
         executor
             .execute(&program, std::time::Instant::now())
             .unwrap();
@@ -3054,6 +3267,9 @@ mod tests {
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
         executor.conn.queue_recv(cr_bytes);
+        executor
+            .negotiations
+            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
 
         (executor, channel_id, target_pcp)
     }

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -17,6 +17,7 @@ use smite::channel_tx::{
     build_funding_transaction,
 };
 use smite::noise::{ConnectionError, NoiseConnection};
+use smite::pending_channel::PendingChannel;
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable};
 use std::collections::HashMap;
@@ -135,9 +136,21 @@ pub enum ExecuteError {
     #[error("commitment: {0}")]
     Commitment(#[from] smite::channel_tx::CommitmentError),
 
-    /// Received a `funding_signed` for a channel with no tracked state.
-    #[error("unknown channel: no tracked state for channel_id {0:?}")]
+    /// Received a message referencing a channel id we have no tracked state
+    /// for. This covers:
+    /// - a `funding_signed` for a `channel_id` we never opened, or
+    /// - an `accept_channel` for a `temporary_channel_id` we never sent
+    ///   `open_channel` for.
+    #[error("unknown channel: no tracked state for channel id {0:?}")]
     UnknownChannel(ChannelId),
+
+    /// Received a second `accept_channel` for a `temporary_channel_id` whose
+    /// in-progress negotiation already has one, i.e. the id was reused before
+    /// its negotiation reached `funding_created`.
+    #[error(
+        "temporary_channel_id reuse: previous negotiation for {0:?} has not yet reached funding_created"
+    )]
+    TempChannelIdReuse(ChannelId),
 
     /// The opener cannot afford the feerate for the commitment transaction.
     #[error("opener cannot afford commitment fee for channel_id {0:?}")]
@@ -162,17 +175,22 @@ pub struct Executor<C, B> {
     /// channel's static configuration and initial commitment state, then
     /// updated as commitments are exchanged and revoked.
     channel_states: HashMap<ChannelId, ChannelState>,
+    /// Negotiation state captured during program execution, keyed by
+    /// `temporary_channel_id`, so the funding flow can build commitments from
+    /// the parameters actually sent on the wire.
+    negotiations: HashMap<ChannelId, PendingChannel>,
 }
 
 impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
     /// Creates an executor with the given connection, bitcoin-cli handle, and
-    /// program context. Channel state starts empty.
+    /// program context. Channel state and negotiations start empty.
     pub fn new(conn: C, bitcoin_cli: B, context: ProgramContext) -> Self {
         Self {
             conn,
             bitcoin_cli,
             context,
             channel_states: HashMap::new(),
+            negotiations: HashMap::new(),
         }
     }
 
@@ -278,8 +296,7 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 // -- Build operations --
                 Operation::BuildOpenChannel => {
                     let oc = build_open_channel(&variables, &instr.inputs);
-                    let encoded = Message::OpenChannel(oc).encode();
-                    Some(Variable::OpenChannelMessage(encoded))
+                    Some(Variable::OpenChannelMessage(oc))
                 }
 
                 Operation::BuildFundingCreated => {
@@ -338,13 +355,15 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 }
 
                 Operation::SendOpenChannel => {
-                    let bytes = resolve_open_channel_message(&variables, instr.inputs[0]);
+                    let oc = resolve_open_channel_message(&variables, instr.inputs[0]);
+                    record_send_open_channel(&mut self.negotiations, oc);
+                    let encoded = Message::OpenChannel(oc.clone()).encode();
                     log::debug!(
                         "[{:?}] SendOpenChannel: {} bytes",
                         start.elapsed(),
-                        bytes.len(),
+                        encoded.len(),
                     );
-                    self.conn.send_message(bytes)?;
+                    self.conn.send_message(&encoded)?;
                     Some(Variable::SentOpenChannel)
                 }
 
@@ -364,6 +383,7 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     log::debug!("[{:?}] RecvAcceptChannel: waiting", start.elapsed());
                     let ac = recv_accept_channel(&mut self.conn)?;
                     log::debug!("[{:?}] RecvAcceptChannel: received", start.elapsed());
+                    record_recv_accept_channel(&mut self.negotiations, &ac)?;
                     Some(Variable::AcceptChannel(ac))
                 }
 
@@ -559,7 +579,7 @@ fn resolve_message(variables: &[Option<Variable>], index: usize) -> &[u8] {
     }
 }
 
-fn resolve_open_channel_message(variables: &[Option<Variable>], index: usize) -> &[u8] {
+fn resolve_open_channel_message(variables: &[Option<Variable>], index: usize) -> &OpenChannel {
     match resolve(variables, index) {
         Variable::OpenChannelMessage(v) => v,
         other => panic!(
@@ -1095,6 +1115,62 @@ fn verify_funding_signed(
         .ok_or(ExecuteError::InvalidCounterpartySignature(fs.channel_id))
 }
 
+/// Records a sent `open_channel`, keyed by `temporary_channel_id`, so the
+/// funding flow can build commitments from the values actually put on the wire.
+///
+/// If a negotiation for the same `temporary_channel_id` is still in progress,
+/// it is left untouched, preserving the first `open_channel`. Once a
+/// `funding_created` has been built, it is overwritten, allowing the
+/// `temporary_channel_id` to be reused for a new negotiation.
+fn record_send_open_channel(
+    negotiations: &mut HashMap<ChannelId, PendingChannel>,
+    open_channel: &OpenChannel,
+) {
+    if negotiations
+        .get(&open_channel.temporary_channel_id)
+        .is_some_and(|pending| !pending.funding_built)
+    {
+        return;
+    }
+
+    negotiations.insert(
+        open_channel.temporary_channel_id,
+        PendingChannel {
+            open_channel: open_channel.clone(),
+            accept_channel: None,
+            funding_built: false,
+        },
+    );
+}
+
+/// Pairs a received `accept_channel` with the recorded `open_channel` of the
+/// same `temporary_channel_id`.
+///
+/// # Errors
+///
+/// Returns [`ExecuteError::UnknownChannel`] if no `open_channel` was recorded
+/// for the message's `temporary_channel_id`.
+///
+/// Returns [`ExecuteError::TempChannelIdReuse`] if the negotiation already has an
+/// `accept_channel` but has not yet reached `funding_created`.
+fn record_recv_accept_channel(
+    negotiations: &mut HashMap<ChannelId, PendingChannel>,
+    accept_channel: &AcceptChannel,
+) -> Result<(), ExecuteError> {
+    let pending = negotiations
+        .get_mut(&accept_channel.temporary_channel_id)
+        .ok_or(ExecuteError::UnknownChannel(
+            accept_channel.temporary_channel_id,
+        ))?;
+    if pending.accept_channel.is_some() && !pending.funding_built {
+        return Err(ExecuteError::TempChannelIdReuse(
+            accept_channel.temporary_channel_id,
+        ));
+    }
+    pending.accept_channel = Some(accept_channel.clone());
+    Ok(())
+}
+
 /// Extracts a field from a parsed `accept_channel` message.
 fn extract_field(ac: &AcceptChannel, field: AcceptChannelField) -> Variable {
     match field {
@@ -1258,7 +1334,7 @@ mod tests {
 
     fn sample_accept_channel() -> AcceptChannel {
         AcceptChannel {
-            temporary_channel_id: ChannelId::new([0xaa; 32]),
+            temporary_channel_id: ChannelId::new([0xbb; 32]),
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,
             channel_reserve_satoshis: 10_000,
@@ -2107,6 +2183,174 @@ mod tests {
         assert_eq!(pong.ignored.len(), 4);
     }
 
+    #[test]
+    fn execute_records_negotiation_for_open_and_accept() {
+        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
+
+        let mut instrs = send_open_channel_instructions();
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
+            operation: Operation::RecvAcceptChannel,
+            inputs: vec![sent_open_channel],
+        });
+        let mut executor = Executor::new(
+            MockConnection::new(),
+            MockBitcoinCli::default(),
+            sample_context(),
+        );
+        executor.conn.queue_recv(ac_bytes);
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        let pending = executor.negotiations.get(&temporary_channel_id).unwrap();
+        assert_eq!(
+            pending.open_channel.temporary_channel_id,
+            temporary_channel_id
+        );
+        let accept_channel = pending.accept_channel.as_ref().unwrap();
+        assert_eq!(accept_channel.clone(), sample_accept_channel());
+        assert!(!pending.funding_built);
+    }
+
+    #[test]
+    fn execute_recv_accept_channel_unknown_channel() {
+        let unknown_id = ChannelId::new([0xcc; 32]);
+        let ac_bytes = Message::AcceptChannel(AcceptChannel {
+            temporary_channel_id: unknown_id,
+            ..sample_accept_channel()
+        })
+        .encode();
+
+        let mut instrs = send_open_channel_instructions();
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
+            operation: Operation::RecvAcceptChannel,
+            inputs: vec![sent_open_channel],
+        });
+        let mut executor = Executor::new(
+            MockConnection::new(),
+            MockBitcoinCli::default(),
+            sample_context(),
+        );
+        executor.conn.queue_recv(ac_bytes);
+        let err = executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, ExecuteError::UnknownChannel(id) if id == unknown_id));
+    }
+
+    #[test]
+    fn execute_recv_accept_channel_rejects_reuse_before_funding() {
+        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
+
+        let mut instrs = send_open_channel_instructions();
+        let built_open_channel = instrs.len() - 2;
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
+            operation: Operation::RecvAcceptChannel,
+            inputs: vec![sent_open_channel],
+        });
+        let resent_open_channel = instrs.len();
+        instrs.push(Instruction {
+            operation: Operation::SendOpenChannel,
+            inputs: vec![built_open_channel],
+        });
+        instrs.push(Instruction {
+            operation: Operation::RecvAcceptChannel,
+            inputs: vec![resent_open_channel],
+        });
+
+        let mut executor = Executor::new(
+            MockConnection::new(),
+            MockBitcoinCli::default(),
+            sample_context(),
+        );
+        executor.conn.queue_recv(ac_bytes.clone());
+        executor.conn.queue_recv(ac_bytes.clone());
+        let err = executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ExecuteError::TempChannelIdReuse(id) if id == temporary_channel_id
+        ));
+    }
+
+    #[test]
+    fn execute_records_only_first_open_channel_for_duplicate_id_before_funding() {
+        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+
+        // First open_channel: funding_satoshis = 100_000.
+        // Second open_channel: same temporary_channel_id, funding_satoshis = 200_000.
+        let mut instrs = send_open_channel_instructions();
+
+        // Override only funding_satoshis; reuse the first open_channel's other 19 inputs.
+        let funding_satoshis = instrs.len();
+        instrs.push(Instruction {
+            operation: Operation::LoadAmount(200_000),
+            inputs: vec![],
+        });
+        let mut build_inputs: Vec<usize> = (0..20).collect();
+        build_inputs[2] = funding_satoshis;
+
+        let built = instrs.len();
+        instrs.push(Instruction {
+            operation: Operation::BuildOpenChannel,
+            inputs: build_inputs,
+        });
+        instrs.push(Instruction {
+            operation: Operation::SendOpenChannel,
+            inputs: vec![built],
+        });
+
+        let mut executor = Executor::new(
+            MockConnection::new(),
+            MockBitcoinCli::default(),
+            sample_context(),
+        );
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        // Both open_channel messages went out on the wire, but only the first
+        // negotiation is recorded for the shared id.
+        assert_eq!(executor.conn.sent.len(), 2);
+        assert_eq!(
+            decode_open_channel(&executor.conn.sent[0]).funding_satoshis,
+            100_000
+        );
+        assert_eq!(
+            decode_open_channel(&executor.conn.sent[1]).funding_satoshis,
+            200_000
+        );
+        let pending = executor.negotiations.get(&temporary_channel_id).unwrap();
+        assert_eq!(pending.open_channel.funding_satoshis, 100_000);
+    }
+
     // -- Panic path tests --
 
     #[test]
@@ -2932,7 +3176,7 @@ mod tests {
         let ac = sample_accept_channel();
         assert_eq!(
             extract_field(&ac, AcceptChannelField::TemporaryChannelId),
-            Variable::ChannelId(ChannelId::new([0xaa; 32]))
+            Variable::ChannelId(ChannelId::new([0xbb; 32]))
         );
     }
 

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -299,17 +299,6 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     Some(Variable::OpenChannelMessage(oc))
                 }
 
-                Operation::BuildFundingCreated => {
-                    let fc = build_funding_created(
-                        &variables,
-                        &instr.inputs,
-                        &mut self.channel_states,
-                        &mut self.negotiations,
-                    )?;
-                    let encoded = Message::FundingCreated(fc).encode();
-                    Some(Variable::FundingCreatedMessage(encoded))
-                }
-
                 Operation::BuildChannelReady { include_alias } => {
                     let cr = build_channel_ready(
                         &variables,
@@ -372,13 +361,19 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 }
 
                 Operation::SendFundingCreated => {
-                    let bytes = resolve_funding_created_message(&variables, instr.inputs[0]);
+                    let fc = build_funding_created(
+                        &variables,
+                        &instr.inputs,
+                        &mut self.channel_states,
+                        &mut self.negotiations,
+                    )?;
+                    let encoded = Message::FundingCreated(fc).encode();
                     log::debug!(
                         "[{:?}] SendFundingCreated: {} bytes",
                         start.elapsed(),
-                        bytes.len(),
+                        encoded.len(),
                     );
-                    self.conn.send_message(bytes)?;
+                    self.conn.send_message(&encoded)?;
                     Some(Variable::SentFundingCreated)
                 }
 
@@ -589,16 +584,6 @@ fn resolve_open_channel_message(variables: &[Option<Variable>], index: usize) ->
         other => panic!(
             "variable {index}: expected OpenChannelMessage, got {:?}",
             other.var_type()
-        ),
-    }
-}
-
-fn resolve_funding_created_message(variables: &[Option<Variable>], index: usize) -> &[u8] {
-    match resolve(variables, index) {
-        Variable::FundingCreatedMessage(v) => v,
-        other => panic!(
-            "variable {index}: expected FundingCreatedMessage, got {:?}",
-            other.var_type(),
         ),
     }
 }
@@ -2775,16 +2760,12 @@ mod tests {
                 inputs: vec![],
             },
             Instruction {
-                operation: Operation::BuildFundingCreated,
+                operation: Operation::SendFundingCreated,
                 inputs: vec![6, 0, 8],
             },
             Instruction {
-                operation: Operation::SendFundingCreated,
-                inputs: vec![9],
-            },
-            Instruction {
                 operation: Operation::RecvFundingSigned,
-                inputs: vec![10],
+                inputs: vec![9],
             },
         ]);
         instrs
@@ -2866,7 +2847,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_build_funding_created_push_exceeds_funding() {
+    fn execute_send_funding_created_push_exceeds_funding() {
         // A negotiated push_msat larger than the funding amount surfaces the
         // commitment construction error.
         let mut negotiation = sample_funding_negotiation();
@@ -2895,7 +2876,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_build_funding_created_funding_msat_overflow() {
+    fn execute_send_funding_created_funding_msat_overflow() {
         // A negotiated funding_satoshis of u64::MAX overflows when converted to
         // millisatoshis.
         let mut negotiation = sample_funding_negotiation();
@@ -2924,7 +2905,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_build_funding_created_no_open_channel() {
+    fn execute_send_funding_created_no_open_channel() {
         // No negotiation exists for this temporary_channel_id, so we get a
         // `funding_created` with an all-zero signature and no recorded channel
         // state.
@@ -2961,7 +2942,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_build_funding_created_no_accept_channel() {
+    fn execute_send_funding_created_no_accept_channel() {
         // The `accept_channel` has not been received yet, so we get a
         // `funding_created` with an all-zero signature and no recorded channel
         // state.
@@ -3149,21 +3130,21 @@ mod tests {
                 operation: Operation::BuildChannelReady {
                     include_alias: false,
                 },
-                inputs: vec![11, 1, 12],
+                inputs: vec![10, 1, 11],
             },
             Instruction {
                 operation: Operation::SendMessage,
-                inputs: vec![13],
+                inputs: vec![12],
             },
             Instruction {
                 operation: Operation::BuildChannelReady {
                     include_alias: true,
                 },
-                inputs: vec![11, 3, 12],
+                inputs: vec![10, 3, 11],
             },
             Instruction {
                 operation: Operation::SendMessage,
-                inputs: vec![15],
+                inputs: vec![14],
             },
         ]);
 

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -92,9 +92,16 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
                 log::debug!("[{:?}] invalid commitment: {e}", start.elapsed());
             }
             Err(ExecuteError::UnknownChannel(id)) => {
-                // The target sent a funding_signed for a channel it was never
-                // asked to open. This is a protocol violation by the target.
+                // The target referenced a channel it was never asked to open.
+                // This is a protocol violation by the target.
                 return ScenarioResult::Fail(format!("unknown channel: {id:?}"));
+            }
+            Err(ExecuteError::TempChannelIdReuse(id)) => {
+                // The target sent a second accept_channel for a
+                // temporary_channel_id whose negotiation already has one and has
+                // not yet reached funding_created. This is a protocol violation
+                // by the target.
+                return ScenarioResult::Fail(format!("temporary channel id reuse: {id:?}"));
             }
             Err(ExecuteError::OpenerCannotAffordFee(id)) => {
                 // The opener cannot afford the commitment feerate. This is a

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -92,8 +92,9 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
                 log::debug!("[{:?}] invalid commitment: {e}", start.elapsed());
             }
             Err(ExecuteError::UnknownChannel(id)) => {
-                // The target referenced a channel it was never asked to open.
-                // This is a protocol violation by the target.
+                // The target referenced a channel we have no record of (a
+                // funding_signed channel_id or an accept_channel temporary id
+                // we never opened). This is a protocol violation by the target.
                 return ScenarioResult::Fail(format!("unknown channel: {id:?}"));
             }
             Err(ExecuteError::TempChannelIdReuse(id)) => {

--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -11,6 +11,7 @@
 //! - [`channel_tx`] - BOLT 3 channel transaction construction (funding and commitment).
 //! - [`noise`] - BOLT 8 `Noise_XK` encrypted transport.
 //! - [`oracles`] - Post-scenario invariant checks.
+//! - [`pending_channel`] - BOLT 2 channel negotiation state.
 //! - [`process`] - Managed subprocess utilities.
 //! - [`runners`] - Fuzz input delivery (Nyx and local modes).
 //! - [`scenarios`] - Scenario trait and the [`scenarios::smite_run`] entry point.
@@ -20,6 +21,7 @@ pub mod bolt;
 pub mod channel_tx;
 pub mod noise;
 pub mod oracles;
+pub mod pending_channel;
 pub mod process;
 pub mod runners;
 pub mod scenarios;

--- a/smite/src/pending_channel.rs
+++ b/smite/src/pending_channel.rs
@@ -1,0 +1,17 @@
+//! BOLT 2 channel negotiation state.
+//!
+//! Remembers the `open_channel`/`accept_channel` parameters of each channel
+//! being established, so later steps can build commitments from them.
+
+use crate::bolt::{AcceptChannel, OpenChannel};
+
+/// Negotiation parameters for a channel being established.
+///
+/// Contains the initiating peer's `open_channel` message, the corresponding
+/// `accept_channel` once received, and whether a `funding_created` has already
+/// been built from this negotiation.
+pub struct PendingChannel {
+    pub open_channel: OpenChannel,
+    pub accept_channel: Option<AcceptChannel>,
+    pub funding_built: bool,
+}


### PR DESCRIPTION
Fixes: #130 

Store negotiated `open_channel`/`accept_channel` messages during execution so later commitment steps use the parameters actually exchanged on the wire.

This change is accompanied by `BuildFundingCreated` using the negotiated state to build the channel state used for signing and verification. Also, all the states are now recorded on send, so there is no state corruption between the target and smite if we store a different state from what was actually sent to the peer.

Mostly, this change is done so that we can extend this approach to add `open_channel <-> accept_channel` oracles, which require a mapping between these two messages. This change lays the groundwork so we can add those oracles in subsequent PRs.