### PR TITLE
smite-ir: implement funding flow generator

### DIFF
--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -7,11 +7,13 @@
 
 mod channel_announcement;
 mod channel_update;
+mod funding_created;
 mod node_announcement;
 mod open_channel;
 
 pub use channel_announcement::ChannelAnnouncementGenerator;
 pub use channel_update::ChannelUpdateGenerator;
+pub use funding_created::FundingCreatedGenerator;
 pub use node_announcement::NodeAnnouncementGenerator;
 pub use open_channel::OpenChannelGenerator;
 
@@ -33,6 +35,7 @@ pub enum AnyGenerator {
     ChannelUpdate(ChannelUpdateGenerator),
     NodeAnnouncement(NodeAnnouncementGenerator),
     OpenChannel(OpenChannelGenerator),
+    FundingCreated(FundingCreatedGenerator),
 }
 
 impl AnyGenerator {
@@ -42,6 +45,7 @@ impl AnyGenerator {
         Self::ChannelUpdate(ChannelUpdateGenerator),
         Self::NodeAnnouncement(NodeAnnouncementGenerator),
         Self::OpenChannel(OpenChannelGenerator),
+        Self::FundingCreated(FundingCreatedGenerator),
     ];
 }
 
@@ -52,6 +56,7 @@ impl Generator for AnyGenerator {
             Self::ChannelUpdate(generator) => generator.generate(builder, rng),
             Self::NodeAnnouncement(generator) => generator.generate(builder, rng),
             Self::OpenChannel(generator) => generator.generate(builder, rng),
+            Self::FundingCreated(generator) => generator.generate(builder, rng),
         }
     }
 }

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -6,12 +6,14 @@
 //! `ProgramBuilder`.
 
 mod channel_announcement;
+mod channel_ready;
 mod channel_update;
 mod funding_created;
 mod node_announcement;
 mod open_channel;
 
 pub use channel_announcement::ChannelAnnouncementGenerator;
+pub use channel_ready::ChannelReadyGenerator;
 pub use channel_update::ChannelUpdateGenerator;
 pub use funding_created::FundingCreatedGenerator;
 pub use node_announcement::NodeAnnouncementGenerator;
@@ -36,6 +38,7 @@ pub enum AnyGenerator {
     NodeAnnouncement(NodeAnnouncementGenerator),
     OpenChannel(OpenChannelGenerator),
     FundingCreated(FundingCreatedGenerator),
+    ChannelReady(ChannelReadyGenerator),
 }
 
 impl AnyGenerator {
@@ -46,6 +49,7 @@ impl AnyGenerator {
         Self::NodeAnnouncement(NodeAnnouncementGenerator),
         Self::OpenChannel(OpenChannelGenerator),
         Self::FundingCreated(FundingCreatedGenerator),
+        Self::ChannelReady(ChannelReadyGenerator),
     ];
 }
 
@@ -57,6 +61,7 @@ impl Generator for AnyGenerator {
             Self::NodeAnnouncement(generator) => generator.generate(builder, rng),
             Self::OpenChannel(generator) => generator.generate(builder, rng),
             Self::FundingCreated(generator) => generator.generate(builder, rng),
+            Self::ChannelReady(generator) => generator.generate(builder, rng),
         }
     }
 }

--- a/smite-ir/src/generators.rs
+++ b/smite-ir/src/generators.rs
@@ -9,6 +9,7 @@ mod channel_announcement;
 mod channel_ready;
 mod channel_update;
 mod funding_created;
+mod funding_flow;
 mod node_announcement;
 mod open_channel;
 
@@ -16,6 +17,7 @@ pub use channel_announcement::ChannelAnnouncementGenerator;
 pub use channel_ready::ChannelReadyGenerator;
 pub use channel_update::ChannelUpdateGenerator;
 pub use funding_created::FundingCreatedGenerator;
+pub use funding_flow::FundingFlowGenerator;
 pub use node_announcement::NodeAnnouncementGenerator;
 pub use open_channel::OpenChannelGenerator;
 
@@ -39,6 +41,7 @@ pub enum AnyGenerator {
     OpenChannel(OpenChannelGenerator),
     FundingCreated(FundingCreatedGenerator),
     ChannelReady(ChannelReadyGenerator),
+    FundingFlow(FundingFlowGenerator),
 }
 
 impl AnyGenerator {
@@ -50,6 +53,7 @@ impl AnyGenerator {
         Self::OpenChannel(OpenChannelGenerator),
         Self::FundingCreated(FundingCreatedGenerator),
         Self::ChannelReady(ChannelReadyGenerator),
+        Self::FundingFlow(FundingFlowGenerator),
     ];
 }
 
