### PR TITLE
smite: extract Violation enum for target-bug findings

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -18,6 +18,7 @@ use smite::channel_tx::{
 };
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite::pending_channel::PendingChannel;
+use smite::violation::Violation;
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable};
 use std::collections::HashMap;
@@ -136,30 +137,10 @@ pub enum ExecuteError {
     #[error("commitment: {0}")]
     Commitment(#[from] smite::channel_tx::CommitmentError),
 
-    /// Received a message referencing a channel id we have no tracked state
-    /// for. This covers:
-    /// - a `funding_signed` for a `channel_id` we never opened, or
-    /// - an `accept_channel` for a `temporary_channel_id` we never sent
-    ///   `open_channel` for.
-    #[error("unknown channel: no tracked state for channel id {0:?}")]
-    UnknownChannel(ChannelId),
-
-    /// Received a second `accept_channel` for a `temporary_channel_id` whose
-    /// in-progress negotiation already has one, i.e. the id was reused before
-    /// its negotiation reached `funding_created`.
-    #[error(
-        "temporary_channel_id reuse: previous negotiation for {0:?} has not yet reached funding_created"
-    )]
-    TempChannelIdReuse(ChannelId),
-
-    /// The opener cannot afford the feerate for the commitment transaction.
-    #[error("opener cannot afford commitment fee for channel_id {0:?}")]
-    OpenerCannotAffordFee(ChannelId),
-
-    /// The counterparty's signature in `funding_signed` failed to verify
-    /// against the holder's first commitment transaction.
-    #[error("invalid counterparty signature for channel_id {0:?}")]
-    InvalidCounterpartySignature(ChannelId),
+    /// The target broke a protocol invariant. Surfaced to the scenario as a
+    /// failure; see [`Violation`] for the full catalog of target-bug findings.
+    #[error(transparent)]
+    Violation(#[from] Violation),
 }
 
 /// Executes IR programs against a target over an established connection.
@@ -209,9 +190,9 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
     /// - the target sends an unexpected message type
     /// - wallet funds are insufficient to perform a channel operation
     /// - the initial commitment transaction cannot be constructed
-    /// - no channel state exists for a received `funding_signed`
-    /// - the opener cannot afford the commitment feerate
-    /// - the counterparty's signature fails verification
+    /// - the target commits a [`Violation`] (unknown channel, temporary
+    ///   channel id reuse, opener cannot afford the commitment feerate, or
+    ///   invalid counterparty signature)
     ///
     /// # Panics
     ///
@@ -1072,8 +1053,8 @@ fn recv_funding_signed(conn: &mut impl Connection) -> Result<FundingSigned, Exec
 /// # Errors
 ///
 /// Returns [`ExecuteError::UnexpectedMessage`] if the received message is not a
