### PR TITLE
smitebot: implement `smitebot stop` command

### DIFF
--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -53,6 +53,16 @@ After spawning, startup is verified by polling for `fuzzer_stats` files. Because
 
 Campaign state is saved to `~/.smitebot/runs/<campaign-id>/state.json` for use by future `stop` and `status` commands.
 
+### smitebot stop
+
+Stops a running campaign: reaps every runner's process group — afl-fuzz and its Nyx QEMU child, which shares the group — tears down the tmux session, and records the stop time in `state.json`.
+
+```bash
+smitebot stop <campaign-id>
+```
+
+`<campaign-id>` is the directory name under `~/.smitebot/runs` (printed by `smitebot start`). 
+
 ### smitebot config
 
 Validates a campaign configuration file, reports the resolved settings, and checks that referenced paths exist on disk.

--- a/smitebot/src/commands.rs
+++ b/smitebot/src/commands.rs
@@ -2,8 +2,10 @@ pub mod build;
 pub mod config;
 pub mod doctor;
 pub mod start;
+pub mod stop;
 
 pub use build::{BuildArgs, BuildCommand};
 pub use config::{ConfigArgs, ConfigCommand};
 pub use doctor::{DoctorArgs, DoctorCommand};
 pub use start::{StartArgs, StartCommand};
+pub use stop::{StopArgs, StopCommand};

