### PR TITLE
smitebot: tmux integration + strategy distribution for start

### DIFF
--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -1,65 +1,72 @@
 # smitebot
 
-`smitebot` is the Smite automation CLI. It is intended to orchestrate common fuzzing workflows and reduce manual setup/operations.
+`smitebot` is the Smite automation CLI. It orchestrates fuzzing campaigns against Lightning Network implementations using AFL++ and Nyx, reducing multi-step manual workflows to single commands.
 
 ## Install
 
-Install `smitebot` once from this repository:
-
 ```bash
 cargo install --path smitebot
-```
-
-After install, run it directly:
-
-```bash
-smitebot doctor --aflpp-path ~/AFLplusplus
-smitebot doctor campaign.toml
 ```
 
 ## Configuration
 
 Campaign settings are stored in a TOML file. See [`sample-campaign.toml`](sample-campaign.toml) for a complete example.
 
-| Field        | Required | Description                                                          |
-| ------------ | -------- | -------------------------------------------------------------------- |
-| `target`     | yes      | Lightning implementation to fuzz (`lnd`, `cln`, `ldk`, or `eclair`). |
-| `scenario`   | yes      | Scenario binary selected by the workload Dockerfile.                 |
-| `aflpp_path` | yes      | Path to the AFL++ source tree.                                       |
-| `smite_dir`  | yes      | Path to the smite repository root.                                   |
-| `runners`    | yes      | Number of parallel AFL++ instances to launch (must be at least 1).   |
-| `seed_dir`   | no       | Directory containing seed inputs; omit to start from an empty corpus.|
-| `output_dir` | yes      | AFL++ output directory for findings and stats.                       |
-| `sharedir`   | yes      | Nyx shared directory path; created automatically by `smitebot start`.|
-| `image`      | no       | Docker image tag override; defaults to `smite-<target>-<scenario>`.  |
-| `afl_env`    | no       | Extra environment variables passed to AFL++ instances.               |
-| `afl_flags`  | no       | Extra CLI flags appended to `afl-fuzz`.                              |
+| Field          | Required | Description                                                                               |
+| -------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `target`       | yes      | Lightning implementation to fuzz (`lnd`, `cln`, `ldk`, or `eclair`).                      |
+| `scenario`     | yes      | Scenario binary selected by the workload Dockerfile.                                      |
+| `aflpp_path`   | yes      | Path to the AFL++ source tree.                                                            |
+| `smite_dir`    | yes      | Path to the smite repository root.                                                        |
+| `runners`      | yes      | Number of parallel AFL++ instances to launch (must be at least 1).                        |
+| `seed_dir`     | no       | Directory containing seed inputs; omit to start from an empty corpus.                     |
+| `output_dir`   | yes      | AFL++ output directory for findings and stats.                                            |
+| `sharedir`     | yes      | Nyx shared directory path; created automatically by `smitebot start`.                     |
+| `image`        | no       | Docker image tag override; defaults to `smite-<target>-<scenario>`.                       |
+| `tmux_session` | no       | Custom tmux session name; defaults to the campaign ID. Must not contain `:`, `.`, or `#`. |
+| `afl_env`      | no       | Extra environment variables passed to AFL++ instances.                                    |
+| `afl_flags`    | no       | Extra CLI flags appended to `afl-fuzz`.                                                   |
 
 ## Commands
 
 ### smitebot start
 
-`smitebot start` launches a fuzzing campaign in the background. It builds the Docker image, sets up the Nyx sharedir, and spawns parallel AFL++ instances.
+Launches a fuzzing campaign. Builds the Docker image, sets up the Nyx sharedir, spawns parallel AFL++ instances inside a tmux session (one window per runner), and attaches to the session.
 
 ```bash
 smitebot start campaign.toml
 ```
 
-For IR scenarios (scenario names starting with `ir`), the required AFL++ custom mutator environment variables are injected automatically.
+Each runner gets a deterministic strategy distribution:
+- Power schedule (`-p`): round-robin across `fast`, `explore`, `coe`, `lin`, `quad`, `exploit`, `rare`
+- `-a binary`: ~70% of secondary runners
+- `AFL_DISABLE_TRIM`: ~60% of secondary runners
+- `AFL_FINAL_SYNC`: primary runner only
+- `AFL_IMPORT_FIRST`: enabled when runner count < 16
+- `AFL_TESTCACHE_SIZE`: auto-sized from available RAM
+
+For IR scenarios (scenario names starting with `ir`), the required AFL++ custom mutator environment variables are injected automatically. User `afl_env` values override strategy defaults.
+
+`start` begins fresh campaigns only. If `output_dir` already holds a prior run's `fuzzer_stats`, it exits with an error instead of resuming (resume is not yet supported).
+
+After spawning, startup is verified by polling for `fuzzer_stats` files. Because AFL++ writes `fuzzer_stats` only after calibrating every seed (minutes under Nyx), a runner is reported as failed the moment its tmux window exits rather than after a fixed timeout; the poll otherwise waits up to a generous ceiling (10 min) for a runner that stays alive but never starts. On failure, the tmux session is preserved with `remain-on-exit` so error output can be inspected.
 
 Campaign state is saved to `~/.smitebot/runs/<campaign-id>/state.json` for use by future `stop` and `status` commands.
 
 ### smitebot config
 
-`smitebot config` validates a campaign configuration file, reports the resolved settings, and checks that referenced paths exist on disk.
+Validates a campaign configuration file, reports the resolved settings, and checks that referenced paths exist on disk.
 
 ```bash
-smitebot config sample-campaign.toml
+smitebot config campaign.toml
+smitebot config campaign.toml --json
 ```
+
+- `--json`: Emit machine-readable JSON output. Both success and error paths produce valid JSON.
 
 ### smitebot build
 
-`smitebot build` builds Smite workload Docker images. It can be used standalone with CLI flags or with a campaign config file. When a config file is provided, CLI flags override individual values.
+Builds Smite workload Docker images. Accepts a campaign config file or standalone CLI flags. When both are provided, CLI flags override config values.
 
 ```bash
 smitebot build --target lnd --scenario encrypted_bytes
@@ -68,25 +75,18 @@ smitebot build campaign.toml --target cln
 smitebot build campaign.toml --coverage --no-cache
 ```
 
-Flags:
-
 - `--target`: Target implementation to build. Required when no config file is provided.
 - `--scenario`: Scenario binary for the workload Dockerfile. Required when no config file is provided.
 - `--smite-dir`: Path to the smite repository root; defaults to `.` when no config file is provided.
 - `--coverage`: Build a coverage-instrumented image.
-- `--image`: Docker image tag; overrides the config value and the default smite naming convention.
+- `--image`: Docker image tag; overrides the config value and the default naming convention.
 - `--no-cache`: Perform a clean rebuild without using cached Docker layers.
 