-/// `channel_ready`, or [`ExecuteError::UnknownChannel`] if no channel state
-/// exists for the message's `channel_id`.
+/// `channel_ready`, or [`Violation::UnknownChannel`] if no channel state exists
+/// for the message's `channel_id`.
 fn recv_channel_ready(
     conn: &mut impl Connection,
     channel_states: &mut HashMap<ChannelId, ChannelState>,
@@ -1090,7 +1071,7 @@ fn recv_channel_ready(
 
     let state = channel_states
         .get_mut(&cr.channel_id)
-        .ok_or(ExecuteError::UnknownChannel(cr.channel_id))?;
+        .ok_or(Violation::UnknownChannel(cr.channel_id))?;
     *state.next_counterparty_per_commitment_point_mut() = Some(cr.second_per_commitment_point);
 
     Ok(())
@@ -1118,29 +1099,29 @@ fn is_channel_ready_expected(
 ///
 /// # Errors
 ///
-/// Returns [`ExecuteError::UnknownChannel`] if no channel state exists for the
-/// given `channel_id`, [`ExecuteError::OpenerCannotAffordFee`] if the opener
-/// cannot afford the commitment feerate, or [`ExecuteError::InvalidCounterpartySignature`]
+/// Returns [`Violation::UnknownChannel`] if no channel state exists for the
+/// given `channel_id`, [`Violation::OpenerCannotAffordFee`] if the opener
+/// cannot afford the commitment feerate, or [`Violation::InvalidCounterpartySignature`]
 /// if the signature is invalid for the holder's initial commitment transaction.
 fn verify_funding_signed(
     fs: &FundingSigned,
     channel_states: &HashMap<ChannelId, ChannelState>,
-) -> Result<(), ExecuteError> {
+) -> Result<(), Violation> {
     let state = channel_states
         .get(&fs.channel_id)
-        .ok_or(ExecuteError::UnknownChannel(fs.channel_id))?;
+        .ok_or(Violation::UnknownChannel(fs.channel_id))?;
 
     // The opener cannot afford the fee, so the acceptor must not send
     // `funding_signed`. Receiving one is a protocol violation.
     if !state.config.can_opener_afford_feerate(&state.commitment) {
-        return Err(ExecuteError::OpenerCannotAffordFee(fs.channel_id));
+        return Err(Violation::OpenerCannotAffordFee(fs.channel_id));
     }
 
     state
         .config
         .verify_counterparty_signature(&state.commitment, &state.holder, &fs.signature)
         .then_some(())
-        .ok_or(ExecuteError::InvalidCounterpartySignature(fs.channel_id))
+        .ok_or(Violation::InvalidCounterpartySignature(fs.channel_id))
 }
 
 /// Records a sent `open_channel`, keyed by `temporary_channel_id`, so the
@@ -1176,22 +1157,22 @@ fn record_send_open_channel(
 ///
 /// # Errors
 ///
-/// Returns [`ExecuteError::UnknownChannel`] if no `open_channel` was recorded
+/// Returns [`Violation::UnknownChannel`] if no `open_channel` was recorded
 /// for the message's `temporary_channel_id`.
 ///
-/// Returns [`ExecuteError::TempChannelIdReuse`] if the negotiation already has an
+/// Returns [`Violation::TempChannelIdReuse`] if the negotiation already has an
 /// `accept_channel` but has not yet reached `funding_created`.
 fn record_recv_accept_channel(
     negotiations: &mut HashMap<ChannelId, PendingChannel>,
     accept_channel: &AcceptChannel,
-) -> Result<(), ExecuteError> {
+) -> Result<(), Violation> {
     let pending = negotiations
         .get_mut(&accept_channel.temporary_channel_id)
-        .ok_or(ExecuteError::UnknownChannel(
+        .ok_or(Violation::UnknownChannel(
             accept_channel.temporary_channel_id,
         ))?;
     if pending.accept_channel.is_some() && !pending.funding_built {
-        return Err(ExecuteError::TempChannelIdReuse(
+        return Err(Violation::TempChannelIdReuse(
             accept_channel.temporary_channel_id,
         ));
     }
@@ -2277,7 +2258,9 @@ mod tests {
             )
             .unwrap_err();
 
-        assert!(matches!(err, ExecuteError::UnknownChannel(id) if id == unknown_id));
+        assert!(
+            matches!(err, ExecuteError::Violation(Violation::UnknownChannel(id)) if id == unknown_id)
+        );
     }
 
     #[test]
@@ -2319,7 +2302,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            ExecuteError::TempChannelIdReuse(id) if id == temporary_channel_id
+            ExecuteError::Violation(Violation::TempChannelIdReuse(id)) if id == temporary_channel_id
         ));
     }
 
@@ -3020,7 +3003,10 @@ mod tests {
                 std::time::Instant::now(),
             )
             .unwrap_err();
-        assert!(matches!(err, ExecuteError::UnknownChannel(id) if id == channel_id));
+        assert!(matches!(
+            err,
+            ExecuteError::Violation(Violation::UnknownChannel(id)) if id == channel_id
+        ));
     }
 
     #[test]
@@ -3067,7 +3053,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            ExecuteError::OpenerCannotAffordFee(id) if id == channel_id
+            ExecuteError::Violation(Violation::OpenerCannotAffordFee(id)) if id == channel_id
         ));
     }
 
@@ -3107,7 +3093,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            ExecuteError::InvalidCounterpartySignature(id) if id == channel_id
+            ExecuteError::Violation(Violation::InvalidCounterpartySignature(id)) if id == channel_id
         ));
     }
 

--- a/smite-scenarios/src/scenarios/encrypted_bytes.rs
+++ b/smite-scenarios/src/scenarios/encrypted_bytes.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use smite::bolt::{Init, Message};
 use smite::noise::NoiseConnection;
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
+use smite::violation::Violation;
 
 use super::{handshake_with_target, ping_pong};
 use crate::targets::Target;
