### PR TITLE
smite-ir/mutators: Add `SpliceMutator`

### DIFF
--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -621,6 +621,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fuzz_with_splice_utilizes_splice_mutator() {
+        let state = State::new(0);
+        let input = seed_program_bytes();
+        let splice_input = seed_program_bytes();
+        let mut splice_used = false;
+        // The mutator sequence is determined by a RNG. Loop until the RNG
+        // rolls `SpliceInsertionMutator` to guarantee the FFI correctly
+        // handed the payload to `mutate_stacked()`.
+        for _ in 0..100 {
+            let _ = fuzz_via_ffi(&state, input.clone(), splice_input.clone(), 1 << 16);
+            let ptr = unsafe { afl_custom_describe(state.0, 256) };
+            let s = unsafe { CStr::from_ptr(ptr) }
+                .to_str()
+                .expect("valid utf-8");
+            if s.contains("splice") {
+                splice_used = true;
+            }
+        }
+        assert!(
+            splice_used,
+            "SpliceInsertionMutator was never chosen despite a valid add_buf"
+        );
+    }
+
     // -- Trim tests --
 
     fn init_trim_via_ffi(state: &State, mut input: Vec<u8>) -> i32 {

--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -89,8 +89,13 @@ impl MutatorState {
     /// Applies a random number of stacked mutations to `program`. The stack
     /// count is a power of two in `[1, 16]` to give a mix of small tweaks and
     /// larger leaps per execution, similar in spirit to AFL++'s havoc stage.
+    ///
+    /// If `splice` is `Some`, `SpliceInsertionMutator` is added to the pool of
+    /// available mutators, allowing the `splice` program to be randomly inserted
+    /// into the target `program` during stack execution.
+    ///
     /// Records the ordered list of mutator names in `last_sequence`.
-    fn mutate_stacked(&mut self, program: &mut Program) {
+    fn mutate_stacked(&mut self, program: &mut Program, splice: Option<Program>) {
         self.last_sequence.clear();
         // Power-of-two stack count: 1, 2, 4, 8, or 16 mutations.
         let stack = 1u32 << self.rng.random_range(0..=4);
@@ -224,16 +229,16 @@ pub unsafe extern "C" fn afl_custom_deinit(data: *mut c_void) {
 /// - `data` must be a pointer returned by [`afl_custom_init`].
 /// - `buf` must point to `buf_size` readable bytes.
 /// - `out_buf` must be a valid, writable pointer to a `*const u8` slot.
-/// - `_add_buf` is unused; we export `afl_custom_splice_optout` so AFL++ never
-///   populates it.
+/// - `add_buf` must point to `add_buf_size` readable bytes, or is null with
+///   `add_buf_size == 0` (no splice input available).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn afl_custom_fuzz(
     data: *mut c_void,
     buf: *mut u8,
     buf_size: usize,
     out_buf: *mut *const u8,
-    _add_buf: *mut u8,
-    _add_buf_size: usize,
+    add_buf: *mut u8,
+    add_buf_size: usize,
     max_size: usize,
 ) -> usize {
     let state = unsafe { &mut *data.cast::<MutatorState>() };
@@ -245,7 +250,13 @@ pub unsafe extern "C" fn afl_custom_fuzz(
         let input = unsafe { slice::from_raw_parts(buf, buf_size) };
         match postcard::from_bytes::<Program>(input) {
             Ok(mut p) => {
-                state.mutate_stacked(&mut p);
+                let splice = if !add_buf.is_null() && add_buf_size > 0 {
+                    let splice_input = unsafe { slice::from_raw_parts(add_buf, add_buf_size) };
+                    postcard::from_bytes::<Program>(splice_input).ok()
+                } else {
+                    None
+                };
+                state.mutate_stacked(&mut p, splice);
                 p
             }
             Err(_) => state.generate_fresh(),
@@ -369,18 +380,6 @@ pub unsafe extern "C" fn afl_custom_post_trim(_data: *mut c_void, _success: u8) 
     1
 }
 
-/// Marker symbol that tells AFL++ not to populate `add_buf` for
-/// [`afl_custom_fuzz`]. AFL++ never actually calls this function -- it only
-/// checks for the symbol's presence via `dlsym` and, if found, skips picking a
-/// splice input before each fuzz call.
-///
-/// # Safety
-///
-/// Never invoked; the signature exists only so the symbol has the correct
-/// linkage.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn afl_custom_splice_optout(_data: *mut c_void) {}
-
 /// Returns a null-terminated description of the most recently applied mutation.
 /// AFL++ uses this when naming queue entries.
 ///
@@ -441,7 +440,12 @@ mod tests {
     /// Calls `afl_custom_fuzz` and returns `(out, len)`. The returned pointer
     /// is borrowed from the state's internal buffer and is only valid until the
     /// next call into the library.
-    fn fuzz_via_ffi(state: &State, mut input: Vec<u8>, max_size: usize) -> (*const u8, usize) {
+    fn fuzz_via_ffi(
+        state: &State,
+        mut input: Vec<u8>,
+        mut splice: Vec<u8>,
+        max_size: usize,
+    ) -> (*const u8, usize) {
         let mut out: *const u8 = ptr::null();
         let len = unsafe {
             afl_custom_fuzz(
@@ -449,8 +453,8 @@ mod tests {
                 input.as_mut_ptr(),
                 input.len(),
                 &raw mut out,
-                ptr::null_mut(),
-                0,
+                splice.as_mut_ptr(),
+                splice.len(),
                 max_size,
             )
         };
@@ -500,7 +504,7 @@ mod tests {
     #[test]
     fn fuzz_with_empty_input_generates_fresh() {
         let state = State::new(1);
-        let (out, len) = fuzz_via_ffi(&state, Vec::new(), 1 << 16);
+        let (out, len) = fuzz_via_ffi(&state, Vec::new(), Vec::new(), 1 << 16);
         assert!(len > 0);
         decode(out, len);
         verify_fresh_generation(&state);
@@ -511,7 +515,7 @@ mod tests {
         let state = State::new(2);
         let mut current = seed_program_bytes();
         for _ in 0..50 {
-            let (out, len) = fuzz_via_ffi(&state, current, 1 << 16);
+            let (out, len) = fuzz_via_ffi(&state, current, Vec::new(), 1 << 16);
             assert!(len > 0);
             // Copy before the next call, which will overwrite the state's
             // out_buf.
@@ -524,7 +528,7 @@ mod tests {
     #[test]
     fn fuzz_with_garbage_input_generates_fresh() {
         let state = State::new(3);
-        let (out, len) = fuzz_via_ffi(&state, vec![0xFFu8; 16], 1 << 16);
+        let (out, len) = fuzz_via_ffi(&state, vec![0xFFu8; 16], Vec::new(), 1 << 16);
         assert!(len > 0);
         decode(out, len);
         verify_fresh_generation(&state);
@@ -536,7 +540,7 @@ mod tests {
         // path to return 0 and still leave *out_buf pointing at something
         // non-null.
         let state = State::new(4);
-        let (out, len) = fuzz_via_ffi(&state, Vec::new(), 4);
+        let (out, len) = fuzz_via_ffi(&state, Vec::new(), Vec::new(), 4);
         assert_eq!(len, 0);
         assert!(!out.is_null());
     }
@@ -547,7 +551,7 @@ mod tests {
         // Loop until we hit the stacked-mutation branch (5% of calls generate
         // fresh instead).
         for _ in 0..10 {
-            let _ = fuzz_via_ffi(&state, seed_program_bytes(), 1 << 16);
+            let _ = fuzz_via_ffi(&state, seed_program_bytes(), Vec::new(), 1 << 16);
             let ptr = unsafe { afl_custom_describe(state.0, 256) };
             let s = unsafe { CStr::from_ptr(ptr) }
                 .to_str()
@@ -576,7 +580,7 @@ mod tests {
     #[test]
     fn describe_respects_max_description_len() {
         let state = State::new(7);
-        let _ = fuzz_via_ffi(&state, Vec::new(), 1 << 16);
+        let _ = fuzz_via_ffi(&state, Vec::new(), Vec::new(), 1 << 16);
         // Cap the description at 5 bytes.
         let ptr = unsafe { afl_custom_describe(state.0, 5) };
         let bytes = unsafe { CStr::from_ptr(ptr) }.to_bytes();
@@ -587,10 +591,19 @@ mod tests {
     }
 
     #[test]
-    fn splice_optout_symbol_exists() {
-        // AFL++ should never call this function, but invoking it should not
-        // crash either.
-        unsafe { afl_custom_splice_optout(ptr::null_mut()) };
+    fn fuzz_valid_input_with_splice_produces_decodable_output() {
+        let state = State::new(0);
+        let splice_input = seed_program_bytes();
+        let mut current = seed_program_bytes();
+        for _ in 0..50 {
+            let (out, len) = fuzz_via_ffi(&state, current, splice_input.clone(), 1 << 16);
+            assert!(len > 0);
+            // Copy before the next call, which will overwrite the state's
+            // out_buf.
+            let bytes = unsafe { slice::from_raw_parts(out, len) }.to_vec();
+            decode(bytes.as_ptr(), bytes.len());
+            current = bytes;
+        }
     }
 
     // -- Trim tests --
@@ -663,7 +676,7 @@ mod tests {
         ] {
             let state = State::new(0);
             // Run a fuzz call so last_sequence has known contents.
-            let _ = fuzz_via_ffi(&state, Vec::new(), 1 << 16);
+            let _ = fuzz_via_ffi(&state, Vec::new(), Vec::new(), 1 << 16);
             let before = unsafe { CStr::from_ptr(afl_custom_describe(state.0, 256)) }
                 .to_str()
                 .expect("valid utf-8")

--- a/smite-ir-mutator/src/lib.rs
+++ b/smite-ir-mutator/src/lib.rs
@@ -43,7 +43,7 @@ use smite_ir::generators::AnyGenerator;
 use smite_ir::minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use smite_ir::mutators::{
     GeneratorInsertionMutator, InputSwapMutator, InstructionDeleteMutator,
-    InstructionReorderMutator, OperationParamMutator,
+    InstructionReorderMutator, OperationParamMutator, SpliceInsertionMutator,
 };
 use smite_ir::{Generator, Mutator, Program, ProgramBuilder};
 
@@ -99,9 +99,16 @@ impl MutatorState {
         self.last_sequence.clear();
         // Power-of-two stack count: 1, 2, 4, 8, or 16 mutations.
         let stack = 1u32 << self.rng.random_range(0..=4);
+        let splice_insert_mutator = splice.map(SpliceInsertionMutator::new);
+        // Only roll up to 6 if we actually have a splice input.
+        let upper_bound = if splice_insert_mutator.is_some() {
+            6
+        } else {
+            5
+        };
         for _ in 0..stack {
             // Uniform pick between the available mutators.
-            let name = match self.rng.random_range(0..5) {
+            let name = match self.rng.random_range(0..upper_bound) {
                 0 => {
                     OperationParamMutator.mutate(program, &mut self.rng);
                     "op-param"
@@ -126,6 +133,13 @@ impl MutatorState {
                     let mutator = GeneratorInsertionMutator::new(generator);
                     mutator.mutate(program, &mut self.rng);
                     "gen-insert"
+                }
+                5 => {
+                    splice_insert_mutator
+                        .as_ref()
+                        .expect("splice present")
+                        .mutate(program, &mut self.rng);
+                    "splice-insert"
                 }
                 _ => unreachable!("random_range() bound out of sync with match arms"),
             };
@@ -568,7 +582,8 @@ mod tests {
                         || name == "input-swap"
                         || name == "instr-delete"
                         || name == "instr-reorder"
-                        || name == "gen-insert",
+                        || name == "gen-insert"
+                        || name == "splice-insert",
                     "unexpected mutator name in description: {name:?} (full: {s:?})",
                 );
             }

--- a/smite-ir/src/mutators.rs
+++ b/smite-ir/src/mutators.rs
@@ -8,12 +8,14 @@ mod input_swap;
 mod instruction_delete;
 mod instruction_reorder;
 mod operation_param;
+mod splice_insert;
 
 pub use generator_insert::GeneratorInsertionMutator;
 pub use input_swap::InputSwapMutator;
 pub use instruction_delete::InstructionDeleteMutator;
 pub use instruction_reorder::InstructionReorderMutator;
 pub use operation_param::OperationParamMutator;
+pub use splice_insert::SpliceInsertionMutator;
 
 use rand::Rng;
 

--- a/smite-ir/src/mutators/splice_insert.rs
+++ b/smite-ir/src/mutators/splice_insert.rs
@@ -1,0 +1,54 @@
+//! Mutator that inserts spliced programs.
+
+use rand::{Rng, RngExt};
+
+use super::Mutator;
+use crate::{Program, ProgramBuilder};
+
+/// Inserts a spliced program at a random point in the given program.
+pub struct SpliceInsertionMutator {
+    splice: Program,
+}
+
+impl SpliceInsertionMutator {
+    #[must_use]
+    pub fn new(splice: Program) -> Self {
+        Self { splice }
+    }
+}
+
+impl Mutator for SpliceInsertionMutator {
+    fn mutate(&self, program: &mut Program, rng: &mut impl Rng) -> bool {
+        let insert_idx = rng.random_range(0..=program.instructions.len());
+        let mut builder = ProgramBuilder::new();
+        let mut iter = std::mem::take(&mut program.instructions).into_iter();
+
+        // Consume and append the pre-insertion instructions.
+        for instr in iter.by_ref().take(insert_idx) {
+            builder.append(instr.operation, &instr.inputs);
+        }
+
+        // Insert the spliced program.
+        for instr in &self.splice.instructions {
+            let shifted_inputs: Vec<usize> = instr
+                .inputs
+                .iter()
+                .map(|&input| input + insert_idx)
+                .collect();
+            builder.append(instr.operation.clone(), &shifted_inputs);
+        }
+
+        // Consume, shift, and append the post-insertion instructions.
+        for mut instr in iter {
+            for input in &mut instr.inputs {
+                if *input >= insert_idx {
+                    *input += self.splice.instructions.len();
+                }
+            }
+            builder.append(instr.operation, &instr.inputs);
+        }
+        *program = builder.build();
+
+        true
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1528,6 +1528,75 @@ fn assert_mutator_preserves_well_formedness<M: Mutator>(mutator: &M, original: &
     }
 }
 
+// Assert that a generated or spliced sequence of instructions is found intact
+// and contiguous somewhere within the mutated program.
+fn assert_mutator_preserves_sequence(mutated: &Program, payload: &Program) {
+    let inserted_correctly = mutated
+        .instructions
+        .windows(payload.instructions.len())
+        .any(|window| {
+            window
+                .iter()
+                .zip(payload.instructions.iter())
+                .all(|(a, b)| a.operation == b.operation)
+        });
+
+    assert!(
+        inserted_correctly,
+        "Payload sequence not found intact in mutated program"
+    );
+}
+
+// Assert that the topological ordering of a SSA program remains valid after
+// a block of instructions of `offset` length is inserted into it.
+fn assert_graph_shifted_correctly(original: &Program, mutated: &Program, offset: usize) {
+    assert_eq!(
+        mutated.instructions.len(),
+        original.instructions.len() + offset,
+        "Mutated program length does not match original + offset"
+    );
+    // Find the exact insert_point chosen by the RNG.
+    let mut insert_point = original.instructions.len();
+    for i in 0..original.instructions.len() {
+        if mutated.instructions[i].operation != original.instructions[i].operation {
+            insert_point = i;
+            break;
+        }
+    }
+    // Validate the tail shift.
+    for mut_idx in (insert_point + offset)..mutated.instructions.len() {
+        let orig_idx = mut_idx - offset;
+        let mut_instr = &mutated.instructions[mut_idx];
+        let orig_instr = &original.instructions[orig_idx];
+
+        // Ensure the operations align perfectly.
+        assert_eq!(mut_instr.operation, orig_instr.operation);
+        assert_eq!(mut_instr.inputs.len(), orig_instr.inputs.len());
+
+        for (i, (&mut_in, &orig_in)) in mut_instr
+            .inputs
+            .iter()
+            .zip(orig_instr.inputs.iter())
+            .enumerate()
+        {
+            if orig_in < insert_point {
+                // If it pointed to something BEFORE the cut, the index should not change.
+                assert_eq!(
+                    mut_in, orig_in,
+                    "Instruction {mut_idx} input {i} shifted, but it points BEFORE the insertion point",
+                );
+            } else {
+                // If it pointed to something AT or AFTER the cut, the index must shift by the offset.
+                assert_eq!(
+                    mut_in,
+                    orig_in + offset,
+                    "Instruction {mut_idx} input {i} failed to shift by exactly {offset}",
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn param_mutator_false_is_noop() {
     let original = Program {
@@ -2288,20 +2357,7 @@ fn generator_insertion_preserves_generated() {
     let mutator = GeneratorInsertionMutator::new(DummyGenerator);
     mutator.mutate(&mut program, &mut rng);
 
-    let inserted_correctly = program
-        .instructions
-        .windows(dummy_program.instructions.len())
-        .any(|window| {
-            window
-                .iter()
-                .zip(dummy_program.instructions.iter())
-                .all(|(a, b)| a.operation == b.operation)
-        });
-
-    assert!(
-        inserted_correctly,
-        "Generated sequence not found intact in mutated program"
-    );
+    assert_mutator_preserves_sequence(&program, &dummy_program);
 }
 
 #[test]
@@ -2313,49 +2369,9 @@ fn generator_insertion_shifts_correctly() {
     let mut rng = SmallRng::seed_from_u64(0);
     mutator.mutate(&mut program, &mut rng);
 
-    // Find the exact insert_point chosen by the RNG.
-    let mut insert_point = original.instructions.len();
-    for i in 0..original.instructions.len() {
-        if program.instructions[i].operation != original.instructions[i].operation {
-            insert_point = i;
-            break;
-        }
-    }
-
     // The length of the generated program.
     let offset = program.instructions.len() - original.instructions.len();
-
-    for mut_idx in (insert_point + offset)..program.instructions.len() {
-        let orig_idx = mut_idx - offset;
-        let mut_instr = &program.instructions[mut_idx];
-        let orig_instr = &original.instructions[orig_idx];
-
-        // Ensure the operations align perfectly.
-        assert_eq!(mut_instr.operation, orig_instr.operation);
-        assert_eq!(mut_instr.inputs.len(), orig_instr.inputs.len());
-
-        for (i, (&mut_in, &orig_in)) in mut_instr
-            .inputs
-            .iter()
-            .zip(orig_instr.inputs.iter())
-            .enumerate()
-        {
-            if orig_in < insert_point {
-                // If it pointed to something BEFORE the cut, the index should not change.
-                assert_eq!(
-                    mut_in, orig_in,
-                    "Instruction {mut_idx} input {i} shifted, but it points BEFORE the insertion point",
-                );
-            } else {
-                // If it pointed to something AT or AFTER the cut, the index must shift by the offset.
-                assert_eq!(
-                    mut_in,
-                    orig_in + offset,
-                    "Instruction {mut_idx} input {i} failed to shift by exactly {offset}",
-                );
-            }
-        }
-    }
+    assert_graph_shifted_correctly(&original, &program, offset);
 }
 
 #[test]

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -13,7 +13,7 @@ use generators::{
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use mutators::{
     GeneratorInsertionMutator, InputSwapMutator, InstructionDeleteMutator,
-    InstructionReorderMutator, OperationParamMutator,
+    InstructionReorderMutator, OperationParamMutator, SpliceInsertionMutator,
 };
 use operation::{AcceptChannelField, ChannelTypeVariant, ShutdownScriptVariant};
 
@@ -2379,6 +2379,81 @@ fn generator_insertion_preserves_well_formedness() {
     let original = generate_open_channel_program(0);
     for &generator in AnyGenerator::ALL {
         let mutator = GeneratorInsertionMutator::new(generator);
+        assert_mutator_preserves_well_formedness(&mutator, &original);
+    }
+}
+
+// -- SpliceInsertionMutator tests --
+
+#[test]
+fn splice_does_not_drop_instructions() {
+    let mut program = generate_open_channel_program(0);
+    let original_program_len = program.instructions.len();
+    let splice_program = generate_channel_update_program(0);
+    let splice_program_len = splice_program.instructions.len();
+
+    let mutator = SpliceInsertionMutator::new(splice_program);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    mutator.mutate(&mut program, &mut rng);
+    assert_eq!(
+        original_program_len + splice_program_len,
+        program.instructions.len()
+    );
+}
+
+#[test]
+fn splice_returns_spliced_on_empty_program() {
+    let mut program = Program {
+        instructions: vec![],
+    };
+    let splice_program = generate_channel_announcement_program(0);
+    let mutator = SpliceInsertionMutator::new(splice_program.clone());
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    mutator.mutate(&mut program, &mut rng);
+    assert_eq!(
+        program, splice_program,
+        "SpliceInsertionMutator didn't insert generated program"
+    );
+}
+
+#[test]
+fn splice_preserves_generated() {
+    let mut program = generate_open_channel_program(0);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    let splice_program = generate_channel_update_program(0);
+    let mutator = SpliceInsertionMutator::new(splice_program.clone());
+    mutator.mutate(&mut program, &mut rng);
+
+    assert_mutator_preserves_sequence(&program, &splice_program);
+}
+
+#[test]
+fn splice_shifts_correctly() {
+    let original = generate_open_channel_program(0);
+    let mut program = original.clone();
+    let splice_program = generate_channel_announcement_program(0);
+
+    let mutator = SpliceInsertionMutator::new(splice_program.clone());
+    let mut rng = SmallRng::seed_from_u64(0);
+    mutator.mutate(&mut program, &mut rng);
+
+    assert_graph_shifted_correctly(&original, &program, splice_program.instructions.len());
+}
+
+#[test]
+fn splice_preserves_well_formedness() {
+    let original = generate_open_channel_program(0);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for &generator in AnyGenerator::ALL {
+        let mut builder = ProgramBuilder::new();
+        generator.generate(&mut builder, &mut rng);
+
+        let splice_program = builder.build();
+        let mutator = SpliceInsertionMutator::new(splice_program);
         assert_mutator_preserves_well_formedness(&mutator, &original);
     }
 }


### PR DESCRIPTION
Add `SpliceMutator` for smite-IR. Mutates a given program by inserting a spliced input at a random point in the said program.