-By default, image tags follow the existing Smite convention:
-
-```text
-smite-<target>-<scenario>
-smite-<target>-<scenario>-coverage
-```
+Image tags follow the Smite convention: `smite-<target>-<scenario>` or `smite-<target>-<scenario>-coverage`.
 
 ### smitebot doctor
 
-`smitebot doctor` validates host prerequisites before running Smite campaigns. It can be used standalone with CLI flags or with a campaign config file. When a config file is provided, CLI flags override individual values.
+Validates host prerequisites before running Smite campaigns. Accepts a campaign config file or standalone CLI flags. When both are provided, CLI flags override config values.
 
 ```bash
 smitebot doctor --aflpp-path ~/AFLplusplus
@@ -95,7 +95,11 @@ smitebot doctor campaign.toml --json
 smitebot doctor campaign.toml --aflpp-path ~/other-aflpp
 ```
 
-## Checks
+- `--aflpp-path`: Path to AFL++ source tree. Required when no config file is provided.
+- `--smite-dir`: Path to the smite repository root; overrides the config value.
+- `--json`: Emit machine-readable JSON output.
+
+Checks performed:
 
 - `x86_64` architecture
 - CPU virtualization enabled (`vmx` or `svm`)
@@ -103,14 +107,12 @@ smitebot doctor campaign.toml --aflpp-path ~/other-aflpp
 - Docker daemon is reachable (`docker version`)
 - AFL++ built with Nyx support (`libnyx.so` under `--aflpp-path`)
 - VMware backdoor is enabled
-- AFL++ tools (`afl-fuzz`, `afl-cmin`, `afl-tmin`, `afl-whatsup`) are executable under `--aflpp-path`
-- Required host tools (`bash`, `python`, `python3`)
+- AFL++ tools (`afl-fuzz`, `afl-cmin`, `afl-tmin`, `afl-whatsup`) are executable
+- Required host tools (`bash`, `python`, `python3`, `tmux`)
 - Required Smite scripts are present and executable
 - Required workload Dockerfiles are present
 