@@ -62,6 +66,7 @@ impl Generator for AnyGenerator {
             Self::OpenChannel(generator) => generator.generate(builder, rng),
             Self::FundingCreated(generator) => generator.generate(builder, rng),
             Self::ChannelReady(generator) => generator.generate(builder, rng),
+            Self::FundingFlow(generator) => generator.generate(builder, rng),
         }
     }
 }

--- a/smite-ir/src/generators/channel_ready.rs
+++ b/smite-ir/src/generators/channel_ready.rs
@@ -1,0 +1,38 @@
+//! Generator for `channel_ready` message flow.
+
+use rand::{Rng, RngExt};
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::{Operation, VariableType};
+
+/// Generates a `channel_ready` -> `channel_ready` flow.
+///
+/// Emits instructions to:
+/// 1. Mine blocks to confirm the funding transaction.
+/// 2. Build and send `channel_ready`
+/// 3. Receive and parse counterparty's `channel_ready`
+#[derive(Clone, Copy)]
+pub struct ChannelReadyGenerator;
+
+impl Generator for ChannelReadyGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        // Mine blocks to confirm the funding transaction.
+        builder.append(Operation::MineBlocks(rng.random_range(1..=16)), &[]);
+
+        // Channel parameters.
+        let channel_id = builder.pick_variable(VariableType::ChannelId, rng);
+        let second_per_commitment_point = builder.generate_fresh(VariableType::Point, rng);
+        let short_channel_id = builder.generate_fresh(VariableType::ShortChannelId, rng);
+        let include_alias = rng.random();
+
+        // Build and send channel_ready.
+        builder.append(
+            Operation::SendChannelReady { include_alias },
+            &[channel_id, second_per_commitment_point, short_channel_id],
+        );
+
+        // Receive channel_ready.
+        builder.append(Operation::RecvChannelReady, &[]);
+    }
+}

--- a/smite-ir/src/generators/funding_created.rs
+++ b/smite-ir/src/generators/funding_created.rs
@@ -1,0 +1,57 @@
+//! Generator for `funding_created` message flow.
+
+use rand::Rng;
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::{Operation, VariableType};
+
+/// Generates a `funding_created` -> `funding_signed` flow.
+///
+/// Emits instructions to:
+/// 1. Create the BOLT 3 funding and commitment transaction
+/// 2. Build and send `funding_created`
+/// 3. Receive and parse `funding_signed`
+/// 4. Broadcast the funding transaction
+#[derive(Clone, Copy)]
+pub struct FundingCreatedGenerator;
+
+impl Generator for FundingCreatedGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        // Funding and commitment transaction keys and parameters.
+        let opener_funding_privkey = builder.pick_variable(VariableType::PrivateKey, rng);
+        let opener_funding_pubkey =
+            builder.append(Operation::DerivePoint, &[opener_funding_privkey]);
+        let acceptor_funding_pubkey = builder.pick_variable(VariableType::Point, rng);
+        let funding_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let feerate_per_kw = builder.pick_variable(VariableType::FeeratePerKw, rng);
+        let temporary_channel_id = builder.pick_variable(VariableType::ChannelId, rng);
+
+        // Create the BOLT 3 funding transaction.
+        let funding_transaction = builder.append(
+            Operation::CreateFundingTransaction,
+            &[
+                opener_funding_pubkey,
+                acceptor_funding_pubkey,
+                funding_satoshis,
+                feerate_per_kw,
+            ],
+        );
+
+        // Build and send funding_created.
+        let sent_funding_created = builder.append(
+            Operation::SendFundingCreated,
+            &[
+                funding_transaction,
+                opener_funding_privkey,
+                temporary_channel_id,
+            ],
+        );
+
+        // Receive funding_signed.
+        builder.append(Operation::RecvFundingSigned, &[sent_funding_created]);
+
+        // Broadcast the funding transaction.
+        builder.append(Operation::BroadcastTransaction, &[funding_transaction]);
+    }
+}

