### PR TITLE
workloads+smite-scenarios: patch CLN to sync with new blocks faster

### DIFF
--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -43,10 +43,14 @@ impl Default for ClnConfig {
 }
 
 impl ClnConfig {
-    fn bitcoind_config(&self) -> bitcoind::BitcoindConfig {
+    fn bitcoind_config(&self, data_dir: &Path) -> bitcoind::BitcoindConfig {
         bitcoind::BitcoindConfig {
             rpc_port: self.bitcoind_rpc_port,
             p2p_port: self.bitcoind_p2p_port,
+            extra_args: vec![format!(
+                "-blocknotify=lightning-cli --lightning-dir='{}' --network=regtest syncblocks",
+                data_dir.join("cln").display()
+            )],
             ..bitcoind::BitcoindConfig::default()
         }
     }
@@ -207,7 +211,8 @@ impl Target for ClnTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let bitcoind_config = config.bitcoind_config(&data_path);
+        let (bitcoind, bitcoin_cli) = bitcoind::start(&bitcoind_config, &data_path)?;
         let (cln, pubkey, cln_dir) = Self::start_cln(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.cln_p2p_port));
 

--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -106,6 +106,13 @@ RUN sed -i '/peer->to_peer/!s/time_from_sec(5)/time_from_sec(0)/' connectd/multi
 # FIXME: tune this value down after further experiments.
 RUN sed -i 's/topo->poll_seconds = 30;/topo->poll_seconds = 2;/' lightningd/chaintopology.c && \
     test "$(grep -c 'topo->poll_seconds = 2;' lightningd/chaintopology.c)" -eq 1
+# Add a `syncblocks` RPC command that forces CLN to poll for new blocks
+# immediately instead of waiting for the polling timer. Scenarios can call it
+# on demand after mining a block. This complements periodic polling: concurrent
+# requests are coalesced, and polling still catches any blocks missed while CLN
+# is processing a previous chain update.
+COPY workloads/cln/patches/syncblocks.patch .
+RUN git apply syncblocks.patch
 # AFL_UBSAN_VERBOSE=1 gives us helpful UBSan reports instead of simply SIGILL.
 ENV AFL_UBSAN_VERBOSE=1
 RUN CC=afl-clang-lto ./configure --prefix=/usr/local --disable-rust \

--- a/workloads/cln/Dockerfile.coverage
+++ b/workloads/cln/Dockerfile.coverage
@@ -79,6 +79,13 @@ RUN grep -q 'kill(sd->pid, SIGKILL)' lightningd/subd.c && \
 # FIXME: tune this value down after further experiments.
 RUN sed -i 's/topo->poll_seconds = 30;/topo->poll_seconds = 2;/' lightningd/chaintopology.c && \
     test "$(grep -c 'topo->poll_seconds = 2;' lightningd/chaintopology.c)" -eq 1
+# Add a `syncblocks` RPC command that forces CLN to poll for new blocks
+# immediately instead of waiting for the polling timer. Scenarios can call it
+# on demand after mining a block. This complements periodic polling: concurrent
+# requests are coalesced, and polling still catches any blocks missed while CLN
+# is processing a previous chain update.
+COPY workloads/cln/patches/syncblocks.patch .
+RUN git apply syncblocks.patch
 RUN CC=clang-${LLVM_V} \
     ./configure --prefix=/usr/local --disable-rust --enable-coverage
 RUN make -j$(nproc) install

--- a/workloads/cln/patches/syncblocks.patch
+++ b/workloads/cln/patches/syncblocks.patch
@@ -1,0 +1,35 @@
+diff --git a/lightningd/chaintopology.c b/lightningd/chaintopology.c
+index e59b9c635..f1ae3e440 100644
+--- a/lightningd/chaintopology.c
++++ b/lightningd/chaintopology.c
+@@ -1128,6 +1128,30 @@ static void try_extend_tip(struct chain_topology *topo)
+ 				     get_new_block, topo);
+ }
+ 
++static struct command_result *json_syncblocks(struct command *cmd,
++					      const char *buffer,
++					      const jsmntok_t *obj UNNEEDED,
++					      const jsmntok_t *params)
++{
++	struct chain_topology *topo = cmd->ld->topology;
++
++	if (!param(cmd, buffer, params, NULL))
++		return command_param_failed();
++
++	if (topo->extend_timer) {
++		topo->extend_timer = tal_free(topo->extend_timer);
++		try_extend_tip(topo);
++	}
++
++	return command_success(cmd, json_stream_success(cmd));
++}
++
++static const struct json_command syncblocks_command = {
++	"syncblocks",
++	json_syncblocks,
++};
++AUTODATA(json_command, &syncblocks_command);
++
+ u32 get_block_height(const struct chain_topology *topo)
+ {
+ 	return topo->tip->height;


### PR DESCRIPTION
ref: #143 

I tried two approaches for CLN:
- Patch the polling interval from 30s (currently 2s) to 50ms
- Add a new `syncblocks` RPC that triggers an immediate chain sync, and tie it to bitcoind’s `-blocknotify` hook

In both cases, I ran campaign for 2 days and didn’t observe any target-side issues, so both approaches appear to be stable. To determine which approach performs better, I compared their coverage using the smite evaluation script. I ran five 1h trials for each approach, then replayed the generated corpus from each trial in local mode while measuring the CPU overhead for both CLN and `bitcoind`. Here are the resulting plots for reference (Let me know if running longer campaign trials would provide a better comparison?):

### Target: cln

#### Median Coverage Over Time

![cln Time Series](https://github.com/user-attachments/assets/7db773c5-ec91-47b3-a4ba-0837ca68cf0b)

#### Distribution Comparisons

| Final Edge Coverage | Area Under Curve (Speed) |
|:---:|:---:|
| ![cln Boxplot](https://github.com/user-attachments/assets/86457e3a-b60c-4277-aa15-d814fbea8d6a) | ![cln AUC](https://github.com/user-attachments/assets/6b5f6e3c-2b51-4eed-9cac-36269053410f) |

---

#### CPU Overhead (median)
![cln CPU Overhead](https://github.com/user-attachments/assets/99fe9502-9513-4957-b7f8-0f6fca517459)

With the 50ms polling interval approach:

```sh
INFO  [smite_scenarios::targets::bitcoind] Starting bitcoind...
INFO  [smite_scenarios::targets::bitcoind] Waiting for bitcoind to be ready...
INFO  [smite_scenarios::targets::bitcoind] bitcoind is ready
INFO  [smite_scenarios::targets::cln] Starting lightningd...
INFO  [smite_scenarios::targets::cln] Waiting for lightningd to be ready and synced...
INFO  [smite_scenarios::targets::cln] CLN identity pubkey: 021821158262e148a50c40b8e4eed6ad2f3a8a5dae475ba5c8269e8881a664fff6, blockheight: 101
INFO  [smite_scenarios::targets::cln] lightningd synced (blockheight=101)
INFO  [smite_scenarios::targets::cln] Both daemons are running, ready to fuzz
DEBUG [smite_scenarios::scenarios] Handshake complete, received target init
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [9.559µs] Executing IR program (28 instructions, 204 input bytes)
DEBUG [smite_scenarios::executor] [59.887µs] SendOpenChannel: 349 bytes
DEBUG [smite_scenarios::executor] [73.212µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [17.164578ms] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [23.921416ms] SendFundingCreated: 132 bytes
DEBUG [smite_scenarios::executor] [23.93913ms] RecvFundingSigned: waiting
DEBUG [smite_scenarios::executor] [41.149847ms] RecvFundingSigned: received
DEBUG [smite_scenarios::executor] [41.309537ms] BroadcastTransaction: txid=a982a06080d7d843d62b56a265ea1201d7f7ac47c7fd32cea854b4e1304906a8
DEBUG [smite_scenarios::executor] [73.766602ms] MineBlocks: mined 8 block(s)
DEBUG [smite_scenarios::executor] [73.781275ms] SendChannelReady: 77 bytes
DEBUG [smite_scenarios::executor] [84.409964ms] RecvChannelReady: waiting
DEBUG [smite_scenarios::executor] skipping gossip message type 258
DEBUG [smite_scenarios::executor] [166.947336ms] RecvChannelReady: received
DEBUG [smite_scenarios::scenarios::ir] [166.954511ms] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [167.001796ms] Target responded with pong
INFO  [smite::scenarios] Test case ran successfully!
DEBUG [smite_scenarios::targets::cln] lightningd: requesting graceful shutdown via lightning-cli stop
DEBUG [smite_scenarios::targets::cln] lightningd: waiting for process to exit
DEBUG [smite::process] bitcoind: dropping running process, attempting shutdown
DEBUG [smite::process] bitcoind: sending SIGTERM to process group 7
DEBUG [smite::process] bitcoind: exited with exit status: 0
```

With the `-blocknotify` hook approach:

```sh
INFO  [smite_scenarios::targets::bitcoind] Starting bitcoind...
INFO  [smite_scenarios::targets::bitcoind] Waiting for bitcoind to be ready...
INFO  [smite_scenarios::targets::bitcoind] bitcoind is ready
INFO  [smite_scenarios::targets::cln] Starting lightningd...
INFO  [smite_scenarios::targets::cln] Waiting for lightningd to be ready and synced...
INFO  [smite_scenarios::targets::cln] CLN identity pubkey: 031b4bda84b978bcc29a6dc8c5a0fdbf66e6bbe4d4a29cda105c99d42510291bcc, blockheight: 101
INFO  [smite_scenarios::targets::cln] lightningd synced (blockheight=101)
INFO  [smite_scenarios::targets::cln] Both daemons are running, ready to fuzz
DEBUG [smite_scenarios::scenarios] Handshake complete, received target init
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [7.524µs] Executing IR program (28 instructions, 204 input bytes)
DEBUG [smite_scenarios::executor] [61.873µs] SendOpenChannel: 349 bytes
DEBUG [smite_scenarios::executor] [72.363µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [17.631703ms] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [23.81154ms] SendFundingCreated: 132 bytes
DEBUG [smite_scenarios::executor] [23.828741ms] RecvFundingSigned: waiting
DEBUG [smite_scenarios::executor] [42.806291ms] RecvFundingSigned: received
DEBUG [smite_scenarios::executor] [43.058768ms] BroadcastTransaction: txid=5f1961dff6b10103072fdd66d72c71a7a2ef0f4f7a0acef1c95871c6ea136cb0
DEBUG [smite_scenarios::executor] [72.396396ms] MineBlocks: mined 8 block(s)
DEBUG [smite_scenarios::executor] [72.413794ms] SendChannelReady: 77 bytes
DEBUG [smite_scenarios::executor] [81.454544ms] RecvChannelReady: waiting
DEBUG [smite_scenarios::executor] skipping gossip message type 258
DEBUG [smite_scenarios::executor] [119.480716ms] RecvChannelReady: received
DEBUG [smite_scenarios::scenarios::ir] [119.486254ms] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [119.546017ms] Target responded with pong
INFO  [smite::scenarios] Test case ran successfully!
DEBUG [smite_scenarios::targets::cln] lightningd: requesting graceful shutdown via lightning-cli stop
DEBUG [smite_scenarios::targets::cln] lightningd: waiting for process to exit
DEBUG [smite::process] bitcoind: dropping running process, attempting shutdown
DEBUG [smite::process] bitcoind: sending SIGTERM to process group 6
DEBUG [smite::process] bitcoind: exited with exit status: 0
```