-## JSON output
-
-By default, output is in a human readable format. The `--json` flag changes output to structured JSON:
+JSON output example:
 
 ```json
 {

--- a/smitebot/src/commands/build.rs
+++ b/smitebot/src/commands/build.rs
@@ -206,6 +206,7 @@ mod tests {
             image: None,
             afl_env: HashMap::new(),
             afl_flags: Vec::new(),
+            tmux_session: None,
         }
     }
 

--- a/smitebot/src/commands/doctor.rs
+++ b/smitebot/src/commands/doctor.rs
@@ -15,8 +15,8 @@ use crate::utils::{find_in_path, is_executable};
 /// AFL++ binaries required for campaign execution and corpus minimization.
 const AFL_TOOLS: &[&str] = &["afl-fuzz", "afl-cmin", "afl-tmin", "afl-whatsup"];
 
-/// Host tools required by Smite helper scripts.
-const HOST_TOOLS: &[&str] = &["bash", "python", "python3"];
+/// Host tools required for campaign operations.
+const HOST_TOOLS: &[&str] = &["bash", "python", "python3", "tmux"];
 
 /// Repository scripts required by doctor and upcoming orchestration commands.
 const REQUIRED_SCRIPTS: &[&str] = &[
@@ -394,6 +394,7 @@ mod tests {
             image: None,
             afl_env: HashMap::new(),
             afl_flags: Vec::new(),
+            tmux_session: None,
         }
     }
 

--- a/smitebot/src/commands/start.rs
+++ b/smitebot/src/commands/start.rs
@@ -1,13 +1,12 @@
 //! Campaign launch orchestration.
 //!
 //! Builds the Docker image, prepares the Nyx sharedir, spawns parallel
-//! `afl-fuzz` processes in the background, and persists campaign state so
+//! `afl-fuzz` processes inside a tmux session, and persists campaign state so
 //! that `stop` and `status` can manage the running campaign later.
 
 use std::fs;
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -16,12 +15,23 @@ use clap::Args;
 use crate::commands::build::{BuildInputs, run_build};
 use crate::config::CampaignConfig;
 use crate::state::{CampaignState, RunnerState, Status};
+use crate::tmux;
 
-/// Maximum time to wait for all runners to report non-zero `execs_per_sec`.
-const STARTUP_TIMEOUT: Duration = Duration::from_mins(5);
+/// Safety ceiling for startup verification.
+///
+/// Genuine launch failures are caught immediately when a runner's tmux window
+/// dies (see `verify_startup`), so this only bounds an alive-but-hung runner.
+/// Nyx seed calibration can take several minutes because each exec restores a
+/// VM snapshot, so the ceiling is deliberately generous; its exact value is not
+/// load-bearing — it only prevents an indefinite hang. Kept comfortably above a
+/// measured fresh start (~45s) so a large seed corpus is not falsely failed.
+const VERIFY_TIMEOUT: Duration = Duration::from_mins(10);
 
 /// How often to poll `fuzzer_stats` files during startup verification.
-const STARTUP_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const VERIFY_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// AFL++ power schedules for round-robin distribution across runners.
+const POWER_SCHEDULES: &[&str] = &["fast", "explore", "coe", "lin", "quad", "exploit", "rare"];
 
 /// Command handler for `smitebot start`.
 pub struct StartCommand;
@@ -52,6 +62,34 @@ impl StartCommand {
             return false;
         }
 
+        if !tmux::is_available() {
+            log::error!("tmux is not available; install it or run `smitebot doctor` for details");
+            return false;
+        }
+
+        let campaign_id = config.campaign_id();
+        let tmux_session = config
+            .tmux_session
+            .clone()
+            .unwrap_or_else(|| campaign_id.clone());
+
+        if tmux::session_exists(&tmux_session) {
+            log::error!(
+                "tmux session '{tmux_session}' already exists — is another campaign running?"
+            );
+            return false;
+        }
+
+        if let Some(stats) = existing_campaign_runner(&config.output_dir, config.runners) {
+            log::error!(
+                "output_dir already holds a campaign ({}); smitebot start only \
+                 begins fresh campaigns and does not resume — remove the directory \
+                 or set a different output_dir",
+                stats.display()
+            );
+            return false;
+        }
+
         let image = config.image_tag();
 
         log::info!("building Docker image {image}");
@@ -77,7 +115,6 @@ impl StartCommand {
             }
         };
 
-        let campaign_id = config.campaign_id();
         let Some(runs_dir) = CampaignState::runs_dir() else {
             log::error!("unable to determine home directory");
             return false;
@@ -94,7 +131,14 @@ impl StartCommand {
             return false;
         };
 
-        let mut state = CampaignState::new(campaign_id, &config, image, image_digest, git_hash);
+        let mut state = CampaignState::new(
+            campaign_id,
+            &config,
+            image,
+            image_digest,
+            git_hash,
+            tmux_session,
+        );
 
         if let Err(e) = state.save(&state_path) {
             log::error!("{e}");
@@ -111,6 +155,12 @@ impl StartCommand {
 
         log::info!("campaign {} is running", state.id);
         log::info!("state saved to {}", state_path.display());
+
+        log::info!("attaching to tmux session '{}'", state.tmux_session);
+        if let Err(e) = tmux::attach(&state.tmux_session) {
+            log::warn!("failed to attach to tmux session: {e}");
+        }
+
         true
     }
 }
@@ -145,59 +195,82 @@ fn setup_nyx(config: &CampaignConfig, image: &str) -> bool {
     true
 }
 
-/// Spawns all runners, verifies they reach non-zero `execs_per_sec`, and updates
-/// campaign state. Runner PIDs are persisted so `smitebot stop` can terminate them.
+/// Spawns all runners inside a tmux session, verifies they produce
+/// `fuzzer_stats`, and updates campaign state with PIDs.
 fn launch_runners(
     config: &CampaignConfig,
     seed_dir: &Path,
     state: &mut CampaignState,
     state_path: &Path,
 ) -> bool {
-    log::info!("starting {} runners", config.runners);
+    let session = &state.tmux_session;
+    log::info!(
+        "starting {} runners in tmux session '{session}'",
+        config.runners
+    );
 
+    let testcache_mb = testcache_size_mb();
     let mut runners = Vec::new();
-    let mut children = Vec::new();
+
     for id in 0..config.runners {
-        match spawn_runner(config, id, seed_dir) {
-            Ok((runner, child)) => {
-                log::info!("spawned runner {id} (pid {})", runner.pid);
-                runners.push(runner);
-                children.push(child);
-            }
-            Err(e) => {
-                log::error!("failed to spawn runner {id}: {e}");
-                kill_runners(&runners);
-                state.status = Status::Failed;
-                state.runners = runners;
-                if let Err(e) = state.save(state_path) {
-                    log::warn!("failed to save state: {e}");
-                }
-                return false;
-            }
+        let cmd = build_runner_shell_cmd(config, id, seed_dir, testcache_mb);
+        let window_name = runner_window_name(id);
+
+        let result = if id == 0 {
+            tmux::create_session(session, &window_name, &cmd)
+        } else {
+            tmux::add_window(session, &window_name, &cmd)
+        };
+
+        if let Err(e) = result {
+            log::error!("failed to create tmux window for runner {id}: {e}");
+            state.runners = runners;
+            fail_campaign(state, state_path);
+            return false;
         }
+
+        runners.push(RunnerState { id, pid: None });
     }
 
     state.runners = runners;
 
-    // Persist PIDs before the lengthy verify_startup poll so smitebot stop
-    // can find the runners if we crash during verification.
     if let Err(e) = state.save(state_path) {
         log::warn!("failed to save state: {e}");
     }
 
-    log::info!("waiting for runners to initialize");
-    if !verify_startup(&config.output_dir, &state.runners, &mut children) {
-        log::error!("not all runners started within the timeout");
-        kill_runners(&state.runners);
-        state.status = Status::Failed;
-        if let Err(e) = state.save(state_path) {
-            log::warn!("failed to save state: {e}");
-        }
+    log::info!("verifying runners started");
+    if !verify_startup(
+        session,
+        &config.output_dir,
+        &mut state.runners,
+        VERIFY_TIMEOUT,
+    ) {
+        // verify_startup has already logged the specific reason per runner
+        // (window died, or ceiling reached).
+        log::error!("one or more runners failed to start");
+        fail_campaign(state, state_path);
         return false;
     }
 
     state.status = Status::Running;
     true
+}
+
+/// Marks the campaign as failed, logs instructions to inspect the tmux session,
+/// and persists the updated state.
+fn fail_campaign(state: &mut CampaignState, state_path: &Path) {
+    if !state.runners.is_empty() {
+        log::info!(
+            "inspect tmux session '{}' for error output, \
+             then: tmux kill-session -t {}",
+            state.tmux_session,
+            state.tmux_session,
+        );
+    }
+    state.status = Status::Failed;
+    if let Err(e) = state.save(state_path) {
+        log::warn!("failed to save state: {e}");
+    }
 }
 
 /// Ensures a seed directory exists for AFL++, creating a minimal corpus if needed.
@@ -216,104 +289,96 @@ fn ensure_seed_dir(config: &CampaignConfig) -> std::io::Result<PathBuf> {
     Ok(seed_dir)
 }
 
-/// Spawns a single `afl-fuzz` process in its own process group.
-///
-/// The child is intentionally orphaned so the campaign outlives the `smitebot`
-/// process. The `stop` command uses the persisted PID to terminate it later.
-fn spawn_runner(
-    config: &CampaignConfig,
-    id: u16,
-    seed_dir: &Path,
-) -> std::io::Result<(RunnerState, Child)> {
-    let afl_fuzz = config.aflpp_path.join("afl-fuzz");
-    let name = id.to_string();
-
-    let mut cmd = Command::new(&afl_fuzz);
-    cmd.arg("-Y");
-    cmd.arg("-i").arg(seed_dir);
-    cmd.arg("-o").arg(&config.output_dir);
-
-    // Runner 0 is the primary (-M), all others are secondaries (-S).
-    if id == 0 {
-        cmd.arg("-M").arg(&name);
-    } else {
-        cmd.arg("-S").arg(&name);
-    }
-
-    for flag in &config.afl_flags {
-        cmd.arg(flag);
-    }
-
-    cmd.arg("--").arg(&config.sharedir);
-
-    // IR mutator defaults first so user afl_env can override them.
-    for (key, val) in ir_mutator_envs(config) {
-        cmd.env(key, val);
-    }
-
-    for (key, val) in &config.afl_env {
-        cmd.env(key, val);
-    }
-
-    cmd.process_group(0);
-
-    let child = cmd.spawn()?;
-    let state = RunnerState {
-        id,
-        pid: child.id(),
-    };
-    Ok((state, child))
+/// tmux window name for a runner, matching the name used when launched.
+fn runner_window_name(id: u16) -> String {
+    format!("runner-{id}")
 }
 
-/// Polls for `fuzzer_stats` files to confirm all runners have started executing.
+/// Returns the path of the first runner `fuzzer_stats` already present under
+/// `output_dir`, indicating a prior campaign's output.
 ///
-/// AFL++ creates `<output_dir>/<runner_name>/fuzzer_stats` once fuzzing begins.
-/// We verify `execs_per_sec` is non-zero to confirm actual execution, not just
-/// file creation.
-fn verify_startup(output_dir: &Path, runners: &[RunnerState], children: &mut [Child]) -> bool {
-    let deadline = Instant::now() + STARTUP_TIMEOUT;
+/// `start` begins fresh campaigns only. A leftover `fuzzer_stats` would make
+/// `verify_startup` read a stale PID and wrongly report a runner as started, so
+/// its presence is rejected up front. Resuming an existing output dir is not yet
+/// supported. AFL++ writes each runner's output to `output_dir/<id>` (see
+/// `RunnerState::name`).
+fn existing_campaign_runner(output_dir: &Path, runners: u16) -> Option<PathBuf> {
+    (0..runners)
+        .map(|id| output_dir.join(id.to_string()).join("fuzzer_stats"))
+        .find(|p| p.exists())
+}
 
-    while Instant::now() < deadline {
-        let all_started = runners
-            .iter()
-            .all(|r| has_nonzero_execs(&output_dir.join(r.name()).join("fuzzer_stats")));
+/// Polls for `fuzzer_stats` files to confirm all runners have started,
+/// extracting the `fuzzer_pid` from each.
+///
+/// `fuzzer_stats` is only written after AFL++ finishes calibrating every seed,
+/// which under Nyx can take minutes for a large corpus, so a plain wall-clock
+/// timeout produces false negatives. Instead, a runner whose tmux window has
+/// died before producing `fuzzer_stats` is reported as a launch failure
+/// immediately; the `timeout` only bounds a runner that stays alive but never
+/// starts fuzzing. `execute` rejects a pre-populated `output_dir` up front (see
+/// `existing_campaign_runner`), so a `fuzzer_stats` appearing here always
+/// belongs to this run.
+fn verify_startup(
+    session: &str,
+    output_dir: &Path,
+    runners: &mut [RunnerState],
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
 
-        if all_started {
-            return true;
-        }
-
-        for (child, runner) in children.iter_mut().zip(runners.iter()) {
-            match child.try_wait() {
-                Ok(Some(_)) => {
-                    log::error!(
-                        "runner {} (pid {}) died during startup",
-                        runner.id,
-                        runner.pid
-                    );
-                    return false;
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    log::error!(
-                        "failed to check runner {} (pid {}): {e}",
-                        runner.id,
-                        runner.pid
-                    );
-                    return false;
-                }
+    loop {
+        let mut all_ready = true;
+        for runner in runners.iter_mut() {
+            if runner.pid.is_some() {
+                continue;
+            }
+            let stats_path = output_dir.join(runner.name()).join("fuzzer_stats");
+            if let Some(pid) = read_fuzzer_pid(&stats_path) {
+                runner.pid = Some(pid);
+            } else {
+                all_ready = false;
             }
         }
 
-        thread::sleep(STARTUP_POLL_INTERVAL);
+        if all_ready {
+            return true;
+        }
+
+        // A runner whose window exited before writing fuzzer_stats failed to
+        // launch; report it now rather than waiting out the ceiling.
+        match tmux::dead_windows(session) {
+            Ok(dead) => {
+                let mut failed = false;
+                for runner in runners.iter().filter(|r| r.pid.is_none()) {
+                    if dead.contains(&runner_window_name(runner.id)) {
+                        log::error!(
+                            "runner {} exited before producing fuzzer_stats; \
+                             inspect window '{}' in tmux session '{session}'",
+                            runner.id,
+                            runner_window_name(runner.id),
+                        );
+                        failed = true;
+                    }
+                }
+                if failed {
+                    return false;
+                }
+            }
+            Err(e) => log::debug!("could not query tmux window liveness: {e}"),
+        }
+
+        if Instant::now() >= deadline {
+            break;
+        }
+        thread::sleep(VERIFY_POLL_INTERVAL);
     }
 
-    for runner in runners {
-        let stats = output_dir.join(runner.name()).join("fuzzer_stats");
-        if !has_nonzero_execs(&stats) {
+    for runner in runners.iter() {
+        if runner.pid.is_none() {
             log::error!(
-                "runner {} (pid {}) did not reach non-zero execs_per_sec",
-                runner.id,
-                runner.pid
+                "runner {} did not produce fuzzer_stats within timeout",
+                runner.id
             );
         }
     }
@@ -321,34 +386,138 @@ fn verify_startup(output_dir: &Path, runners: &[RunnerState], children: &mut [Ch
     false
 }
 
-/// Returns true if the `fuzzer_stats` file exists and reports non-zero `execs_per_sec`.
-fn has_nonzero_execs(path: &Path) -> bool {
-    let Ok(contents) = fs::read_to_string(path) else {
-        return false;
-    };
-    contents.lines().any(|line| {
-        line.trim_start().starts_with("execs_per_sec")
-            && line
-                .split(':')
-                .nth(1)
-                .and_then(|v| v.trim().parse::<f64>().ok())
-                .is_some_and(|n| n > 0.0)
+/// Reads the `fuzzer_pid` field from a `fuzzer_stats` file.
+fn read_fuzzer_pid(path: &Path) -> Option<u32> {
+    let contents = fs::read_to_string(path).ok()?;
+    contents
+        .lines()
+        .find(|l| l.trim_start().starts_with("fuzzer_pid"))
+        .and_then(|l| l.split(':').nth(1))
+        .and_then(|v| v.trim().parse().ok())
+}
+
+/// Returns the strategy flags and env vars for a specific runner.
+///
+/// Distribution is deterministic by runner index. Runner 0 is primary.
+fn runner_strategy(
+    runner_id: u16,
+    runner_count: u16,
+    testcache_mb: Option<u64>,
+) -> (Vec<String>, Vec<(String, String)>) {
+    let mut flags = Vec::new();
+    let mut envs = Vec::new();
+
+    let schedule = POWER_SCHEDULES[runner_id as usize % POWER_SCHEDULES.len()];
+    flags.extend(["-p".to_string(), schedule.to_string()]);
+
+    if runner_id == 0 {
+        envs.push(("AFL_FINAL_SYNC".to_string(), "1".to_string()));
+    }
+
+    // AFL++ docs: the strategy knobs below apply to "the other secondaries",
+    // not the primary. See fuzzing_in_depth.md §c "Using multiple cores".
+    if runner_id > 0 {
+        // -a binary on ~70% of secondary runners.
+        let secondary_count = runner_count.saturating_sub(1) as usize;
+        let binary_count = (secondary_count * 7).div_ceil(10);
+        if ((runner_id - 1) as usize) < binary_count {
+            flags.extend(["-a".to_string(), "binary".to_string()]);
+        }
+
+        // AFL_DISABLE_TRIM on ~60% of secondary runners.
+        let trim_count = (secondary_count * 6).div_ceil(10);
+        if ((runner_id - 1) as usize) < trim_count {
+            envs.push(("AFL_DISABLE_TRIM".to_string(), "1".to_string()));
+        }
+    }
+
+    // AFL_IMPORT_FIRST loads test cases from other fuzzers first, but the
+    // AFL++ docs warn it "can slow down the start ... if you have many fuzzers."
+    // 16 is a heuristic; AFL++ docs don't specify a threshold.
+    if runner_count < 16 {
+        envs.push(("AFL_IMPORT_FIRST".to_string(), "1".to_string()));
+    }
+
+    if let Some(size) = testcache_mb {
+        envs.push(("AFL_TESTCACHE_SIZE".to_string(), size.to_string()));
+    }
+
+    (flags, envs)
+}
+
+/// Returns a suggested `AFL_TESTCACHE_SIZE` in MB based on available RAM.
+fn testcache_size_mb() -> Option<u64> {
+    let contents = fs::read_to_string("/proc/meminfo").ok()?;
+    let free_mb = contents
+        .lines()
+        .find(|l| l.starts_with("MemAvailable:"))
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|kb| kb / 1024)?;
+
+    // AFL++ docs recommend 50–500 MB. Thresholds are conservative since
+    // multiple runners share the same machine.
+    Some(if free_mb > 32_000 {
+        500
+    } else if free_mb > 8_000 {
+        250
+    } else {
+        50
     })
 }
 
-/// Kills all runner process groups via SIGKILL.
-fn kill_runners(runners: &[RunnerState]) {
-    for runner in runners {
-        let pgid = format!("-{}", runner.pid);
-        match Command::new("kill").args(["-9", &pgid]).status() {
-            Ok(status) if status.success() => {
-                log::info!("killed runner {} (pgid {})", runner.id, runner.pid);
-            }
-            _ => {
-                log::warn!("failed to kill runner {} (pgid {})", runner.id, runner.pid);
-            }
-        }
+/// Wraps a string in single quotes for safe shell interpolation.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Builds the full shell command string for a single runner to be run by tmux.
+fn build_runner_shell_cmd(
+    config: &CampaignConfig,
+    id: u16,
+    seed_dir: &Path,
+    testcache_mb: Option<u64>,
+) -> String {
+    let afl_fuzz = config.aflpp_path.join("afl-fuzz");
+    let (strategy_flags, strategy_envs) = runner_strategy(id, config.runners, testcache_mb);
+
+    // Env precedence: strategy → IR mutator → user afl_env (last wins).
+    let mut envs = strategy_envs;
+    for (k, v) in ir_mutator_envs(config) {
+        envs.push((k.to_string(), v));
     }
+    for (k, v) in &config.afl_env {
+        envs.push((k.clone(), v.clone()));
+    }
+
+    let mut parts: Vec<String> = envs
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, shell_quote(v)))
+        .collect();
+
+    parts.push("exec".to_string());
+    parts.push(shell_quote(&afl_fuzz.display().to_string()));
+    parts.extend([
+        "-Y".to_string(),
+        "-i".to_string(),
+        shell_quote(&seed_dir.display().to_string()),
+        "-o".to_string(),
+        shell_quote(&config.output_dir.display().to_string()),
+        if id == 0 { "-M" } else { "-S" }.to_string(),
+        id.to_string(),
+    ]);
+
+    for flag in &strategy_flags {
+        parts.push(shell_quote(flag));
+    }
+    for flag in &config.afl_flags {
+        parts.push(shell_quote(flag));
+    }
+
+    parts.push("--".to_string());
+    parts.push(shell_quote(&config.sharedir.display().to_string()));
+
+    parts.join(" ")
 }
 
 /// Returns the environment variables needed for the smite-ir custom mutator.
@@ -428,75 +597,248 @@ mod tests {
     use super::*;
 
     #[test]
-    fn verify_startup_detects_fuzzer_stats() {
+    fn shell_quote_wraps_in_single_quotes() {
+        assert_eq!(shell_quote("hello"), "'hello'");
+    }
+
+    #[test]
+    fn shell_quote_escapes_embedded_quotes() {
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn read_fuzzer_pid_parses_pid() {
         let dir = tempfile::tempdir().unwrap();
-        let runners = vec![
-            RunnerState { id: 0, pid: 100 },
-            RunnerState { id: 1, pid: 101 },
+        let stats = dir.path().join("fuzzer_stats");
+        fs::write(
+            &stats,
+            "start_time        : 1718000000\nfuzzer_pid        : 12345\nexecs_per_sec     : 0.00\n",
+        )
+        .unwrap();
+        assert_eq!(read_fuzzer_pid(&stats), Some(12345));
+    }
+
+    #[test]
+    fn read_fuzzer_pid_returns_none_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_fuzzer_pid(&dir.path().join("missing")), None);
+    }
+
+    #[test]
+    fn verify_startup_reads_pids_from_fuzzer_stats() {
+        let dir = tempfile::tempdir().unwrap();
+        let stats_content =
+            "start_time        : 1718000000\nfuzzer_pid        : 42\nexecs_per_sec     : 0.00\n";
+
+        let mut runners = vec![
+            RunnerState { id: 0, pid: None },
+            RunnerState { id: 1, pid: None },
         ];
 
-        let stats_content = "start_time        : 1718000000\nexecs_per_sec     : 531.23\n";
         for runner in &runners {
             let runner_dir = dir.path().join(runner.name());
             fs::create_dir_all(&runner_dir).unwrap();
             fs::write(runner_dir.join("fuzzer_stats"), stats_content).unwrap();
         }
 
-        let mut children: Vec<Child> = (0..2)
-            .map(|_| Command::new("sleep").arg("60").spawn().unwrap())
+        // All stats are present on the first poll.
+        assert!(verify_startup(
+            "no-such-session",
+            dir.path(),
+            &mut runners,
+            Duration::from_secs(5),
+        ));
+        assert_eq!(runners[0].pid, Some(42));
+        assert_eq!(runners[1].pid, Some(42));
+    }
+
+    #[test]
+    fn verify_startup_returns_false_when_stats_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut runners = vec![RunnerState { id: 0, pid: None }];
+
+        // No fuzzer_stats and no live tmux session — the ceiling is hit and the
+        // runner reported as unstarted. A near-zero timeout keeps the test fast.
+        assert!(!verify_startup(
+            "no-such-session",
+            dir.path(),
+            &mut runners,
+            Duration::from_millis(1),
+        ));
+        assert!(runners[0].pid.is_none());
+    }
+
+    #[test]
+    fn existing_campaign_runner_detects_leftover_fuzzer_stats() {
+        let dir = tempfile::tempdir().unwrap();
+        // A prior run of the secondary left fuzzer_stats behind.
+        let runner_dir = dir.path().join("1");
+        fs::create_dir_all(&runner_dir).unwrap();
+        fs::write(runner_dir.join("fuzzer_stats"), "fuzzer_pid : 7\n").unwrap();
+
+        assert_eq!(
+            existing_campaign_runner(dir.path(), 2),
+            Some(runner_dir.join("fuzzer_stats"))
+        );
+    }
+
+    #[test]
+    fn existing_campaign_runner_none_for_fresh_output_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        // Empty output dir (and one with only the synthesized .seeds) is fresh.
+        assert_eq!(existing_campaign_runner(dir.path(), 4), None);
+    }
+
+    #[test]
+    fn runner_strategy_primary_gets_final_sync() {
+        let (flags, envs) = runner_strategy(0, 8, None);
+        assert!(envs.iter().any(|(k, v)| k == "AFL_FINAL_SYNC" && v == "1"));
+        assert!(flags.contains(&"-p".to_string()));
+    }
+
+    #[test]
+    fn runner_strategy_secondary_no_final_sync() {
+        let (_, envs) = runner_strategy(1, 8, None);
+        assert!(!envs.iter().any(|(k, _)| k == "AFL_FINAL_SYNC"));
+    }
+
+    #[test]
+    fn runner_strategy_cycles_power_schedules() {
+        let schedules: Vec<String> = (0..7)
+            .map(|id| {
+                let (flags, _) = runner_strategy(id, 8, None);
+                flags[1].clone()
+            })
             .collect();
-
-        assert!(verify_startup(dir.path(), &runners, &mut children));
-
-        for mut child in children {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
+        assert_eq!(
+            schedules,
+            ["fast", "explore", "coe", "lin", "quad", "exploit", "rare"]
+        );
     }
 
     #[test]
-    fn verify_startup_detects_dead_runner() {
-        let dir = tempfile::tempdir().unwrap();
-        let runners = vec![RunnerState { id: 0, pid: 100 }];
-
-        // No fuzzer_stats file — runner hasn't started yet.
-        // Child exits immediately, so try_wait should detect death.
-        let mut children = vec![Command::new("false").spawn().unwrap()];
-
-        // Give the process a moment to exit.
-        thread::sleep(Duration::from_millis(50));
-
-        assert!(!verify_startup(dir.path(), &runners, &mut children));
+    fn runner_strategy_wraps_schedules_past_seven() {
+        let (flags, _) = runner_strategy(7, 8, None);
+        assert_eq!(flags[1], "fast");
     }
 
     #[test]
-    fn has_nonzero_execs_rejects_zero() {
+    fn runner_strategy_binary_hint_on_70_percent_of_secondaries() {
+        // 10 runners: 1 primary + 9 secondary. 70% of 9 = 7 (ceil).
+        let binary_count = (0..10u16)
+            .filter(|&id| {
+                let (flags, _) = runner_strategy(id, 10, None);
+                flags.contains(&"-a".to_string())
+            })
+            .count();
+        assert_eq!(binary_count, 7);
+
+        // Primary never gets -a binary.
+        let (flags, _) = runner_strategy(0, 10, None);
+        assert!(!flags.contains(&"-a".to_string()));
+    }
+
+    #[test]
+    fn runner_strategy_disable_trim_on_60_percent_of_secondaries() {
+        // 10 runners: 1 primary + 9 secondary. 60% of 9 = 6 (ceil).
+        let trim_count = (0..10u16)
+            .filter(|&id| {
+                let (_, envs) = runner_strategy(id, 10, None);
+                envs.iter().any(|(k, _)| k == "AFL_DISABLE_TRIM")
+            })
+            .count();
+        assert_eq!(trim_count, 6);
+
+        // Primary never gets AFL_DISABLE_TRIM.
+        let (_, envs) = runner_strategy(0, 10, None);
+        assert!(!envs.iter().any(|(k, _)| k == "AFL_DISABLE_TRIM"));
+    }
+
+    #[test]
+    fn runner_strategy_import_first_under_16() {
+        let (_, envs) = runner_strategy(0, 8, None);
+        assert!(envs.iter().any(|(k, _)| k == "AFL_IMPORT_FIRST"));
+
+        let (_, envs) = runner_strategy(0, 16, None);
+        assert!(!envs.iter().any(|(k, _)| k == "AFL_IMPORT_FIRST"));
+    }
+
+    #[test]
+    fn runner_strategy_includes_testcache() {
+        let (_, envs) = runner_strategy(0, 8, Some(500));
+        assert!(
+            envs.iter()
+                .any(|(k, v)| k == "AFL_TESTCACHE_SIZE" && v == "500")
+        );
+    }
+
+    #[test]
+    fn build_runner_shell_cmd_primary() {
         let dir = tempfile::tempdir().unwrap();
-        let stats = dir.path().join("fuzzer_stats");
+        let config = sample_config(dir.path());
+        let seed_dir = dir.path().join("seeds");
+
+        let cmd = build_runner_shell_cmd(&config, 0, &seed_dir, Some(500));
+
+        assert!(cmd.contains("exec"));
+        assert!(cmd.contains("afl-fuzz"));
+        assert!(cmd.contains("-Y"));
+        assert!(cmd.contains("-M"));
+        assert!(cmd.contains("AFL_FINAL_SYNC='1'"));
+        assert!(cmd.contains("AFL_TESTCACHE_SIZE='500'"));
+        assert!(cmd.contains("-p"));
+    }
+
+    #[test]
+    fn build_runner_shell_cmd_secondary() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = sample_config(dir.path());
+        let seed_dir = dir.path().join("seeds");
+
+        let cmd = build_runner_shell_cmd(&config, 1, &seed_dir, None);
+
+        assert!(cmd.contains("-S"));
+        assert!(!cmd.contains("-M"));
+        assert!(!cmd.contains("AFL_FINAL_SYNC"));
+    }
+
+    #[test]
+    fn build_runner_shell_cmd_respects_env_precedence() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("campaign.toml");
         fs::write(
-            &stats,
-            "start_time        : 1718000000\nexecs_per_sec     : 0.00\n",
+            &config_path,
+            format!(
+                r#"
+target = "lnd"
+scenario = "encrypted_bytes"
+aflpp_path = "{}"
+smite_dir = "{}"
+runners = 2
+output_dir = "{}"
+sharedir = "{}"
+
+[afl_env]
+AFL_DISABLE_TRIM = "0"
+"#,
+                dir.path().display(),
+                dir.path().display(),
+                dir.path().join("out").display(),
+                dir.path().join("nyx").display(),
+            ),
         )
         .unwrap();
-        assert!(!has_nonzero_execs(&stats));
-    }
+        let config = CampaignConfig::load(&config_path).unwrap();
+        let seed_dir = dir.path().join("seeds");
 
-    #[test]
-    fn has_nonzero_execs_rejects_missing_file() {
-        let dir = tempfile::tempdir().unwrap();
-        assert!(!has_nonzero_execs(&dir.path().join("missing")));
-    }
+        // Use secondary runner (id=1) because primary doesn't get AFL_DISABLE_TRIM.
+        let cmd = build_runner_shell_cmd(&config, 1, &seed_dir, None);
 
-    #[test]
-    fn has_nonzero_execs_accepts_positive_value() {
-        let dir = tempfile::tempdir().unwrap();
-        let stats = dir.path().join("fuzzer_stats");
-        fs::write(
-            &stats,
-            "start_time        : 1718000000\nexecs_per_sec     : 531.23\n",
-        )
-        .unwrap();
-        assert!(has_nonzero_execs(&stats));
+        // Strategy sets AFL_DISABLE_TRIM='1' first, user override AFL_DISABLE_TRIM='0' last.
+        // Both appear; shell uses last assignment.
+        let first_pos = cmd.find("AFL_DISABLE_TRIM='1'").unwrap();
+        let last_pos = cmd.find("AFL_DISABLE_TRIM='0'").unwrap();
+        assert!(last_pos > first_pos);
     }
 
     #[test]
@@ -604,7 +946,12 @@ sharedir = "{}"
     #[test]
     fn ir_mutator_envs_empty_for_non_ir_scenario() {
         let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("campaign.toml");
+        let config = sample_config(dir.path());
+        assert!(ir_mutator_envs(&config).is_empty());
+    }
+
+    fn sample_config(dir: &Path) -> CampaignConfig {
+        let config_path = dir.join("campaign.toml");
         fs::write(
             &config_path,
             format!(
@@ -613,19 +960,17 @@ target = "lnd"
 scenario = "encrypted_bytes"
 aflpp_path = "{}"
 smite_dir = "{}"
-runners = 1
+runners = 8
 output_dir = "{}"
 sharedir = "{}"
 "#,
-                dir.path().display(),
-                dir.path().display(),
-                dir.path().join("out").display(),
-                dir.path().join("nyx").display(),
+                dir.display(),
+                dir.display(),
+                dir.join("out").display(),
+                dir.join("nyx").display(),
             ),
         )
         .unwrap();
-        let config = CampaignConfig::load(&config_path).unwrap();
-
-        assert!(ir_mutator_envs(&config).is_empty());
+        CampaignConfig::load(&config_path).unwrap()
     }
 }

--- a/smitebot/src/config.rs
+++ b/smitebot/src/config.rs
@@ -38,6 +38,8 @@ pub struct CampaignConfig {
     /// Extra CLI flags appended to the `afl-fuzz` command.
     #[serde(default)]
     pub afl_flags: Vec<String>,
+    /// Custom tmux session name; defaults to the campaign ID when absent.
+    pub tmux_session: Option<String>,
 }
 
 /// Lightning Network implementation to target.
@@ -83,6 +85,8 @@ pub enum ConfigError {
     EmptyScenario,
     #[error("image must not be empty when specified")]
     EmptyImage,
+    #[error("invalid tmux_session: {0}")]
+    InvalidTmuxSessionName(String),
 }
 
 impl CampaignConfig {
@@ -163,6 +167,23 @@ impl CampaignConfig {
         if self.image.as_ref().is_some_and(String::is_empty) {
             return Err(ConfigError::EmptyImage);
         }
+        if let Some(session) = &self.tmux_session {
+            if session.is_empty() {
+                return Err(ConfigError::InvalidTmuxSessionName(
+                    "must not be empty".to_string(),
+                ));
+            }
+            // tmux 3.6b and earlier silently replace ':', '.', and '#' with '_'
+            // in session names (https://github.com/tmux/tmux/commit/d339ab51).
+            // Reject these characters to avoid unexpected session names.
+            for c in [':', '.', '#'] {
+                if session.contains(c) {
+                    return Err(ConfigError::InvalidTmuxSessionName(format!(
+                        "contains '{c}': tmux 3.6b and earlier replace this character with '_' in session names"
+                    )));
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -209,6 +230,7 @@ sharedir = "/tmp/smite-nyx"
         assert_eq!(config.output_dir, PathBuf::from("/tmp/smite-out"));
         assert_eq!(config.sharedir, PathBuf::from("/tmp/smite-nyx"));
         assert!(config.image.is_none());
+        assert!(config.tmux_session.is_none());
     }
 
     #[test]
@@ -321,6 +343,68 @@ sharedir = "/tmp/smite-nyx"
 
         let err = CampaignConfig::load(&path).unwrap_err();
         assert!(matches!(err, ConfigError::EmptyImage));
+    }
+
+    #[test]
+    fn load_parses_tmux_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}tmux_session = \"my-campaign\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let config = CampaignConfig::load(&path).unwrap();
+        assert_eq!(config.tmux_session.as_deref(), Some("my-campaign"));
+    }
+
+    #[test]
+    fn load_rejects_empty_tmux_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}tmux_session = \"\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert_eq!(err.to_string(), "invalid tmux_session: must not be empty");
+    }
+
+    #[test]
+    fn load_rejects_tmux_session_with_colon() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}tmux_session = \"my:session\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid tmux_session: contains ':': tmux 3.6b and earlier replace \
+             this character with '_' in session names"
+        );
+    }
+
+    #[test]
+    fn load_rejects_tmux_session_with_dot() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}tmux_session = \"my.session\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid tmux_session: contains '.': tmux 3.6b and earlier replace \
+             this character with '_' in session names"
+        );
+    }
+
+    #[test]
+    fn load_rejects_tmux_session_with_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = format!("{VALID_CONFIG}tmux_session = \"my#session\"\n");
+        let path = write_config(dir.path(), &content);
+
+        let err = CampaignConfig::load(&path).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid tmux_session: contains '#': tmux 3.6b and earlier replace \
+             this character with '_' in session names"
+        );
     }
 
     #[test]

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -3,6 +3,7 @@
 mod commands;
 mod config;
 mod state;
+mod tmux;
 mod utils;
 
 use std::process::ExitCode;

--- a/smitebot/src/state.rs
+++ b/smitebot/src/state.rs
@@ -35,6 +35,8 @@ pub struct CampaignState {
     pub smite_git_hash: String,
     /// Unix timestamp (seconds since epoch) when the campaign started.
     pub start_time: u64,
+    /// Name of the tmux session hosting the campaign runners.
+    pub tmux_session: String,
     /// State of each AFL++ runner process.
     pub runners: Vec<RunnerState>,
 }
@@ -56,8 +58,9 @@ pub enum Status {
 pub struct RunnerState {
     /// Runner index (0 = primary, 1..N = secondary).
     pub id: u16,
-    /// Process ID of the afl-fuzz instance.
-    pub pid: u32,
+    /// Process ID of the afl-fuzz instance, read from `fuzzer_stats` after
+    /// startup verification.
+    pub pid: Option<u32>,
 }
 
 impl RunnerState {
@@ -93,6 +96,7 @@ impl CampaignState {
         image: String,
         image_digest: String,
         smite_git_hash: String,
+        tmux_session: String,
     ) -> Self {
         Self {
             id,
@@ -105,6 +109,7 @@ impl CampaignState {
             sharedir: config.sharedir.clone(),
             smite_git_hash,
             start_time: utils::epoch_secs(),
+            tmux_session,
             runners: Vec::new(),
         }
     }
@@ -157,9 +162,16 @@ mod tests {
             sharedir: PathBuf::from("/tmp/smite-nyx"),
             smite_git_hash: "deadbeef".to_string(),
             start_time: 1_749_465_600,
+            tmux_session: "lnd-encrypted_bytes-1_749_465_600".to_string(),
             runners: vec![
-                RunnerState { id: 0, pid: 1234 },
-                RunnerState { id: 1, pid: 1235 },
+                RunnerState {
+                    id: 0,
+                    pid: Some(1234),
+                },
+                RunnerState {
+                    id: 1,
+                    pid: Some(1235),
+                },
             ],
         }
     }
@@ -180,8 +192,9 @@ mod tests {
         assert_eq!(loaded.target, Target::Lnd);
         assert_eq!(loaded.scenario, "encrypted_bytes");
         assert_eq!(loaded.runners.len(), 2);
+        assert_eq!(loaded.tmux_session, state.tmux_session);
         assert_eq!(loaded.runners[0].name(), "0");
-        assert_eq!(loaded.runners[1].pid, 1235);
+        assert_eq!(loaded.runners[1].pid, Some(1235));
     }
 
     #[test]
@@ -231,6 +244,7 @@ sharedir = "/tmp/nyx"
             "smite-lnd-encrypted_bytes".to_string(),
             "sha256:abc123".to_string(),
             "deadbeef".to_string(),
+            "test-session".to_string(),
         );
 
         assert_eq!(state.status, Status::Starting);
@@ -239,6 +253,7 @@ sharedir = "/tmp/nyx"
         assert_eq!(state.image, "smite-lnd-encrypted_bytes");
         assert_eq!(state.image_digest, "sha256:abc123");
         assert_eq!(state.smite_git_hash, "deadbeef");
+        assert_eq!(state.tmux_session, "test-session");
         assert!(state.runners.is_empty());
     }
 

--- a/smitebot/src/tmux.rs
+++ b/smitebot/src/tmux.rs
@@ -1,0 +1,123 @@
+//! Thin wrapper around the tmux CLI for managing campaign sessions.
+
+use std::io;
+use std::process::{Command, Stdio};
+
+/// Returns `true` if `tmux` is installed and runnable.
+pub fn is_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Returns `true` if a tmux session with the given exact name exists.
+pub fn session_exists(name: &str) -> bool {
+    let target = format!("={name}");
+    Command::new("tmux")
+        .args(["has-session", "-t", &target])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Creates a new detached tmux session with one window running `shell_cmd`.
+///
+/// Sets `remain-on-exit` atomically so dead windows preserve error output
+/// even if the command exits immediately.
+pub fn create_session(name: &str, window_name: &str, shell_cmd: &str) -> io::Result<()> {
+    run_tmux(&[
+        "new-session",
+        "-d",
+        "-s",
+        name,
+        "-n",
+        window_name,
+        shell_cmd,
+        ";",
+        "set-option",
+        "-t",
+        name,
+        "remain-on-exit",
+        "on",
+    ])
+}
+
+/// Adds a new window running `shell_cmd` to an existing tmux session.
+///
+/// Sets `remain-on-exit` on the new window because session-level
+/// `remain-on-exit` does not propagate to windows created after the fact.
+pub fn add_window(session: &str, window_name: &str, shell_cmd: &str) -> io::Result<()> {
+    let target = format!("={session}");
+    run_tmux(&[
+        "new-window",
+        "-t",
+        &target,
+        "-n",
+        window_name,
+        shell_cmd,
+        ";",
+        "set-option",
+        "-w",
+        "remain-on-exit",
+        "on",
+    ])
+}
+
+/// Returns the names of windows in `session` whose command has exited.
+///
+/// Used during startup verification to tell a runner that failed to launch
+/// (its pane is dead) apart from one still calibrating (pane alive). Relies on
+/// `remain-on-exit`, which keeps dead windows queryable instead of destroying
+/// them. Window names are assumed free of spaces (they are `runner-<id>`).
+pub fn dead_windows(session: &str) -> io::Result<Vec<String>> {
+    let target = format!("={session}");
+    let output = Command::new("tmux")
+        .args([
+            "list-panes",
+            "-s",
+            "-t",
+            &target,
+            "-F",
+            "#{pane_dead} #{window_name}",
+        ])
+        .stderr(Stdio::null())
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "tmux list-panes failed for session {session}: {}",
+            output.status
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.strip_prefix("1 "))
+        .map(str::to_owned)
+        .collect())
+}
+
+/// Attaches to a session, using `switch-client` when already inside tmux.
+pub fn attach(session: &str) -> io::Result<()> {
+    let target = format!("={session}");
+    let cmd = if std::env::var_os("TMUX").is_some() {
+        "switch-client"
+    } else {
+        "attach-session"
+    };
+    run_tmux(&[cmd, "-t", &target])
+}
+
+fn run_tmux(args: &[&str]) -> io::Result<()> {
+    let status = Command::new("tmux").args(args).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "tmux {} failed: {status}",
+            args[0]
+        )))
+    }
+}


### PR DESCRIPTION

  ## Summary

  - Spawn each `afl-fuzz` runner in its own tmux window instead of invisible background processes, users see individual AFL++ TUIs, can attach/detach via `Ctrl-b d`, and reconnect over SSH
  - Distribute AFL++ power schedules, format hints, and env vars across runners (ported from AFL_Runner's `MultipleCores` mode) for campaign diversity instead of running N identical fuzzers
  - A `fuzzer_stats` older than launch (leftover in a reused `output_dir`) is ignored, so a stale PID is never recorded as a live runner.
  - On failure, preserve tmux session for inspection (`remain-on-exit`) instead of killing it


 ### Strategy distribution

 Round-robin power schedules; `-a binary` on ~70% of secondaries; `AFL_DISABLE_TRIM` on ~60%; `AFL_IMPORT_FIRST` when < 16 runners; `AFL_FINAL_SYNC` on the primary; testcache auto-sized from RAM. IR scenarios auto-inject the custom-mutator env vars. Optional `tmux_session` config key, validated on `CampaignConfig`.

  ## tmux session layout

  tmux session: "lnd-encrypted_bytes-1749465600"  (or custom name from campaign.toml)
    ├── window 0: "runner-0"  →  afl-fuzz -Y -M 0 ...
    ├── window 1: "runner-1"  →  afl-fuzz -Y -S 1 ...
    ├── window 2: "runner-2"  →  afl-fuzz -Y -S 2 ...
    └── ...

  Each runner command is built as a shell string with `exec` so afl-fuzz replaces the shell process directly. Environment variables are prepended as `KEY='val'` assignments, and paths are single-quote escaped.

  ## Features 

  - **One window per runner**, not panes — each runner gets the full AFL++ TUI
  - **Deterministic** flag distribution by runner index (no `rand` dependency)
  - Verification now polls two signals:
   **fresh `fuzzer_stats`** → runner started
   **dead tmux window** (`pane_dead`) → runner failed to launch, reported at once
   neither yet → still calibrating; keep polling to a generous 15-min ceiling that only bounds an alive-but-hung runner
  - **Don't kill session on failure** — `remain-on-exit` preserves error output for debugging;,user cleans up manually or via future `stop` command
  - **Session name collision** doubles as duplicate campaign guard  - Nested tmux handled: `switch-client` when `$TMUX` is set, `attach-session` otherwise
  - **No new dependencies** — tmux CLI called via `std::process::Command`
  
  Ref. #138  #70 