--- a/smite-ir/src/generators/funding_flow.rs
+++ b/smite-ir/src/generators/funding_flow.rs
@@ -1,0 +1,129 @@
+//! Generator for the complete v1 outbound channel funding flow.
+
+use rand::seq::IndexedRandom;
+use rand::{Rng, RngExt};
+
+use super::Generator;
+use crate::builder::ProgramBuilder;
+use crate::operation::AcceptChannelField;
+use crate::operation::{ChannelTypeVariant, ShutdownScriptVariant};
+use crate::{Operation, VariableType};
+
+/// Generates the complete v1 outbound channel funding flow.
+///
+/// Emits instructions to:
+/// 1. Build and send `open_channel`, then receive `accept_channel`
+/// 2. Build and send `funding_created`, then receive `funding_signed`
+/// 3. Broadcast and mine blocks to confirm the funding transaction
+/// 4. Complete the `channel_ready` exchange
+#[derive(Clone, Copy)]
+pub struct FundingFlowGenerator;
+
+impl Generator for FundingFlowGenerator {
+    fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
+        // Private/Public keys are generated fresh to ensure they're distinct.
+        let funding_privkey = builder.generate_fresh(VariableType::PrivateKey, rng);
+        let funding_pubkey = builder.append(Operation::DerivePoint, &[funding_privkey]);
+        let revocation_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let payment_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let delayed_payment_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let htlc_basepoint = builder.generate_fresh(VariableType::Point, rng);
+        let first_per_commitment_point = builder.generate_fresh(VariableType::Point, rng);
+
+        // Channel parameters.
+        let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
+        let temporary_channel_id = builder.pick_variable(VariableType::ChannelId, rng);
+        let funding_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let push_msat = builder.pick_variable(VariableType::Amount, rng);
+        let dust_limit_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let max_htlc_value_in_flight_msat = builder.pick_variable(VariableType::Amount, rng);
+        let channel_reserve_satoshis = builder.pick_variable(VariableType::Amount, rng);
+        let htlc_minimum_msat = builder.pick_variable(VariableType::Amount, rng);
+        let feerate_per_kw = builder.pick_variable(VariableType::FeeratePerKw, rng);
+        let to_self_delay = builder.pick_variable(VariableType::U16, rng);
+        let max_accepted_htlcs = builder.pick_variable(VariableType::U16, rng);
+        let channel_flags = builder.pick_variable(VariableType::U8, rng);
+        let shutdown_script_variant = ShutdownScriptVariant::random(rng);
+        let upfront_shutdown_script =
+            builder.append(Operation::LoadShutdownScript(shutdown_script_variant), &[]);
+        let variant = *ChannelTypeVariant::ALL
+            .choose(rng)
+            .expect("ChannelTypeVariant::ALL is non-empty");
+        let channel_type = builder.append(Operation::LoadChannelType(variant), &[]);
+
+        // Build and send open_channel.
+        let open_channel_msg = builder.append(
+            Operation::BuildOpenChannel,
+            &[
+                chain_hash,
+                temporary_channel_id,
+                funding_satoshis,
+                push_msat,
+                dust_limit_satoshis,
+                max_htlc_value_in_flight_msat,
+                channel_reserve_satoshis,
+                htlc_minimum_msat,
+                feerate_per_kw,
+                to_self_delay,
+                max_accepted_htlcs,
+                funding_pubkey,
+                revocation_basepoint,
+                payment_basepoint,
+                delayed_payment_basepoint,
+                htlc_basepoint,
+                first_per_commitment_point,
+                channel_flags,
+                upfront_shutdown_script,
+                channel_type,
+            ],
+        );
+        let sent_open_channel = builder.append(Operation::SendOpenChannel, &[open_channel_msg]);
+
+        // Receive accept_channel.
+        let accept_channel = builder.append(Operation::RecvAcceptChannel, &[sent_open_channel]);
+        let acceptor_funding_pubkey = builder.append(
+            Operation::ExtractAcceptChannel(AcceptChannelField::FundingPubkey),
+            &[accept_channel],
+        );
+
+        // Create the BOLT 3 funding transaction.
+        let funding_transaction = builder.append(
+            Operation::CreateFundingTransaction,
+            &[
+                funding_pubkey,
+                acceptor_funding_pubkey,
+                funding_satoshis,
+                feerate_per_kw,
+            ],
+        );
+
+        // Build and send funding_created.
+        let sent_funding_created = builder.append(
+            Operation::SendFundingCreated,
+            &[funding_transaction, funding_privkey, temporary_channel_id],
+        );
+
+        // Receive funding_signed.
+        let channel_id = builder.append(Operation::RecvFundingSigned, &[sent_funding_created]);
+
+        // Broadcast the funding transaction.
+        builder.append(Operation::BroadcastTransaction, &[funding_transaction]);
+
+        // Mine blocks to confirm the funding transaction.
+        builder.append(Operation::MineBlocks(rng.random_range(1..=16)), &[]);
+
+        // Channel ready parameters.
+        let second_per_commitment_point = builder.generate_fresh(VariableType::Point, rng);
+        let short_channel_id = builder.generate_fresh(VariableType::ShortChannelId, rng);
+        let include_alias = rng.random();
+
+        // Build and send channel_ready.
+        builder.append(
+            Operation::SendChannelReady { include_alias },
+            &[channel_id, second_per_commitment_point, short_channel_id],
+        );
+
+        // Receive channel_ready.
+        builder.append(Operation::RecvChannelReady, &[]);
+    }
+}

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -7,8 +7,8 @@ use smite::bolt::{MAX_MESSAGE_SIZE, ShortChannelId};
 
 use super::*;
 use generators::{
-    AnyGenerator, ChannelAnnouncementGenerator, ChannelUpdateGenerator, NodeAnnouncementGenerator,
-    OpenChannelGenerator,
+    AnyGenerator, ChannelAnnouncementGenerator, ChannelUpdateGenerator, FundingCreatedGenerator,
+    NodeAnnouncementGenerator, OpenChannelGenerator,
 };
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use mutators::{
@@ -837,7 +837,8 @@ fn any_generator_all_is_complete() {
             AnyGenerator::ChannelAnnouncement(_)
             | AnyGenerator::ChannelUpdate(_)
             | AnyGenerator::NodeAnnouncement(_)
-            | AnyGenerator::OpenChannel(_) => 4,
+            | AnyGenerator::OpenChannel(_)
+            | AnyGenerator::FundingCreated(_) => 5,
         }
     };
     assert_eq!(AnyGenerator::ALL.len(), variant_count(AnyGenerator::ALL[0]));
