### PR TITLE
ldk: sync wallet immediately on each new block

### DIFF
--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -41,6 +41,9 @@ impl LdkConfig {
         bitcoind::BitcoindConfig {
             rpc_port: self.bitcoind_rpc_port,
             p2p_port: self.bitcoind_p2p_port,
+            // signals the wrapper (SIGUSR1) to sync on each new block instead
+            // of waiting for the next poll.
+            extra_args: vec!["-blocknotify=pkill -USR1 -f ^ldk-node-wrapper".to_string()],
             ..bitcoind::BitcoindConfig::default()
         }
     }
@@ -85,6 +88,22 @@ impl LdkTarget {
         // process teardown closes TCP sockets).
         if let Ok(handler) = std::env::var("SMITE_CRASH_HANDLER") {
             cmd.env("LD_PRELOAD", handler);
+        }
+
+        // Ignore SIGUSR1 until main() installs the real handler. Initial-block
+        // generation triggers a burst of asynchronous `-blocknotify`
+        // (`pkill -USR1`), and a stray one landing before the handler is set
+        // would kill the wrapper, since SIGUSR1 is fatal by default. SIG_IGN
+        // survives exec; a caught handler would not.
+        //
+        // SAFETY: runs in the child after fork, before exec; calls only the
+        // async-signal-safe `signal`.
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            cmd.pre_exec(|| {
+                libc::signal(libc::SIGUSR1, libc::SIG_IGN);
+                Ok(())
+            });
         }
 
         let mut ldk = ManagedProcess::spawn(&mut cmd, "ldk-node-wrapper")?;

--- a/workloads/ldk/Dockerfile
+++ b/workloads/ldk/Dockerfile
@@ -91,6 +91,7 @@ ARG SCENARIO
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libstdc++6 \
     libgcc-s1 \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy ldk-node-wrapper binary and crash handlers

--- a/workloads/ldk/Dockerfile.coverage
+++ b/workloads/ldk/Dockerfile.coverage
@@ -69,6 +69,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libstdc++6 \
     libgcc-s1 \
     ca-certificates \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy LLVM tools and shared library for coverage report generation

