### PR TITLE
smite: mine consensus-valid transactions that violate mempool policy

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -62,17 +62,24 @@ const MAX_MINIMUM_DEPTH: u32 = 8;
 
 /// Abstraction over bitcoin-cli operations, allowing mock implementations in tests.
 pub trait BitcoinRpc {
-    /// Mines the given number of blocks.
-    fn mine_blocks(&mut self, num_blocks: u8);
+    /// Mines the given number of blocks, including any transactions in the
+    /// `private_mempool` in the first block.
+    fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]);
 
     /// Returns the wallet's spendable UTXOs.
+    #[must_use]
     fn get_utxos(&mut self) -> Vec<Utxo>;
 
     /// Returns the scriptPubKey for a newly generated wallet address.
+    #[must_use]
     fn get_new_address_script_pubkey(&mut self) -> ScriptBuf;
 
-    /// Signs and broadcasts a transaction
-    fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction);
+    /// Signs and broadcasts a transaction. Returns hex-encoded raw transaction
+    /// if it is consensus-valid but rejected by mempool policy, so it can be
+    /// added to the `private_mempool`; returns `None` if it was broadcast or is
+    /// already confirmed.
+    #[must_use]
+    fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) -> Option<String>;
 
     /// Locks the given outpoints so subsequent [`get_utxos`](Self::get_utxos)
     /// calls exclude them, preventing independently built transactions from
@@ -81,12 +88,13 @@ pub trait BitcoinRpc {
 
     /// Returns the number of confirmations for the transaction with the given
     /// txid, or `0` if it is unconfirmed or unknown to the node.
+    #[must_use]
     fn get_transaction_confirmations(&mut self, txid: Txid) -> u32;
 }
 
 impl BitcoinRpc for BitcoinCli {
-    fn mine_blocks(&mut self, num_blocks: u8) {
-        BitcoinCli::mine_blocks(self, num_blocks);
+    fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]) {
+        BitcoinCli::mine_blocks(self, num_blocks, private_mempool);
     }
 
     fn get_utxos(&mut self) -> Vec<Utxo> {
@@ -97,8 +105,8 @@ impl BitcoinRpc for BitcoinCli {
         BitcoinCli::get_new_address_script_pubkey(self)
     }
 
-    fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) {
-        BitcoinCli::sign_and_broadcast_tx(self, tx);
+    fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) -> Option<String> {
+        BitcoinCli::sign_and_broadcast_tx(self, tx)
     }
 
     fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
@@ -244,6 +252,12 @@ pub struct Executor<C, B> {
     /// `temporary_channel_id`, so the funding flow can build commitments from
     /// the parameters actually sent on the wire.
     negotiations: HashMap<ChannelId, PendingChannel>,
+    /// Transactions stored outside Bitcoin Core's mempool, typically because they
+    /// were rejected by mempool policy, to be included in the next `MineBlocks`
+    /// operation. Each is stored as `(txid, raw_hex)`: re-signing the same
+    /// transaction can change its raw hex, but the txid stays the same, so
+    /// deduplication keys on the txid while the raw hex is what gets mined.
+    private_mempool: Vec<(Txid, String)>,
 }
 
 impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
@@ -256,6 +270,7 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
             context,
             channel_states: HashMap::new(),
             negotiations: HashMap::new(),
+            private_mempool: Vec::new(),
         }
     }
 
@@ -476,19 +491,34 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 }
 
                 Operation::MineBlocks(v) => {
-                    self.bitcoin_cli.mine_blocks(*v);
+                    // Clear the private mempool and mine the requested blocks,
+                    // adding those transactions to the first block.
+                    let private_mempool: Vec<String> = std::mem::take(&mut self.private_mempool)
+                        .into_iter()
+                        .map(|(_, hex)| hex)
+                        .collect();
+                    self.bitcoin_cli.mine_blocks(*v, &private_mempool);
                     log::debug!("[{:?}] MineBlocks: mined {} block(s)", start.elapsed(), v);
                     None
                 }
 
                 Operation::BroadcastTransaction => {
                     let ft = resolve_funding_transaction(&variables, instr.inputs[0]);
+                    let txid = ft.tx.compute_txid();
                     log::debug!(
                         "[{:?}] BroadcastTransaction: txid={}",
                         start.elapsed(),
-                        ft.tx.compute_txid(),
+                        txid
                     );
-                    self.bitcoin_cli.sign_and_broadcast_tx(&ft.tx);
+                    // Queue transactions rejected by the mempool in the private
+                    // mempool so they can be mined later. Dedup on txid so the
+                    // same transaction broadcast again before then is queued
+                    // once, regardless of any change to its signed hex.
+                    if let Some(hex) = self.bitcoin_cli.sign_and_broadcast_tx(&ft.tx)
+                        && !self.private_mempool.iter().any(|(t, _)| *t == txid)
+                    {
+                        self.private_mempool.push((txid, hex));
+                    }
                     None
                 }
             };