@@ -1128,6 +1129,51 @@ fn generated_open_channel_program_structure() {
     );
 }
 
+fn generate_funding_created_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    FundingCreatedGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+// If FundingCreatedGenerator completes without panicking, every instruction has
+// correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_funding_created_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_funding_created_program(seed);
+    }
+}
+
+#[test]
+fn generated_funding_created_program_structure() {
+    let program = generate_funding_created_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    // Must end with SendFundingCreated, RecvFundingSigned, BroadcastTransaction.
+    assert!(
+        matches!(ops[ops.len() - 3], Operation::SendFundingCreated),
+        "third-to-last instruction should be SendFundingCreated",
+    );
+    assert!(
+        matches!(ops[ops.len() - 2], Operation::RecvFundingSigned),
+        "second-to-last instruction should be RecvFundingSigned",
+    );
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::BroadcastTransaction),
+        "last instruction should be BroadcastTransaction",
+    );
+
+    // Exactly one create funding transaction.
+    assert_eq!(
+        ops.iter()
+            .filter(|op| matches!(op, Operation::CreateFundingTransaction))
+            .count(),
+        1,
+        "expected exactly one CreateFundingTransaction",
+    );
+}
+
 fn generate_channel_announcement_program(seed: u64) -> Program {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut builder = ProgramBuilder::new();
@@ -1246,6 +1292,14 @@ fn generated_channel_update_program_structure() {
 #[test]
 fn generated_open_channel_program_postcard_roundtrip() {
     let program = generate_open_channel_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generated_funding_created_program_postcard_roundtrip() {
+    let program = generate_funding_created_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -7,8 +7,8 @@ use smite::bolt::{MAX_MESSAGE_SIZE, ShortChannelId};
 
 use super::*;
 use generators::{
-    AnyGenerator, ChannelAnnouncementGenerator, ChannelUpdateGenerator, FundingCreatedGenerator,
-    NodeAnnouncementGenerator, OpenChannelGenerator,
+    AnyGenerator, ChannelAnnouncementGenerator, ChannelReadyGenerator, ChannelUpdateGenerator,
+    FundingCreatedGenerator, NodeAnnouncementGenerator, OpenChannelGenerator,
 };
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use mutators::{
@@ -838,7 +838,8 @@ fn any_generator_all_is_complete() {
             | AnyGenerator::ChannelUpdate(_)
             | AnyGenerator::NodeAnnouncement(_)
             | AnyGenerator::OpenChannel(_)
-            | AnyGenerator::FundingCreated(_) => 5,
+            | AnyGenerator::FundingCreated(_)
+            | AnyGenerator::ChannelReady(_) => 6,
         }
     };
     assert_eq!(AnyGenerator::ALL.len(), variant_count(AnyGenerator::ALL[0]));
@@ -1174,6 +1175,49 @@ fn generated_funding_created_program_structure() {
     );
 }
 
+fn generate_channel_ready_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    ChannelReadyGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+// If ChannelReadyGenerator completes without panicking, every instruction has
+// correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_channel_ready_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_channel_ready_program(seed);
+    }
+}
+
+#[test]
+fn generated_channel_ready_program_structure() {
+    let program = generate_channel_ready_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    // Must end with SendChannelReady, RecvChannelReady.
+    assert!(
+        matches!(ops[ops.len() - 2], Operation::SendChannelReady { .. }),
+        "second-to-last instruction should be SendChannelReady",
+    );
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::RecvChannelReady),
+        "last instruction should be RecvChannelReady",
+    );
+
+    // At least 1 DerivePoint instructions.
+    let derive_count = program
+        .instructions
+        .iter()
+        .filter(|i| matches!(i.operation, Operation::DerivePoint))
+        .count();
+    assert!(
+        derive_count >= 1,
+        "expected at least one DerivePoint, got {derive_count}"
+    );
+}
+
 fn generate_channel_announcement_program(seed: u64) -> Program {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut builder = ProgramBuilder::new();
@@ -1300,6 +1344,14 @@ fn generated_open_channel_program_postcard_roundtrip() {
 #[test]
 fn generated_funding_created_program_postcard_roundtrip() {
     let program = generate_funding_created_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generated_channel_ready_program_postcard_roundtrip() {
+    let program = generate_channel_ready_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -8,7 +8,7 @@ use smite::bolt::{MAX_MESSAGE_SIZE, ShortChannelId};
 use super::*;
 use generators::{
     AnyGenerator, ChannelAnnouncementGenerator, ChannelReadyGenerator, ChannelUpdateGenerator,
-    FundingCreatedGenerator, NodeAnnouncementGenerator, OpenChannelGenerator,
+    FundingCreatedGenerator, FundingFlowGenerator, NodeAnnouncementGenerator, OpenChannelGenerator,
 };
 use minimizers::{CommonSubexpressionEliminator, DeadCodeEliminator, Minimizer};
 use mutators::{
@@ -839,7 +839,8 @@ fn any_generator_all_is_complete() {
             | AnyGenerator::NodeAnnouncement(_)
             | AnyGenerator::OpenChannel(_)
             | AnyGenerator::FundingCreated(_)
-            | AnyGenerator::ChannelReady(_) => 6,
+            | AnyGenerator::ChannelReady(_)
+            | AnyGenerator::FundingFlow(_) => 7,
         }
     };
     assert_eq!(AnyGenerator::ALL.len(), variant_count(AnyGenerator::ALL[0]));
@@ -1218,6 +1219,92 @@ fn generated_channel_ready_program_structure() {
     );
 }
 
+fn generate_funding_flow_program(seed: u64) -> Program {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut builder = ProgramBuilder::new();
+    FundingFlowGenerator.generate(&mut builder, &mut rng);
+    builder.build()
+}
+
+// If FundingFlowGenerator completes without panicking, every instruction has
+// correct input types (enforced by ProgramBuilder::append).
+#[test]
+fn generated_funding_flow_program_is_type_correct() {
+    for seed in 0..100 {
+        generate_funding_flow_program(seed);
+    }
+}
+
+#[test]
+fn generated_funding_flow_program_structure() {
+    let program = generate_funding_flow_program(0);
+    let ops: Vec<_> = program.instructions.iter().map(|i| &i.operation).collect();
+
+    // Must end with SendChannelReady, RecvChannelReady.
+    assert!(
+        matches!(ops[ops.len() - 2], Operation::SendChannelReady { .. }),
+        "second-to-last instruction should be SendChannelReady",
+    );
+    assert!(
+        matches!(ops[ops.len() - 1], Operation::RecvChannelReady),
+        "last instruction should be RecvChannelReady",
+    );
+
+    // Must extract the funding pubkey from `accept_channel` exactly once.
+    assert_eq!(
+        ops.iter()
+            .filter(|op| matches!(
+                op,
+                Operation::ExtractAcceptChannel(AcceptChannelField::FundingPubkey)
+            ))
+            .count(),
+        1,
+        "expected exactly one ExtractAcceptChannel(FundingPubkey)",
+    );
+
+    // Key operations must appear in protocol order.
+    let position = |pred: fn(&Operation) -> bool| {
+        ops.iter()
+            .position(|op| pred(op))
+            .expect("operation present")
+    };
+
+    let recv_accept_channel = position(|op| matches!(op, Operation::RecvAcceptChannel));
+    let send_funding_created = position(|op| matches!(op, Operation::SendFundingCreated));
+    let recv_funding_signed = position(|op| matches!(op, Operation::RecvFundingSigned));
+    let broadcast_transaction = position(|op| matches!(op, Operation::BroadcastTransaction));
+    let send_channel_ready = position(|op| matches!(op, Operation::SendChannelReady { .. }));
+    let recv_channel_ready = position(|op| matches!(op, Operation::RecvChannelReady));
+
+    assert!(
+        recv_accept_channel < send_funding_created,
+        "RecvAcceptChannel should precede SendFundingCreated",
+    );
+    assert!(
+        recv_funding_signed < broadcast_transaction,
+        "RecvFundingSigned should precede BroadcastTransaction",
+    );
+    assert!(
+        broadcast_transaction < send_channel_ready,
+        "BroadcastTransaction should precede SendChannelReady",
+    );
+    assert!(
+        send_channel_ready < recv_channel_ready,
+        "SendChannelReady should precede RecvChannelReady",
+    );
+
+    // At least 7 DerivePoint instructions.
+    let derive_count = program
+        .instructions
+        .iter()
+        .filter(|i| matches!(i.operation, Operation::DerivePoint))
+        .count();
+    assert!(
+        derive_count >= 7,
+        "expected at least 7 DerivePoint, got {derive_count}"
+    );
+}
+
 fn generate_channel_announcement_program(seed: u64) -> Program {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut builder = ProgramBuilder::new();
@@ -1352,6 +1439,14 @@ fn generated_funding_created_program_postcard_roundtrip() {
 #[test]
 fn generated_channel_ready_program_postcard_roundtrip() {
     let program = generate_channel_ready_program(42);
+    let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
+    let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
+    assert_eq!(program, decoded);
+}
+
+#[test]
+fn generated_funding_flow_program_postcard_roundtrip() {
+    let program = generate_funding_flow_program(42);
     let bytes = postcard::to_allocvec(&program).expect("postcard serialization");
     let decoded: Program = postcard::from_bytes(&bytes).expect("postcard deserialization");
     assert_eq!(program, decoded);


### PR DESCRIPTION
Adds `funding_created` and `channel_ready` generators.
Depends-on: https://github.com/morehouse/smite/pull/137

Verified that all targets correctly send `funding_signed` and `channel_ready` once the commitment transaction is signed and the funding transaction confirms. For CLN, we need to reduce the blockchain polling interval to receive `channel_ready` promptly. We should also bump the CLN version, since I observed crashes that have been fixed in its latest release.

All other targets were able to reach `channel_ready` without any issues, but for CLN I had to (mentioning this so we can discuss a solution and add a fix in smite):
- patch the CLN polling interval from 30 seconds to 2 seconds (I arbitrarily chose the same value as LDK)
- patch `recv_non_ping` to also reject gossip messages, since CLN was apparently sending `channel_update` before sending `channel_ready`

[cln-coverage.tar.gz](https://github.com/user-attachments/files/29754676/cln-coverage.tar.gz)
[eclair-coverage.tar.gz](https://github.com/user-attachments/files/29754698/eclair-coverage.tar.gz)
[ldk-coverage.tar.gz](https://github.com/user-attachments/files/29754703/ldk-coverage.tar.gz)
[lnd-coverage.tar.gz](https://github.com/user-attachments/files/29754719/lnd-coverage.tar.gz)