@@ -56,7 +57,7 @@ impl<T: Target> Scenario for EncryptedBytesScenario<T> {
         if let Err(e) = ping_pong(&mut self.conn) {
             log::debug!("[{:?}] ping_pong: {e}", start.elapsed());
             if e.is_timeout() {
-                return ScenarioResult::Fail("target hung (ping timeout)".into());
+                return ScenarioResult::Fail(Violation::Hung.to_string());
             }
             // Non-timeout error likely means the target closed the connection.
             // This is expected when we send invalid messages, but it could also
@@ -68,7 +69,7 @@ impl<T: Target> Scenario for EncryptedBytesScenario<T> {
         // Check if target is still alive (and trigger coverage sync for LND)
         if let Err(e) = self.target.check_alive() {
             log::debug!("[{:?}] check_alive: {e}", start.elapsed());
-            return ScenarioResult::Fail("target crashed".into());
+            return ScenarioResult::Fail(Violation::Crashed.to_string());
         }
 
         ScenarioResult::Ok

--- a/smite-scenarios/src/scenarios/init.rs
+++ b/smite-scenarios/src/scenarios/init.rs
@@ -6,6 +6,7 @@ use smite::bolt;
 use smite::bolt::{Init, Message};
 use smite::noise::{MAX_MESSAGE_SIZE, NoiseConnection};
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
+use smite::violation::Violation;
 
 use super::{handshake_with_target, ping_pong};
 use crate::targets::Target;
@@ -68,7 +69,7 @@ impl<T: Target> Scenario for InitScenario<T> {
         if let Err(e) = ping_pong(&mut self.conn) {
             log::debug!("[{:?}] ping_pong: {e}", start.elapsed());
             if e.is_timeout() {
-                return ScenarioResult::Fail("target hung (ping timeout)".into());
+                return ScenarioResult::Fail(Violation::Hung.to_string());
             }
             // Non-timeout error likely means the target closed the connection.
             // This is expected for invalid init messages, but it could also
@@ -79,7 +80,7 @@ impl<T: Target> Scenario for InitScenario<T> {
 
         if let Err(e) = self.target.check_alive() {
             log::debug!("[{:?}] check_alive: {e}", start.elapsed());
-            return ScenarioResult::Fail("target crashed".into());
+            return ScenarioResult::Fail(Violation::Crashed.to_string());
         }
 
         ScenarioResult::Ok

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use smite::bitcoin::BitcoinCli;
 use smite::noise::NoiseConnection;
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
+use smite::violation::Violation;
 use smite_ir::Program;
 
 use super::{SnapshotSetup, ping_pong};
@@ -91,34 +92,9 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
                 // bug in the target.
                 log::debug!("[{:?}] invalid commitment: {e}", start.elapsed());
             }
-            Err(ExecuteError::UnknownChannel(id)) => {
-                // The target referenced a channel we have no record of (a
-                // funding_signed channel_id or an accept_channel temporary id
-                // we never opened). This is a protocol violation by the target.
-                return ScenarioResult::Fail(format!("unknown channel: {id:?}"));
-            }
-            Err(ExecuteError::TempChannelIdReuse(id)) => {
-                // The target sent a second accept_channel for a
-                // temporary_channel_id whose negotiation already has one and has
-                // not yet reached funding_created. This is a protocol violation
-                // by the target.
-                return ScenarioResult::Fail(format!("temporary channel id reuse: {id:?}"));
-            }
-            Err(ExecuteError::OpenerCannotAffordFee(id)) => {
-                // The opener cannot afford the commitment feerate. This is a
-                // protocol violation by the target (it should not have sent
-                // funding_signed if the opener cannot afford the fee).
-                return ScenarioResult::Fail(format!(
-                    "opener cannot afford fee for channel {id:?}"
-                ));
-            }
-            Err(ExecuteError::InvalidCounterpartySignature(id)) => {
-                // The target's funding_signed signature did not verify against
-                // the holder's commitment transaction. This is a protocol
-                // violation by the target.
-                return ScenarioResult::Fail(format!(
-                    "invalid counterparty signature for channel {id:?}"
-                ));
+            Err(ExecuteError::Violation(v)) => {
+                // The target broke a protocol invariant.
+                return ScenarioResult::Fail(v.to_string());
             }
         }
 
@@ -127,7 +103,7 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
         if let Err(e) = ping_pong(self.executor.conn_mut()) {
             log::debug!("[{:?}] ping_pong: {e}", start.elapsed());
             if e.is_timeout() {
-                return ScenarioResult::Fail("target hung (ping timeout)".into());
+                return ScenarioResult::Fail(Violation::Hung.to_string());
             }
         } else {
             log::debug!("[{:?}] Target responded with pong", start.elapsed());
@@ -135,7 +111,7 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
 
         if let Err(e) = self.target.check_alive() {
             log::debug!("[{:?}] check_alive: {e}", start.elapsed());
-            return ScenarioResult::Fail("target crashed".into());
+            return ScenarioResult::Fail(Violation::Crashed.to_string());
         }
 
         ScenarioResult::Ok

--- a/smite-scenarios/src/scenarios/noise.rs
+++ b/smite-scenarios/src/scenarios/noise.rs
@@ -10,6 +10,7 @@ use smite::noise::{
     ACT_TWO_SIZE, ENCRYPTED_LENGTH_SIZE, MAC_SIZE, NoiseCipher, NoiseConnection, NoiseHandshake,
 };
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
+use smite::violation::Violation;
 
 use super::{EPHEMERAL_KEY, handshake_with_target, ping_pong};
 use crate::targets::Target;
@@ -313,7 +314,12 @@ impl<T: Target> Scenario for NoiseScenario<T> {
             log::debug!("[{:?}] Syncing via ping-pong", start.elapsed());
             if let Err(e) = ping_pong(&mut self.sync_conn) {
                 log::debug!("[{:?}] Sync ping-pong failed: {e}", start.elapsed());
-                return ScenarioResult::Fail("target unresponsive".into());
+                let violation = if e.is_timeout() {
+                    Violation::Hung
+                } else {
+                    Violation::UnexpectedDisconnect
+                };
+                return ScenarioResult::Fail(violation.to_string());
             }
         }
 
@@ -321,7 +327,7 @@ impl<T: Target> Scenario for NoiseScenario<T> {
 
         if let Err(e) = self.target.check_alive() {
             log::debug!("[{:?}] check_alive: {e}", start.elapsed());
-            return ScenarioResult::Fail("target crashed".into());
+            return ScenarioResult::Fail(Violation::Crashed.to_string());
         }
 
         log::debug!("[{:?}] Target still alive", start.elapsed());

--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -15,6 +15,7 @@
 //! - [`process`] - Managed subprocess utilities.
 //! - [`runners`] - Fuzz input delivery (Nyx and local modes).
 //! - [`scenarios`] - Scenario trait and the [`scenarios::smite_run`] entry point.
+//! - [`violation`] - Target-misbehavior findings that make a test case fail.
 
 pub mod bitcoin;
 pub mod bolt;
@@ -27,3 +28,4 @@ pub mod pending_channel;
 pub mod process;
 pub mod runners;
 pub mod scenarios;
+pub mod violation;

--- a/smite/src/violation.rs
+++ b/smite/src/violation.rs
@@ -1,0 +1,55 @@
+//! Target-misbehavior findings.
+//!
+//! Each [`Violation`] variant names a buggy target behavior (e.g., crashing,
+//! hanging, breaking a protocol invariant). This is how the fuzzer reports bugs
+//! in the target.
+//!
+//! Conditions that are *not* the target's fault should be ordinary errors and
+//! never a `Violation` (e.g., transport failures, insufficient wallet funds,
+//! mutator-produced invalid commitments, undecodable harness input).
+
+use crate::bolt::ChannelId;
+
+/// A detected misbehavior of the target under test.
+#[derive(Debug, thiserror::Error)]
+pub enum Violation {
+    /// The target process died during or after processing the input.
+    #[error("target crashed")]
+    Crashed,
+
+    /// The target stopped responding to the post-input ping-pong sync.
+    #[error("target hung (ping timeout)")]
+    Hung,
+
+    /// The target closed the connection during the post-input ping-pong sync
+    /// instead of responding.
+    #[error("target unexpectedly disconnected")]
+    UnexpectedDisconnect,
+
+    /// The target referenced a channel for which no state was ever established.
+    /// This covers:
+    /// - a `funding_signed` or `channel_ready` for a `channel_id` we never
+    ///   opened, or
+    /// - an `accept_channel` for a `temporary_channel_id` we never sent
+    ///   `open_channel` for.
+    #[error("unknown channel: no tracked state for channel_id {0:?}")]
+    UnknownChannel(ChannelId),
+
+    /// The target sent a second `accept_channel` for a `temporary_channel_id`
+    /// whose in-progress negotiation already has one, i.e. the id was reused
+    /// before its negotiation reached `funding_created`.
+    #[error(
+        "temporary_channel_id reuse: previous negotiation for {0:?} has not yet reached funding_created"
+    )]
+    TempChannelIdReuse(ChannelId),
+
+    /// The target sent `funding_signed` even though the opener cannot afford the
+    /// commitment feerate.
+    #[error("opener cannot afford commitment fee for channel_id {0:?}")]
+    OpenerCannotAffordFee(ChannelId),
+
+    /// The target's `funding_signed` signature failed to verify against the
+    /// holder's initial commitment transaction.
+    #[error("invalid counterparty signature for channel_id {0:?}")]
+    InvalidCounterpartySignature(ChannelId),
+}


### PR DESCRIPTION
Carve target-misbehavior findings out of `ExecuteError` into a dedicated `Violation` enum, and replace raw finding strings in scenarios with its variants. Centralizes the finding vocabulary so new oracles route through a single match arm and each message lives in one place.