### PR TITLE
workloads: patch CLN to reduce the block-polling interval to 2s

### DIFF
--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -100,6 +100,12 @@ RUN sed -i '/peer->to_peer/!s/time_from_sec(5)/time_from_sec(0)/' connectd/multi
     test "$(grep -c 'time_from_sec(0)' connectd/multiplex.c)" -eq 3 && \
     test "$(grep -c 'time_from_sec(5)' connectd/multiplex.c)" -eq 1 && \
     grep -A1 'time_from_sec(5)' connectd/multiplex.c | grep -q close_peer_io_timeout
+# Reduce the block-polling interval from the 30s default to 2s. CLN only
+# notices newly confirmed transactions when this poll runs, so shorten the
+# interval to make block-related events available to scenarios promptly.
+# FIXME: tune this value down after further experiments.
+RUN sed -i 's/topo->poll_seconds = 30;/topo->poll_seconds = 2;/' lightningd/chaintopology.c && \
+    test "$(grep -c 'topo->poll_seconds = 2;' lightningd/chaintopology.c)" -eq 1
 # AFL_UBSAN_VERBOSE=1 gives us helpful UBSan reports instead of simply SIGILL.
 ENV AFL_UBSAN_VERBOSE=1
 RUN CC=afl-clang-lto ./configure --prefix=/usr/local --disable-rust \

--- a/workloads/cln/Dockerfile.coverage
+++ b/workloads/cln/Dockerfile.coverage
@@ -73,6 +73,12 @@ RUN pip3 install --break-system-packages mako
 # Remove the SIGKILL to ensure we get full coverage data.
 RUN grep -q 'kill(sd->pid, SIGKILL)' lightningd/subd.c && \
     sed -i '/kill(sd->pid, SIGKILL)/d' lightningd/subd.c
+# Reduce the block-polling interval from the 30s default to 2s. CLN only
+# notices newly confirmed transactions when this poll runs, so shorten the
+# interval to make block-related events available to scenarios promptly.
+# FIXME: tune this value down after further experiments.
+RUN sed -i 's/topo->poll_seconds = 30;/topo->poll_seconds = 2;/' lightningd/chaintopology.c && \
+    test "$(grep -c 'topo->poll_seconds = 2;' lightningd/chaintopology.c)" -eq 1
 RUN CC=clang-${LLVM_V} \
     ./configure --prefix=/usr/local --disable-rust --enable-coverage
 RUN make -j$(nproc) install


### PR DESCRIPTION
ref: https://github.com/morehouse/smite/pull/141#pullrequestreview-4674442898

CLN's chaintopology polls for new blocks every 30s by default. Patch the poll interval to 2s so scenarios observe new blocks without long delays.

Once rebased onto https://github.com/morehouse/smite/pull/146, `channel_ready` is received within the timeout
```sh
INFO  [smite_scenarios::targets::bitcoind] Starting bitcoind...
INFO  [smite_scenarios::targets::bitcoind] Waiting for bitcoind to be ready...
INFO  [smite_scenarios::targets::bitcoind] bitcoind is ready
INFO  [smite_scenarios::targets::cln] Starting lightningd...
INFO  [smite_scenarios::targets::cln] Waiting for lightningd to be ready and synced...
INFO  [smite_scenarios::targets::cln] CLN identity pubkey: 0210706ffa6bf45c7ff2d79f0d27d55c6e62f1b6a9bec461e5134d960894e1a928, blockheight: 101
INFO  [smite_scenarios::targets::cln] lightningd synced (blockheight=101)
INFO  [smite_scenarios::targets::cln] Both daemons are running, ready to fuzz
DEBUG [smite_scenarios::scenarios] Handshake complete, received target init
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [7.489µs] Executing IR program (28 instructions, 204 input bytes)
DEBUG [smite_scenarios::executor] [57.656µs] SendOpenChannel: 350 bytes
DEBUG [smite_scenarios::executor] [67.686µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [19.772242ms] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [26.892333ms] SendFundingCreated: 132 bytes
DEBUG [smite_scenarios::executor] [26.911159ms] RecvFundingSigned: waiting
DEBUG [smite_scenarios::executor] [46.806452ms] RecvFundingSigned: received
DEBUG [smite_scenarios::executor] [46.93025ms] BroadcastTransaction: txid=5c7aa1a77e13e7e6952eaf24a3ccae9cc67e7a5ac929ca8385f234fd4f1c47e6
DEBUG [smite_scenarios::executor] [68.625106ms] MineBlocks: mined 8 block(s)
DEBUG [smite_scenarios::executor] [68.642111ms] SendChannelReady: 77 bytes
DEBUG [smite_scenarios::executor] [74.405065ms] RecvChannelReady: waiting
DEBUG [smite_scenarios::executor] skipping gossip message type 258
DEBUG [smite_scenarios::executor] [1.915084801s] RecvChannelReady: received
DEBUG [smite_scenarios::scenarios::ir] [1.915100558s] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [1.915394849s] Target responded with pong
INFO  [smite::scenarios] Test case ran successfully!
DEBUG [smite_scenarios::targets::cln] lightningd: requesting graceful shutdown via lightning-cli stop
DEBUG [smite_scenarios::targets::cln] lightningd: waiting for process to exit
DEBUG [smite::process] bitcoind: dropping running process, attempting shutdown
DEBUG [smite::process] bitcoind: sending SIGTERM to process group 7
DEBUG [smite::process] bitcoind: exited with exit status: 0
```

Note that this is just a workaround to achieve the full funding flow for CLN. The execs/sec are not very good, so I’m currently experimenting with ways to tune them.