### PR TITLE
smite-ir: add LookupShortChannelId operation

### DIFF
--- a/smite-ir/src/mutators/operation_param.rs
+++ b/smite-ir/src/mutators/operation_param.rs
@@ -116,7 +116,8 @@ fn mutate_operation(op: &mut Operation, rng: &mut impl Rng) -> bool {
         | Operation::RecvAcceptChannel
         | Operation::RecvFundingSigned
         | Operation::RecvChannelReady
-        | Operation::BroadcastTransaction => {
+        | Operation::BroadcastTransaction
+        | Operation::LookupShortChannelId => {
             unreachable!("is_param_mutable returned true for {op:?}")
         }
     }

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -226,6 +226,32 @@ pub enum Operation {
     /// Sign wallet inputs of the transaction and broadcast it via `bitcoin-cli`.
     /// Input: `FundingTransaction`.
     BroadcastTransaction,
+    /// Look up the confirmed block position of a broadcast funding transaction
+    /// and produce the corresponding BOLT 7 `short_channel_id`.
+    ///
+    /// This is the bridge between an on-chain funding output and the gossip
+    /// layer: the resulting `ShortChannelId` can be fed into
+    /// `BuildChannelAnnouncement`, `BuildChannelUpdate`, and
+    /// `BuildAnnouncementSignatures` so that gossip messages reference a real
+    /// UTXO and can pass the on-chain validation performed by CLN and LND.
+    ///
+    /// The typical program shape is:
+    ///
+    /// ```text
+    /// ft   = CreateFundingTransaction(...)
+    /// _    = BroadcastTransaction(ft)
+    /// _    = MineBlocks(k)          // k >= 1 for the tx to be confirmed
+    /// scid = LookupShortChannelId(ft)
+    /// ```
+    ///
+    /// If the funding transaction is unknown to the node or still in the
+    /// mempool (e.g. `MineBlocks` was dropped by a mutator), the sentinel
+    /// `ShortChannelId::new(0, 0, 0)` is produced. This keeps downstream
+    /// consumers well-typed without introducing a target- or program-side
+    /// error: any resulting gossip message simply fails on-chain validation.
+    ///
+    /// Input: `FundingTransaction`.
+    LookupShortChannelId,
 }
 
 /// A BOLT 2 compliant `upfront_shutdown_script` template.
@@ -680,6 +706,7 @@ impl fmt::Display for Operation {
             Self::RecvFundingSigned => write!(f, "RecvFundingSigned"),
             Self::RecvChannelReady => write!(f, "RecvChannelReady()"),
             Self::BroadcastTransaction => write!(f, "BroadcastTransaction"),
+            Self::LookupShortChannelId => write!(f, "LookupShortChannelId"),
         }
     }
 }
