### PR TITLE
smite: fix funding transaction signing and broadcast

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -41,6 +41,11 @@ pub trait BitcoinRpc {
     /// Signs and broadcasts a transaction
     fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction);
 
+    /// Locks the given outpoints so subsequent [`get_utxos`](Self::get_utxos)
+    /// calls exclude them, preventing independently built transactions from
+    /// reusing the same coins.
+    fn lock_utxos(&mut self, outpoints: &[OutPoint]);
+
     /// Returns the number of confirmations for the transaction with the given
     /// txid, or `0` if it is unconfirmed or unknown to the node.
     fn get_transaction_confirmations(&mut self, txid: Txid) -> u32;
@@ -61,6 +66,10 @@ impl BitcoinRpc for BitcoinCli {
 
     fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) {
         BitcoinCli::sign_and_broadcast_tx(self, tx);
+    }
+
+    fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
+        BitcoinCli::lock_utxos(self, outpoints);
     }
 
     fn get_transaction_confirmations(&mut self, txid: Txid) -> u32 {
@@ -646,7 +655,8 @@ fn consume_sent_funding_created(variables: &mut [Option<Variable>], index: usize
 // -- Operation handlers --
 
 /// Create a funding transaction by querying the bitcoind for UTXOs and a
-/// change address, then calling [`build_funding_transaction`].
+/// change address, then calling [`build_funding_transaction`]. Locks the
+/// selected inputs so a subsequently built transaction cannot reselect them.
 fn create_funding_transaction(
     variables: &[Option<Variable>],
     inputs: &[usize],
@@ -670,6 +680,16 @@ fn create_funding_transaction(
         utxos,
         change_spk,
     )?;
+
+    // Lock the selected inputs so a subsequently built transaction does not
+    // reselect the same UTXOs.
+    let selected: Vec<OutPoint> = funding
+        .tx
+        .input
+        .iter()
+        .map(|txin| txin.previous_output)
+        .collect();
+    cli.lock_utxos(&selected);
 
     Ok(funding)
 }
@@ -1311,6 +1331,10 @@ mod tests {
 
         fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) {
             self.broadcast_calls.push(tx.clone());
+        }
+
+        fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
+            self.utxos.retain(|u| !outpoints.contains(&u.outpoint));
         }
 
         fn get_transaction_confirmations(&mut self, _txid: Txid) -> u32 {

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -165,7 +165,7 @@ impl BitcoinCli {
             .script_pubkey()
     }
 
-    /// Signs and broadcasts a transaction.
+    /// Signs and broadcasts a transaction, unless it is already confirmed.
     ///
     /// # Panics
     ///
@@ -180,6 +180,14 @@ impl BitcoinCli {
         struct SignRawTransactionResponse {
             hex: String,
             complete: bool,
+        }
+
+        // A confirmed transaction may be broadcast again by the fuzzer. Its
+        // inputs are spent, so the wallet can no longer fully sign it, skip
+        // signing and broadcasting it again.
+        let txid = tx.compute_txid();
+        if self.get_transaction_confirmations(txid) > 0 {
+            return;
         }
 
         let tx_hex = serialize_hex(tx);
@@ -222,7 +230,7 @@ impl BitcoinCli {
             .expect("sendrawtransaction should return a valid UTF-8 txid");
         assert_eq!(
             broadcast_txid.trim(),
-            tx.compute_txid().to_string(),
+            txid.to_string(),
             "sendrawtransaction returned unexpected txid"
         );
     }

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::{Address, Amount, Network, OutPoint, ScriptBuf, Transaction, Txid};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A spendable UTXO used as a transaction input.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -224,6 +224,54 @@ impl BitcoinCli {
             broadcast_txid.trim(),
             tx.compute_txid().to_string(),
             "sendrawtransaction returned unexpected txid"
+        );
+    }
+
+    /// Locks the given outpoints in the wallet so they are excluded from
+    /// `listunspent` and automatic coin selection.
+    ///
+    /// Prevents independently built transactions from selecting the same UTXO.
+    /// `listunspent` only excludes an output once its spending transaction
+    /// reaches the mempool, so transactions built beforehand can share an input.
+    /// The second transaction then either fails broadcast as a non-fee-bumping
+    /// RBF replacement, or later fails signing because the prevout has left the
+    /// UTXO set.
+    ///
+    /// # Panics
+    ///
+    /// If the `bitcoin-cli lockunspent` command fails to execute or exits
+    /// non-zero.
+    pub fn lock_utxos(&self, outpoints: &[OutPoint]) {
+        #[derive(Serialize)]
+        struct LockOutpoint {
+            txid: String,
+            vout: u32,
+        }
+
+        if outpoints.is_empty() {
+            return;
+        }
+
+        let locks: Vec<LockOutpoint> = outpoints
+            .iter()
+            .map(|o| LockOutpoint {
+                txid: o.txid.to_string(),
+                vout: o.vout,
+            })
+            .collect();
+        let locks_json = serde_json::to_string(&locks).expect("outpoints serialize to valid JSON");
+
+        let lock_out = self
+            .run()
+            .arg("lockunspent")
+            .arg("false")
+            .arg(&locks_json)
+            .output()
+            .expect("bitcoin-cli lockunspent should not fail");
+        assert!(
+            lock_out.status.success(),
+            "bitcoin-cli lockunspent failed: {}",
+            String::from_utf8_lossy(&lock_out.stderr)
         );
     }
 

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -215,6 +215,8 @@ impl BitcoinCli {
             .run()
             .arg("sendrawtransaction")
             .arg(&signed_tx.hex)
+            // Disable the high-feerate cap and accept any fee rate for broadcast.
+            .arg("0")
             .output()
             .expect("bitcoin-cli sendrawtransaction should not fail");
         assert!(


### PR DESCRIPTION
ref: https://github.com/morehouse/smite/pull/137#pullrequestreview-4658385631

Now we can’t create two transactions with overlapping inputs. We return early when signing or broadcasting a transaction if it has already been broadcast and confirmed, since the wallet can’t sign a transaction whose inputs have already been spent