--- a/workloads/ldk/src/main.rs
+++ b/workloads/ldk/src/main.rs
@@ -14,8 +14,17 @@ use ldk_node::bitcoin::Network;
 /// Signal handler sets this to true to trigger shutdown.
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
+/// Set by the SIGUSR1 handler. bitcoind's `-blocknotify` sends SIGUSR1 on each
+/// new block so the main loop syncs immediately instead of waiting for the next
+/// 2s chain poll.
+static NEW_BLOCK: AtomicBool = AtomicBool::new(false);
+
 extern "C" fn handle_signal(_: libc::c_int) {
     SHUTDOWN.store(true, Ordering::SeqCst);
+}
+
+extern "C" fn handle_block(_: libc::c_int) {
+    NEW_BLOCK.store(true, Ordering::SeqCst);
 }
 
 fn main() {
@@ -25,6 +34,8 @@ fn main() {
         let sighandler = handle_signal as *const () as libc::sighandler_t;
         libc::signal(libc::SIGTERM, sighandler);
         libc::signal(libc::SIGINT, sighandler);
+        let blockhandler = handle_block as *const () as libc::sighandler_t;
+        libc::signal(libc::SIGUSR1, blockhandler);
     }
 
     let args: Vec<String> = std::env::args().collect();
@@ -74,7 +85,19 @@ fn main() {
 
     // Wait for shutdown signal
     while !SHUTDOWN.load(Ordering::SeqCst) {
-        std::thread::sleep(Duration::from_millis(100));
+        // Sync the wallet whenever bitcoind signals a new block. ldk-node's own
+        // 2s background poll keeps running, so this is technically redundant and
+        // may race it, but that's safe: ldk-node coalesces concurrent syncs, so
+        // whichever loses the race just waits on the in-flight sync's result
+        // rather than applying the block twice. We accept the redundancy to sync
+        // on the block instead of up to 2s later.
+        if NEW_BLOCK.swap(false, Ordering::SeqCst)
+            && let Err(e) = node.sync_wallets()
+        {
+            eprintln!("sync_wallets failed: {e}");
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
     }
 
     node.stop().expect("node stop");


### PR DESCRIPTION
ref: #143 

ldk-node currently polls the chain every 2s, so we have to wait up to 2s to receive `channel_ready` after the funding tx has confirmed and new blocks have been mined. One way to fix this would be to patch the library (using some hacky approach) and reduce the polling interval. Another option is to use ldk-node’s `sync_wallets` API, which triggers a manual chain sync in the same way as the default polling mechanism. A third option is to add custom ZMQ logic to ldk-node (again, via some hacky approach) so it can receive block notifications immediately.

This PR takes the second approach, inspired by the existing signal handler used to shut down ldk-node and by how the rust implementation of the Electrum server handles this: https://github.com/romanz/electrs/blob/3e4b49886d0a675a202b3968aba8167f69d584b2/src/signals.rs#L64-L78

Core provides the `-blocknotify` hook, which spawns a shell process to run a cmd whenever a new block is accepted. This PR uses that hook to send `SIGUSR1` to `ldk-node-wrapper`. The wrapper listens for this signal and, when received, calls the `sync_wallets` API to trigger an immediate chain sync.

```sh
INFO  [smite_scenarios::targets::bitcoind] Starting bitcoind...
INFO  [smite_scenarios::targets::bitcoind] Waiting for bitcoind to be ready...
INFO  [smite_scenarios::targets::bitcoind] bitcoind is ready
INFO  [smite_scenarios::targets::ldk] Starting ldk-node-wrapper...
INFO  [smite_scenarios::targets::ldk] LDK identity pubkey: 02a7c9c397cb9349436258fbd093e4f3d35f10404f06400c2d1f150f1be5c0954b
INFO  [smite_scenarios::targets::ldk] ldk-node-wrapper is ready and synced
INFO  [smite_scenarios::targets::ldk] Both daemons are running, ready to fuzz
DEBUG [smite_scenarios::scenarios] Handshake complete, received target init
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [3.835µs] Executing IR program (28 instructions, 204 input bytes)
DEBUG [smite_scenarios::executor] [62.464µs] SendOpenChannel: 349 bytes
DEBUG [smite_scenarios::executor] [70.49µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [4.727553ms] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [10.376372ms] SendFundingCreated: 132 bytes
DEBUG [smite_scenarios::executor] [10.387942ms] RecvFundingSigned: waiting
DEBUG [smite_scenarios::executor] [12.733584ms] RecvFundingSigned: received
DEBUG [smite_scenarios::executor] [12.992208ms] BroadcastTransaction: txid=5f2376e8aaf24a53d6024e9a4c97e7b6ca0166e8ff7c3b140690722ab900d45f
DEBUG [smite_scenarios::executor] [31.531731ms] MineBlocks: mined 8 block(s)
DEBUG [smite_scenarios::executor] [31.540853ms] SendChannelReady: 77 bytes
DEBUG [smite_scenarios::executor] [37.002874ms] RecvChannelReady: waiting
DEBUG [smite_scenarios::executor] [75.280356ms] RecvChannelReady: received
DEBUG [smite_scenarios::scenarios::ir] [75.293886ms] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [115.762316ms] Target responded with pong
INFO  [smite::scenarios] Test case ran successfully!
DEBUG [smite::process] ldk-node-wrapper: dropping running process, attempting shutdown
DEBUG [smite::process] ldk-node-wrapper: sending SIGTERM to process group 356
DEBUG [smite::process] ldk-node-wrapper: exited with exit status: 0
DEBUG [smite::process] bitcoind: dropping running process, attempting shutdown
DEBUG [smite::process] bitcoind: sending SIGTERM to process group 7
DEBUG [smite::process] bitcoind: exited with exit status: 0
```

I verified this by running a campaign over the weekend and found no issues in LDK