--- a/smitebot/src/commands/stop.rs
+++ b/smitebot/src/commands/stop.rs
@@ -1,0 +1,270 @@
+//! Campaign teardown: stop a running campaign and reap all of its processes.
+//!
+//! Each afl-fuzz runner is a process-group leader, and its Nyx QEMU child shares
+//! that group and keeps the group id even after it orphans. So a group-directed
+//! kill (`pkill -g <pgid>`) reaps the QEMU too — which a plain `tmux kill-session`
+//! does not (it leaks QEMU). Nyx QEMU did not exit on SIGTERM in testing, so the
+//! kill escalates SIGTERM -> SIGKILL.
+
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use clap::Args;
+
+use crate::state::{CampaignState, Status};
+use crate::tmux;
+use crate::utils;
+
+/// How long to wait for a signalled group to exit before giving up on that
+/// stage. Conservative headroom for afl-fuzz to finish `AFL_FINAL_SYNC` on a
+/// large corpus and exit after SIGTERM; the poll returns as soon as every group
+/// is gone, so this full duration is only spent when something ignores the
+/// signal (SIGTERM, or SIGKILL against a process wedged in uninterruptible I/O).
+const GRACEFUL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Poll interval while waiting for process groups to exit, and the delay before
+/// the first poll: freshly-signalled runners won't have exited any sooner.
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Command handler for `smitebot stop`.
+pub struct StopCommand;
+
+/// CLI arguments for `smitebot stop`.
+#[derive(Debug, Args)]
+pub struct StopArgs {
+    /// Campaign ID to stop (a directory name under `~/.smitebot/runs`).
+    campaign_id: String,
+}
+
+impl StopCommand {
+    /// Stops a campaign: reaps its runner process groups, tears down the tmux
+    /// session, and records the stop in state.json.
+    pub fn execute(args: &StopArgs) -> bool {
+        let Some(runs_dir) = CampaignState::runs_dir() else {
+            log::error!("unable to determine home directory");
+            return false;
+        };
+        let state_path = runs_dir.join(&args.campaign_id).join("state.json");
+
+        let mut state = match CampaignState::load(&state_path) {
+            Ok(state) => state,
+            Err(e) => {
+                log::error!("{e}");
+                log::error!(
+                    "campaign '{}' not found; list campaigns with: ls {}",
+                    args.campaign_id,
+                    runs_dir.display()
+                );
+                return false;
+            }
+        };
+
+        if state.status == Status::Stopped {
+            log::info!("campaign {} is already stopped", state.id);
+            return true;
+        }
+
+        let clean = terminate_runners(&state);
+
+        if let Err(e) = tmux::kill_session(&state.tmux_session) {
+            // The session may already be gone (e.g. killed manually); not fatal.
+            log::debug!("kill-session '{}': {e}", state.tmux_session);
+        }
+
+        state.status = Status::Stopped;
+        state.stop_time = Some(utils::epoch_secs());
+        if let Err(e) = state.save(&state_path) {
+            log::error!(
+                "runners were reaped but recording the stop failed: {e}; \
+                 campaign {} will still show as running in state.json",
+                state.id
+            );
+            return false;
+        }
+
+        if clean {
+            log::info!("campaign {} stopped", state.id);
+        } else {
+            log::error!(
+                "campaign {} stopped, but some processes survived SIGKILL; \
+                 inspect with `pgrep -a qemu` and kill them manually",
+                state.id
+            );
+        }
+        clean
+    }
+}
+
+/// Terminates every runner process group for a campaign.
+///
+/// PIDs come only from the live tmux session, never from state.json: a recorded
+/// PID whose session is gone (e.g. after a reboot) may have been recycled by the
+/// OS, and group-killing it could hit an unrelated process. When the session is
+/// alive, its pane PIDs are the afl-fuzz leaders, and each shares its process
+/// group with its Nyx QEMU child, so the group kill reaps the QEMU too. Returns
+/// `true` if no process survived.
+fn terminate_runners(state: &CampaignState) -> bool {
+    if !tmux::session_exists(&state.tmux_session) {
+        log::warn!(
+            "no live tmux session for campaign {}; nothing to reap \
+             (if runners leaked — e.g. the session was killed manually — check `pgrep -a qemu`)",
+            state.id,
+        );
+        return true;
+    }
+
+    let pgids = match tmux::list_pane_pids(&state.tmux_session) {
+        Ok(pgids) => pgids,
+        Err(e) => {
+            log::error!(
+                "could not read runner PIDs from tmux for campaign {}: {e}; \
+                 not reaping — runners may still be alive, check `pgrep -a qemu`",
+                state.id,
+            );
+            return false;
+        }
+    };
+    if pgids.is_empty() {
+        // Session exists but has no panes left; nothing to reap.
+        return true;
+    }
+
+    kill_groups(&pgids)
+}
+
+/// Signals each process group, escalating SIGTERM -> SIGKILL, until all exit.
+fn kill_groups(pgids: &[u32]) -> bool {
+    if signal_and_wait(pgids, "TERM", GRACEFUL_TIMEOUT) {
+        return true;
+    }
+    if signal_and_wait(pgids, "KILL", GRACEFUL_TIMEOUT) {
+        return true;
+    }
+
+    // Report every survivor, not just the first, so the operator sees all the
+    // pgids that still need a manual kill.
+    let mut clean = true;
+    for &pgid in pgids {
+        if group_alive(pgid) {
+            log::error!("process group {pgid} still alive after SIGKILL");
+            clean = false;
+        }
+    }
+    clean
+}
+
+/// Sends `signal` to every still-alive group, then polls at `POLL_INTERVAL`
+/// until all exit or `timeout` elapses. Returns `true` if every group is gone.
+///
+/// The first poll is delayed one `POLL_INTERVAL`: the just-signalled runners
+/// won't have exited any sooner, so checking immediately only wastes work.
+fn signal_and_wait(pgids: &[u32], signal: &str, timeout: Duration) -> bool {
+    for &pgid in pgids {
+        if group_alive(pgid) {
+            signal_group(pgid, signal);
+        }
+    }
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        thread::sleep(POLL_INTERVAL);
+        if pgids.iter().all(|&pgid| !group_alive(pgid)) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+    }
+}
+
+/// Sends `signal` to every process in the process group `pgid`.
+///
+/// Uses `pkill -g` (not `kill -<pgid>`: the `kill` *binary* silently ignores a
+/// negative-PID group target, unlike the shell builtin). Errors are ignored:
+/// the group may already be gone, which is the desired end state anyway.
+fn signal_group(pgid: u32, signal: &str) {
+    let _ = Command::new("pkill")
+        .arg(format!("-{signal}"))
+        .args(["-g", &pgid.to_string()])
+        .status();
+}
+
+/// Returns `true` if any *live* (non-zombie) process remains in group `pgid`.
+///
+/// Zombies don't count: a killed afl-fuzz is parented to tmux (`remain-on-exit`),
+/// so it lingers as a zombie until the tmux teardown reaps it — it is already
+/// dead for our purposes. `pgrep -g` selects the process group; `ps` then filters
+/// out zombie states (`Z`).
+fn group_alive(pgid: u32) -> bool {
+    let Ok(out) = Command::new("pgrep")
+        .args(["-g", &pgid.to_string()])
+        .output()
+    else {
+        return false;
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let pids: Vec<&str> = stdout.split_whitespace().collect();
+    if pids.is_empty() {
+        return false;
+    }
+    match Command::new("ps")
+        .args(["-o", "stat=", "-p", &pids.join(",")])
+        .output()
+    {
+        Ok(o) => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .any(|line| !line.trim_start().starts_with('Z')),
+        Err(_) => true, // can't check — assume alive so we don't report a false "clean"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::process::CommandExt;
+
+    use super::*;
+
+    /// Spawns a `sh` process-group leader running `shell_cmd`. The commands
+    /// outlive the test unless killed, so a passing test proves the whole group
+    /// was reaped. Caller must `wait()` the returned child.
+    fn spawn_group(shell_cmd: &str) -> std::process::Child {
+        let child = Command::new("sh")
+            .args(["-c", shell_cmd])
+            .process_group(0)
+            .spawn()
+            .expect("spawn test process group");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !group_alive(child.id()) {
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(group_alive(child.id()), "test group never came up");
+        child
+    }
+
+    #[test]
+    fn kill_groups_reaps_whole_process_group() {
+        let mut child = spawn_group("sleep 300 & sleep 300");
+        let pgid = child.id();
+        assert!(kill_groups(&[pgid]));
+        assert!(!group_alive(pgid));
+        let _ = child.wait(); // reap the leader zombie left by the group kill
+    }
+
+    #[test]
+    fn kill_escalates_to_sigkill_when_sigterm_ignored() {
+        // The leader ignores SIGTERM (inherited across the group), so only the
+        // SIGKILL escalation can reap it.
+        let mut child = spawn_group("trap '' TERM; sleep 300");
+        let pgid = child.id();
+
+        // SIGTERM is ignored -> the group is still alive when the wait expires.
+        assert!(!signal_and_wait(&[pgid], "TERM", Duration::from_millis(1)));
+        assert!(group_alive(pgid));
+
+        // SIGKILL can't be caught -> the group is gone.
+        assert!(signal_and_wait(&[pgid], "KILL", GRACEFUL_TIMEOUT));
+        assert!(!group_alive(pgid));
+        let _ = child.wait(); // reap the leader zombie left by the group kill
+    }
+}

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -12,7 +12,7 @@ use clap::{Parser, Subcommand};
 
 use commands::{
     BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, DoctorArgs, DoctorCommand, StartArgs,
-    StartCommand,
+    StartCommand, StopArgs, StopCommand,
 };
 
 #[derive(Debug, Parser)]
@@ -32,6 +32,8 @@ enum Commands {
     Doctor(DoctorArgs),
     /// Launch a fuzzing campaign.
     Start(StartArgs),
+    /// Stop a running campaign and reap its processes.
+    Stop(StopArgs),
 }
 
 fn main() -> ExitCode {
@@ -43,6 +45,7 @@ fn main() -> ExitCode {
         Commands::Config(args) => ConfigCommand::execute(&args),
         Commands::Doctor(args) => DoctorCommand::execute(&args),
         Commands::Start(args) => StartCommand::execute(&args),
+        Commands::Stop(args) => StopCommand::execute(&args),
     };
 
     if success {

--- a/smitebot/src/state.rs
+++ b/smitebot/src/state.rs
@@ -35,6 +35,8 @@ pub struct CampaignState {
     pub smite_git_hash: String,
     /// Unix timestamp (seconds since epoch) when the campaign started.
     pub start_time: u64,
+    /// Unix timestamp when the campaign was stopped; `None` while running.
+    pub stop_time: Option<u64>,
     /// Name of the tmux session hosting the campaign runners.
     pub tmux_session: String,
     /// State of each AFL++ runner process.
@@ -51,6 +53,8 @@ pub enum Status {
     Running,
     /// One or more runners failed to start.
     Failed,
+    /// Campaign was torn down by `smitebot stop`.
+    Stopped,
 }
 
 /// State of a single AFL++ runner process.
@@ -86,6 +90,16 @@ pub enum StateError {
         path: PathBuf,
         source: std::io::Error,
     },
+    #[error("failed to read state from {}: {source}", path.display())]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse state from {}: {source}", path.display())]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
 }
 
 impl CampaignState {
@@ -109,6 +123,7 @@ impl CampaignState {
             sharedir: config.sharedir.clone(),
             smite_git_hash,
             start_time: utils::epoch_secs(),
+            stop_time: None,
             tmux_session,
             runners: Vec::new(),
         }
@@ -144,6 +159,18 @@ impl CampaignState {
         })?;
         Ok(())
     }
+
+    /// Loads campaign state from a JSON file written by `save`.
+    pub fn load(path: &Path) -> Result<Self, StateError> {
+        let contents = fs::read_to_string(path).map_err(|source| StateError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        serde_json::from_str(&contents).map_err(|source| StateError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -162,6 +189,7 @@ mod tests {
             sharedir: PathBuf::from("/tmp/smite-nyx"),
             smite_git_hash: "deadbeef".to_string(),
             start_time: 1_749_465_600,
+            stop_time: None,
             tmux_session: "lnd-encrypted_bytes-1_749_465_600".to_string(),
             runners: vec![
                 RunnerState {
@@ -271,5 +299,55 @@ sharedir = "/tmp/nyx"
             serde_json::to_string(&Status::Failed).unwrap(),
             "\"failed\""
         );
+        assert_eq!(
+            serde_json::to_string(&Status::Stopped).unwrap(),
+            "\"stopped\""
+        );
+    }
+
+    #[test]
+    fn load_reads_saved_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut state = sample_state();
+        state.status = Status::Stopped;
+        state.stop_time = Some(1_749_469_200);
+        state.save(&path).unwrap();
+
+        let loaded = CampaignState::load(&path).unwrap();
+
+        assert_eq!(loaded.id, state.id);
+        assert_eq!(loaded.status, Status::Stopped);
+        assert_eq!(loaded.stop_time, Some(1_749_469_200));
+    }
+
+    #[test]
+    fn load_reports_missing_file() {
+        let err = CampaignState::load(Path::new("/no/such/state.json")).unwrap_err();
+        assert!(matches!(err, StateError::Read { .. }));
+    }
+
+    #[test]
+    fn load_reports_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        fs::write(&path, "{ not json").unwrap();
+
+        let err = CampaignState::load(&path).unwrap_err();
+        assert!(matches!(err, StateError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_defaults_stop_time_when_absent() {
+        // state.json files written before stop_time existed must still load.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let json = serde_json::to_string(&sample_state()).unwrap();
+        let without = json.replace(r#""stop_time":null,"#, "");
+        assert!(!without.contains("stop_time"));
+        fs::write(&path, without).unwrap();
+
+        let loaded = CampaignState::load(&path).unwrap();
+        assert_eq!(loaded.stop_time, None);
     }
 }

--- a/smitebot/src/tmux.rs
+++ b/smitebot/src/tmux.rs
@@ -99,6 +99,36 @@ pub fn dead_windows(session: &str) -> io::Result<Vec<String>> {
         .collect())
 }
 
+/// Returns the foreground PID of each pane in `session`.
+///
+/// Each pane runs `exec afl-fuzz`, so these are the live afl-fuzz PIDs. `stop`
+/// uses them as the authoritative source because state.json PIDs can be missing
+/// when startup verification times out. Errors if the `tmux list-panes` command
+/// fails (e.g. the session vanished); an empty vec means the session has no panes.
+pub fn list_pane_pids(session: &str) -> io::Result<Vec<u32>> {
+    let target = format!("={session}");
+    let output = Command::new("tmux")
+        .args(["list-panes", "-s", "-t", &target, "-F", "#{pane_pid}"])
+        .stderr(Stdio::null())
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "tmux list-panes failed for session {session}: {}",
+            output.status
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect())
+}
+
+/// Kills a tmux session and all of its windows.
+pub fn kill_session(session: &str) -> io::Result<()> {
+    let target = format!("={session}");
+    run_tmux(&["kill-session", "-t", &target])
+}
+
 /// Attaches to a session, using `switch-client` when already inside tmux.
 pub fn attach(session: &str) -> io::Result<()> {
     let target = format!("={session}");


### PR DESCRIPTION
## Summary

Adds `smitebot stop <campaign-id>`: tears down a running campaign and reaps  **all** of its processes, including the Nyx QEMU children that a plain `tmux kill-session` leaks.

  ## The problem

In Nyx mode each `afl-fuzz` runner spawns a QEMU child, and `tmux kill-session` only sends SIGHUP to the `afl-fuzz` panes, the QEMU children **orphan (reparented away from tmux) and keep running**.

  ## How it works

  Verified against the live process tree and AFL++ source:

  - Each `afl-fuzz` pane is its own **process-group leader**. Its QEMU child is in the **same process group** and *keeps that group id even after it orphans*. So one **group-directed kill reaps the QEMU too**.
  - In testing, an orphaned QEMU did not exit on SIGTERM, so the kill escalates **SIGTERM → SIGKILL**.
  - A killed `afl-fuzz` lingers as a **zombie** under tmux `remain-on-exit` until the session is torn down, so the "did everything die?" check ignores zombie (`Z`) states.

  `stop`:
  1. Loads `state.json` for the campaign (errors name the path + how to list campaigns).
  2. Reads the **live** runner PIDs from the tmux session (`tmux list-panes`) — *not* from `state.json`, whose PIDs can be missing (slow startup) or stale/recycled (after a reboot), killing a recycled PID's group could hit an unrelated process.
  3. `pkill -TERM -g <pgid>` each group → waits (polling, non-zombie only) → `pkill -KILL -g <pgid>` any straggler.
  4. `tmux kill-session` to remove windows and reap the zombie leaders.
  5. Records `status = "stopped"` + `stop_time` in `state.json`.

  ## state.json changes

  - New status `stopped`.  New field stop_time: Option<u64> (absent in older state files → deserializes to None, so they still load).


  **Live end-to-end test I ran** (2-runner lnd campaign):

  _Before — 2 afl-fuzz, their 2 QEMU, 1 session:_
  ```
  $ pgrep -a afl-fuzz ; pgrep -a qemu ; tmux ls
  12122 .../afl-fuzz -Y ... -M 0 ...
  12128 .../afl-fuzz -Y ... -S 1 ...
  12131 .../qemu-system-x86_64 ... worker_id=0 ... load=off
  12158 .../qemu-system-x86_64 ... worker_id=1 ... load=on
  lnd-encrypted_bytes-1783687998: 2 windows
  ```

  _Stop, then re-check — zero survivors:_
  ```
  $ smitebot stop lnd-encrypted_bytes-1783687998
  INFO  [smitebot::commands::stop] campaign lnd-encrypted_bytes-1783687998
  stopped

  $ pgrep -a afl-fuzz ; pgrep -a qemu ; tmux ls
  no server running on /tmp/tmux-1000/default

  $ grep -E 'status|stop_time'
  ~/.smitebot/runs/lnd-encrypted_bytes-1783687998/state.json
    "status": "stopped",
    "stop_time": 1783688225,
  ```
## Workflow 
Each runner group is sent SIGTERM, then SIGKILL after a grace period for anything still alive (Nyx QEMU in fast-reload mode did not exit on SIGTERM in testing). Runner PIDs are read from the live tmux session rather than `state.json`: the recorded PIDs can be stale (e.g. after a reboot) and may have been recycled by the OS, so group-killing them could hit an unrelated process. Reading from tmux also means stop works even when startup verification left the PIDs unrecorded in `state.json`.

Ref. #70 