@@ -691,7 +718,9 @@ impl Operation {
     pub fn output_type(&self) -> Option<VariableType> {
         match self {
             Self::LoadAmount(_) => Some(VariableType::Amount),
-            Self::LoadShortChannelId(_) => Some(VariableType::ShortChannelId),
+            Self::LoadShortChannelId(_) | Self::LookupShortChannelId => {
+                Some(VariableType::ShortChannelId)
+            }
             Self::LoadFeeratePerKw(_) => Some(VariableType::FeeratePerKw),
             Self::LoadBlockHeight(_) => Some(VariableType::BlockHeight),
             Self::LoadTimestamp(_) => Some(VariableType::Timestamp),
@@ -768,7 +797,9 @@ impl Operation {
             ],
             Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
             Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
-            Self::BroadcastTransaction => vec![VariableType::FundingTransaction],
+            Self::BroadcastTransaction | Self::LookupShortChannelId => {
+                vec![VariableType::FundingTransaction]
+            }
 
             Self::BuildOpenChannel => vec![
                 VariableType::ChainHash,    // chain_hash
@@ -876,7 +907,8 @@ impl Operation {
             | Self::RecvFundingSigned
             | Self::RecvChannelReady
             | Self::MineBlocks(_)
-            | Self::BroadcastTransaction => vec![],
+            | Self::BroadcastTransaction
+            | Self::LookupShortChannelId => vec![],
 
             Self::RecvAcceptChannel => AcceptChannelField::ALL
                 .iter()
@@ -899,7 +931,8 @@ impl Operation {
             | Self::RecvChannelReady
             | Self::MineBlocks(_)
             | Self::CreateFundingTransaction
-            | Self::BroadcastTransaction => true,
+            | Self::BroadcastTransaction
+            | Self::LookupShortChannelId => true,
             Self::LoadAmount(_)
             | Self::LoadShortChannelId(_)
             | Self::BuildChannelAnnouncement
@@ -964,7 +997,8 @@ impl Operation {
             | Self::RecvAcceptChannel
             | Self::RecvFundingSigned
             | Self::RecvChannelReady
-            | Self::BroadcastTransaction => false,
+            | Self::BroadcastTransaction
+            | Self::LookupShortChannelId => false,
         }
     }
 }

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -669,6 +669,18 @@ fn create_and_broadcast_tx_operation() {
     assert!(!op.is_param_mutable());
 }
 
+#[test]
+fn lookup_short_channel_id_operation() {
+    let op = Operation::LookupShortChannelId;
+    assert_eq!(op.input_types(), vec![VariableType::FundingTransaction]);
+    assert_eq!(op.output_type(), Some(VariableType::ShortChannelId));
+    assert!(!op.is_param_mutable());
+    // Non-deterministic (depends on chain state), so must not be dropped by DCE
+    // or deduplicated by CSE.
+    assert!(op.has_side_effects());
+    assert_eq!(op.to_string(), "LookupShortChannelId");
+}
+
 fn create_and_broadcast_tx_instructions() -> Vec<Instruction> {
     vec![
         Instruction {

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -6,7 +6,7 @@
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::{OutPoint, ScriptBuf, Txid};
-use smite::bitcoin::{BitcoinCli, Utxo};
+use smite::bitcoin::{BitcoinCli, TxBlockPosition, Utxo};
 use smite::bolt::{
     AcceptChannel, AnnouncementSignatures, ChannelAnnouncement, ChannelId, ChannelReady,
     ChannelReadyTlvs, ChannelUpdate, FundingCreated, FundingSigned, Message, NodeAnnouncement,
@@ -82,6 +82,10 @@ pub trait BitcoinRpc {
     /// Returns the number of confirmations for the transaction with the given
     /// txid, or `0` if it is unconfirmed or unknown to the node.
     fn get_transaction_confirmations(&mut self, txid: Txid) -> u32;
+
+    /// Returns the confirmed block position of the transaction with the given
+    /// txid, or `None` if it is unconfirmed or unknown to the node.
+    fn get_transaction_block_position(&mut self, txid: Txid) -> Option<TxBlockPosition>;
 }
 
 impl BitcoinRpc for BitcoinCli {
@@ -107,6 +111,10 @@ impl BitcoinRpc for BitcoinCli {
 
     fn get_transaction_confirmations(&mut self, txid: Txid) -> u32 {
         BitcoinCli::get_transaction_confirmations(self, txid)
+    }
+
+    fn get_transaction_block_position(&mut self, txid: Txid) -> Option<TxBlockPosition> {
+        BitcoinCli::get_transaction_block_position(self, txid)
     }
 }
 
@@ -490,6 +498,36 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     );
                     self.bitcoin_cli.sign_and_broadcast_tx(&ft.tx);
                     None
+                }
+
+                Operation::LookupShortChannelId => {
+                    let ft = resolve_funding_transaction(&variables, instr.inputs[0]);
+                    let txid = ft.tx.compute_txid();
+                    // Fall back to a sentinel SCID when the transaction is
+                    // unknown to the node or still in the mempool (e.g. a
+                    // mutator dropped `MineBlocks`). The resulting gossip
+                    // message will simply fail on-chain validation, which is
+                    // the intended fuzzing behaviour for a valid but
+                    // unconfirmed program.
+                    let scid = match self.bitcoin_cli.get_transaction_block_position(txid) {
+                        Some(pos) => {
+                            let funding_output_index =
+                                u16::try_from(ft.vout).expect("funding output index fits in u16");
+                            ShortChannelId::new(
+                                pos.block_height,
+                                pos.tx_index,
+                                funding_output_index,
+                            )
+                        }
+                        None => ShortChannelId::new(0, 0, 0),
+                    };
+                    log::debug!(
+                        "[{:?}] LookupShortChannelId: txid={} scid={}",
+                        start.elapsed(),
+                        txid,
+                        scid,
+                    );
+                    Some(Variable::ShortChannelId(scid))
                 }
             };
 
@@ -1393,6 +1431,7 @@ mod tests {
     struct MockBitcoinCli {
         mine_blocks_calls: Vec<u8>,
         broadcast_calls: Vec<Transaction>,
+        block_position_lookups: Vec<Txid>,
         utxos: Vec<Utxo>,
         change_spk: ScriptBuf,
         confirmations: u32,
@@ -1422,6 +1461,16 @@ mod tests {
 
         fn get_transaction_confirmations(&mut self, _txid: Txid) -> u32 {
             self.confirmations
+        }
+
+        fn get_transaction_block_position(&mut self, txid: Txid) -> Option<TxBlockPosition> {
+            self.block_position_lookups.push(txid);
+            // Distinctive coordinates so tests can verify the executor
+            // combined them with the funding transaction's vout.
+            (self.confirmations > 0).then_some(TxBlockPosition {
+                block_height: 800_042,
+                tx_index: 7,
+            })
         }
     }
 
@@ -1620,6 +1669,73 @@ mod tests {
                 inputs: vec![6],
             },
         ]
+    }
+
+    /// Builds instructions that construct and send a `channel_announcement`
+    /// referencing the `ShortChannelId` produced at variable index `scid_var`.
+    ///
+    /// `base` is the variable index the first appended instruction will occupy
+    /// (i.e. the current program length), used to wire up the inputs to
+    /// `BuildChannelAnnouncement`.
+    fn channel_announcement_from_scid_instructions(
+        base: usize,
+        scid_var: usize,
+    ) -> Vec<Instruction> {
+        vec![
+            Instruction {
+                operation: Operation::LoadFeatures(vec![0x01, 0x02]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadChainHashFromContext,
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey([0x11; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey([0x22; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey([0x33; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey([0x44; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::BuildChannelAnnouncement,
+                // features, chain_hash, short_channel_id, node_sk_1, node_sk_2,
+                // bitcoin_sk_1, bitcoin_sk_2.
+                inputs: vec![
+                    base,
+                    base + 1,
+                    scid_var,
+                    base + 2,
+                    base + 3,
+                    base + 4,
+                    base + 5,
+                ],
+            },
+            Instruction {
+                operation: Operation::SendMessage,
+                inputs: vec![base + 6],
+            },
+        ]
+    }
+
+    /// Decodes a sent message expected to be a `channel_announcement`.
+    fn decode_sent_channel_announcement(bytes: &[u8]) -> ChannelAnnouncement {
+        match Message::decode(bytes).expect("valid message") {
+            Message::ChannelAnnouncement(ca) => ca,
+            other => panic!(
+                "expected ChannelAnnouncement, got type {}",
+                other.msg_type()
+            ),
+        }
     }
 
     fn decode_open_channel(bytes: &[u8]) -> OpenChannel {
@@ -2818,6 +2934,125 @@ mod tests {
             broadcast_tx.compute_txid().to_string(),
             "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
         );
+    }
+
+    // LookupShortChannelId should combine the confirmed block position with
+    // the funding output's vout to produce the correct SCID, which we verify
+    // by feeding it into a channel_announcement and decoding the sent message.
+    #[test]
+    fn execute_lookup_short_channel_id_confirmed() {
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        let mut instrs = create_and_broadcast_tx_instructions();
+        instrs.push(Instruction {
+            operation: Operation::MineBlocks(6),
+            inputs: vec![],
+        });
+        instrs.push(Instruction {
+            // Feed the FundingTransaction produced by
+            // CreateFundingTransaction (instruction 6) into the lookup. The
+            // resulting ShortChannelId is variable 9.
+            operation: Operation::LookupShortChannelId,
+            inputs: vec![6],
+        });
+        // Build and send a channel_announcement carrying the looked-up SCID.
+        instrs.extend(channel_announcement_from_scid_instructions(instrs.len(), 9));
+
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .expect("lookup after confirmation should succeed");
+
+        assert_eq!(executor.bitcoin_cli.mine_blocks_calls, vec![6]);
+        // The executor must have queried the mock with the broadcast
+        // transaction's txid.
+        assert_eq!(executor.bitcoin_cli.block_position_lookups.len(), 1);
+        let broadcast_txid = executor.bitcoin_cli.broadcast_calls[0].compute_txid();
+        assert_eq!(
+            executor.bitcoin_cli.block_position_lookups[0],
+            broadcast_txid,
+        );
+
+        // The mock returns block_height=800_042, tx_index=7 for a confirmed
+        // tx, and the funding output is always at vout 0.
+        let ca = decode_sent_channel_announcement(&executor.conn.sent[0]);
+        assert_eq!(ca.short_channel_id, ShortChannelId::new(800_042, 7, 0));
+    }
+
+    // LookupShortChannelId should produce the sentinel SCID (0/0/0) when the
+    // funding transaction is unknown to the node (e.g. never broadcast or
+    // never confirmed), rather than panicking. We verify the sentinel value
+    // via the SCID carried in a channel_announcement.
+    #[test]
+    fn execute_lookup_short_channel_id_unconfirmed_returns_sentinel() {
+        let mock_cli = MockBitcoinCli {
+            utxos: vec![sample_utxo()],
+            change_spk: sample_change_spk(),
+            ..Default::default()
+        };
+        // No BroadcastTransaction and no MineBlocks: the mock reports zero
+        // confirmations and get_transaction_block_position returns None.
+        let mut instrs = vec![
+            Instruction {
+                operation: Operation::LoadPrivateKey([1u8; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![0],
+            },
+            Instruction {
+                operation: Operation::LoadPrivateKey([2u8; 32]),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::DerivePoint,
+                inputs: vec![2],
+            },
+            Instruction {
+                operation: Operation::LoadAmount(10_000_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::LoadFeeratePerKw(15_000),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::CreateFundingTransaction,
+                inputs: vec![1, 3, 4, 5],
+            },
+            // The looked-up SCID is variable 7.
+            Instruction {
+                operation: Operation::LookupShortChannelId,
+                inputs: vec![6],
+            },
+        ];
+        instrs.extend(channel_announcement_from_scid_instructions(instrs.len(), 7));
+
+        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .expect("lookup on unconfirmed tx should not fail");
+        // The mock was queried but returned None (zero confirmations), so the
+        // executor took the sentinel path without panicking.
+        assert!(executor.bitcoin_cli.mine_blocks_calls.is_empty());
+        assert_eq!(executor.bitcoin_cli.block_position_lookups.len(), 1);
+
+        let ca = decode_sent_channel_announcement(&executor.conn.sent[0]);
+        assert_eq!(ca.short_channel_id, ShortChannelId::new(0, 0, 0));
     }
 
     #[test]


### PR DESCRIPTION
Adds `LookupShortChannelId`, which takes a `FundingTransaction` and produces the BOLT 7 `short_channel_id` derived from its confirmed block position.

This is the missing piece needed to build validly-signed gossip messages that reference a real on-chain UTXO and can pass the UTXO validation checks in CLN and LND.

If the transaction is not yet confirmed (e.g. a mutator dropped `MineBlocks`), the sentinel `ShortChannelId::new(0, 0, 0)` is returned rather than panicking. A valid but unconfirmed program should not be a fatal error.

Ref: #71