@@ -1392,6 +1422,7 @@ mod tests {
     #[derive(Default)]
     struct MockBitcoinCli {
         mine_blocks_calls: Vec<u8>,
+        mined_private_mempool: Vec<String>,
         broadcast_calls: Vec<Transaction>,
         utxos: Vec<Utxo>,
         change_spk: ScriptBuf,
@@ -1399,8 +1430,9 @@ mod tests {
     }
 
     impl BitcoinRpc for MockBitcoinCli {
-        fn mine_blocks(&mut self, num_blocks: u8) {
+        fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]) {
             self.mine_blocks_calls.push(num_blocks);
+            self.mined_private_mempool = private_mempool.to_vec();
             self.confirmations += u32::from(num_blocks);
         }
 
@@ -1412,8 +1444,21 @@ mod tests {
             self.change_spk.clone()
         }
 
-        fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) {
+        fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) -> Option<String> {
             self.broadcast_calls.push(tx.clone());
+
+            // Simulate a mempool-policy rejection: if any output is below its
+            // dust threshold, return the tx hex so it gets queued in the
+            // private mempool. Otherwise the tx is accepted.
+            let has_dust = tx
+                .output
+                .iter()
+                .any(|o| o.value < o.script_pubkey.minimal_non_dust());
+            if has_dust {
+                Some(bitcoin::consensus::encode::serialize_hex(tx))
+            } else {
+                None
+            }
         }
 
         fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
@@ -2769,6 +2814,7 @@ mod tests {
 
         // Verify that mine_blocks was called with the correct number
         assert_eq!(executor.bitcoin_cli.mine_blocks_calls, vec![6]);
+        assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
     }
 
     #[test]
@@ -2817,6 +2863,56 @@ mod tests {
         assert_eq!(
             broadcast_tx.compute_txid().to_string(),
             "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
+        );
+    }
+
+    #[test]
+    fn execute_broadcast_dedupes_rejected_tx_in_private_mempool() {
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+
+        // Fund with a dust amount so the built funding tx carries a below-dust
+        // output.
+        let mut instrs = create_and_broadcast_tx_instructions();
+        instrs[4] = Instruction {
+            operation: Operation::LoadAmount(200),
+            inputs: vec![],
+        };
+        let funding_tx = instrs.len() - 2;
+        instrs.push(Instruction {
+            operation: Operation::BroadcastTransaction,
+            inputs: vec![funding_tx],
+        });
+        instrs.push(Instruction {
+            operation: Operation::MineBlocks(1),
+            inputs: vec![],
+        });
+
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        assert_eq!(executor.bitcoin_cli.broadcast_calls.len(), 2);
+        assert_eq!(
+            executor.bitcoin_cli.broadcast_calls[0].compute_txid(),
+            executor.bitcoin_cli.broadcast_calls[1].compute_txid(),
+        );
+
+        let rejected_hex =
+            bitcoin::consensus::encode::serialize_hex(&executor.bitcoin_cli.broadcast_calls[0]);
+        assert!(executor.private_mempool.is_empty());
+        assert_eq!(
+            executor.bitcoin_cli.mined_private_mempool,
+            vec![rejected_hex]
         );
     }
 
@@ -3423,6 +3519,7 @@ mod tests {
                 std::time::Instant::now(),
             )
             .unwrap();
+        assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
 
         // The target's next per-commitment point is still unknown and the queued
         // `channel_ready` remains untouched.
@@ -3457,6 +3554,7 @@ mod tests {
                 std::time::Instant::now(),
             )
             .unwrap();
+        assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
 
         // The `channel_ready` was consumed and the target's next per-commitment
         // point is now recorded.

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -86,11 +86,31 @@ impl BitcoinCli {
 
     /// Mines the given number of blocks.
     ///
+    /// Any transactions stored in `private_mempool` are included in the first
+    /// block. Any remaining blocks are then mined normally. If
+    /// `private_mempool` is empty, the current mempool is mined as usual.
+    ///
     /// # Panics
     ///
-    /// If the `bitcoin-cli -generate` command fails to execute or returns
-    /// a non-success exit status.
-    pub fn mine_blocks(&self, num_blocks: u8) {
+    /// If the `bitcoin-cli -generate` or `generateblock` command fails to
+    /// execute or exits non-zero.
+    pub fn mine_blocks(&self, num_blocks: u8, private_mempool: &[String]) {
+        if private_mempool.is_empty() {
+            self.generate(num_blocks);
+            return;
+        }
+
+        // Include the private mempool in the first block, then mine the
+        // remaining blocks normally.
+        self.mine_block_including(private_mempool);
+        if num_blocks > 1 {
+            self.generate(num_blocks - 1);
+        }
+    }
+
+    /// Mines `num_blocks` blocks from the node's mempool via
+    /// `bitcoin-cli -generate`.
+    fn generate(&self, num_blocks: u8) {
         let mine_out = self
             .run()
             .arg("-generate")
@@ -103,6 +123,62 @@ impl BitcoinCli {
             num_blocks,
             String::from_utf8_lossy(&mine_out.stderr)
         );
+    }
+
+    /// Mines a single block containing the current mempool together with the
+    /// transactions stored in `private_mempool`.
+    ///
+    /// Since `generateblock` only includes the transactions it is given, the
+    /// current mempool (fetched via `getrawmempool`) is included as well so
+    /// already-broadcast transactions are not omitted from the block.
+    ///
+    /// # Panics
+    ///
+    /// - If `bitcoin-cli getrawmempool`, `getnewaddress`, or `generateblock`
+    ///   fails to execute or exits non-zero.
+    /// - If `getrawmempool` does not return valid JSON.
+    /// - If `getnewaddress` does not return a valid regtest address.
+    /// - If any transaction in `private_mempool` is consensus-invalid.
+    /// - If the combined transaction list contains a duplicate rawtx/txid or is
+    ///   not topologically ordered.
+    fn mine_block_including(&self, private_mempool: &[String]) {
+        let mut txs = self.get_raw_mempool();
+        txs.extend_from_slice(private_mempool);
+        let txs_json = serde_json::to_string(&txs).expect("tx list serializes to valid JSON");
+
+        let address = self.get_new_address();
+        let gen_out = self
+            .run()
+            .arg("generateblock")
+            .arg(address.to_string())
+            .arg(&txs_json)
+            .output()
+            .expect("bitcoin-cli generateblock should not fail");
+        assert!(
+            gen_out.status.success(),
+            "bitcoin-cli generateblock failed: {}",
+            String::from_utf8_lossy(&gen_out.stderr)
+        );
+    }
+
+    /// Returns the txids currently in the node's mempool.
+    ///
+    /// # Panics
+    ///
+    /// - If `bitcoin-cli getrawmempool` fails to execute or exits non-zero.
+    /// - If the output is not valid JSON.
+    fn get_raw_mempool(&self) -> Vec<String> {
+        let out = self
+            .run()
+            .arg("getrawmempool")
+            .output()
+            .expect("bitcoin-cli getrawmempool should not fail");
+        assert!(
+            out.status.success(),
+            "bitcoin-cli getrawmempool failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        serde_json::from_slice(&out.stdout).expect("getrawmempool should return valid JSON")
     }
 
     /// Returns the wallet's spendable UTXOs, sorted deterministically.
@@ -168,6 +244,16 @@ impl BitcoinCli {
     /// - If the output is not valid UTF-8 or not a valid regtest address.
     #[must_use]
     pub fn get_new_address_script_pubkey(&self) -> ScriptBuf {
+        self.get_new_address().script_pubkey()
+    }
+
+    /// Returns a newly generated wallet address.
+    ///
+    /// # Panics
+    ///
+    /// - If `bitcoin-cli getnewaddress` fails to execute or exits non-zero.
+    /// - If the output is not valid UTF-8 or not a valid regtest address.
+    fn get_new_address(&self) -> Address {
         let addr_out = self
             .run()
             .arg("getnewaddress")
@@ -183,20 +269,32 @@ impl BitcoinCli {
         Address::from_str(addr_str.trim())
             .and_then(|a| a.require_network(Network::Regtest))
             .expect("getnewaddress should return a valid address")
-            .script_pubkey()
     }
 
     /// Signs and broadcasts a transaction, unless it is already confirmed.
     ///
+    /// If the signed transaction is accepted by the mempool, it is broadcast
+    /// normally. If the mempool rejects it (for example, because it is below
+    /// the minimum relay feerate or creates a dust output), it is returned
+    /// instead so the caller can mine it later, bypassing mempool policy.
+    ///
+    /// Returns `None` if the transaction was already confirmed or was broadcast
+    /// successfully, or hex-encoded raw transaction if it was rejected by the
+    /// mempool.
+    ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli signrawtransactionwithwallet` or `sendrawtransaction`
-    ///   fails to execute or exits non-zero.
+    /// - If `bitcoin-cli signrawtransactionwithwallet` fails to execute or
+    ///   exits non-zero.
     /// - If the sign output is not valid JSON.
     /// - If signing returns `complete=false`.
-    /// - If `sendrawtransaction` does not return a valid UTF-8 txid.
+    /// - If `bitcoin-cli sendrawtransaction` fails to execute.
+    /// - If the broadcast is rejected for any reason other than a below-dust
+    ///   output or a below-minimum relay feerate.
+    /// - If a successful broadcast does not return a valid UTF-8 txid.
     /// - If the broadcasted txid does not match the given transaction's txid.
-    pub fn sign_and_broadcast_tx(&self, tx: &Transaction) {
+    #[must_use]
+    pub fn sign_and_broadcast_tx(&self, tx: &Transaction) -> Option<String> {
         #[derive(Deserialize)]
         struct SignRawTransactionResponse {
             hex: String,
@@ -208,7 +306,7 @@ impl BitcoinCli {
         // signing and broadcasting it again.
         let txid = tx.compute_txid();
         if self.get_transaction_confirmations(txid) > 0 {
-            return;
+            return None;
         }
 
         let tx_hex = serialize_hex(tx);
@@ -240,11 +338,17 @@ impl BitcoinCli {
             .arg("0")
             .output()
             .expect("bitcoin-cli sendrawtransaction should not fail");
-        assert!(
-            broadcast_out.status.success(),
-            "bitcoin-cli sendrawtransaction failed: {}",
-            String::from_utf8_lossy(&broadcast_out.stderr)
-        );
+
+        if !broadcast_out.status.success() {
+            let stderr = String::from_utf8_lossy(&broadcast_out.stderr);
+            // If the feerate is below the default minimum relay feerate, or any
+            // output is below its dust threshold, return the transactions so
+            // they can be mined directly, bypassing mempool policy.
+            if stderr.contains("tx with dust output") || stderr.contains("min relay fee not met") {
+                return Some(signed_tx.hex);
+            }
+            panic!("bitcoin-cli sendrawtransaction failed: {stderr}");
+        }
 
         // Safe because bitcoind descriptor wallets currently default to native
         // SegWit, so signing does not alter the txid computed from the unsigned
@@ -256,6 +360,8 @@ impl BitcoinCli {
             txid.to_string(),
             "sendrawtransaction returned unexpected txid"
         );
+
+        None
     }
 
     /// Locks the given outpoints in the wallet so they are excluded from


### PR DESCRIPTION
There were a couple of crashes while I was running the funding-flow generator, where we were getting panics in smite because of the restrictive assert statements we have set. These commits fix those issues in smite.

So now we can’t create two transactions with overlapping inputs. We return early when signing or broadcasting a transaction if it has already been broadcast and confirmed, since the wallet can’t sign a transaction whose inputs have already been spent. There were also a couple of crashes around broadcasting, where either `funding_satoshis` itself was below the dust limit, or the feerate used to calculate the transaction fee was too low compared to `bitcoind` default policy. So now we reject those inputs as well.

These cases do not really contribute to fuzzing, because in practice, if `bitcoind` default policy rejects them, Lightning nodes should also reject those `open_channel` messages before sending `accept_channel`. But let’s say they are not rejected, then I think those cases can be caught once we add the `open_channel` and `accept_channel` oracle. So in either case, we don’t need to relax `bitcoind` default policy to exercise the full funding flow