### PR TITLE
smite-scenarios: expect channel_ready only for a valid funding outpoint

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -873,11 +873,20 @@ fn build_funding_created(
 
     let channel_id = ChannelId::v1_from_funding_outpoint(config.funding_outpoint);
 
+    // Check whether the funding outpoint is valid and contains the negotiated
+    // amount and funding script. If not, there is a good chance the target will
+    // neither complete the funding flow nor send an error message.
+    let is_funding_outpoint_valid = funding_tx.matches_funding_output(
+        &open_channel.funding_pubkey,
+        &accept_channel.funding_pubkey,
+        open_channel.funding_satoshis,
+    );
+
     // Building the same message again must not clobber a channel whose state
     // has already been established (and possibly advanced).
     channel_states
         .entry(channel_id)
-        .or_insert_with(|| ChannelState::new(config, holder, state));
+        .or_insert_with(|| ChannelState::new(config, holder, state, is_funding_outpoint_valid));
 
     // Mark this negotiation as having built `funding_created`. It is retained
     // so repeated `funding_created` messages can still be built, but a later
@@ -1194,7 +1203,8 @@ fn recv_channel_ready(
 /// Returns `true` if the target owes us a `channel_ready` message.
 ///
 /// A `channel_ready` is expected when a tracked channel is still at commitment
-/// number 0, the counterparty's next per-commitment point is unknown, and the
+/// number 0, the counterparty's next per-commitment point is unknown, the
+/// advertised funding outpoint pays the negotiated funding output, and the
 /// funding transaction has at least [`MAX_MINIMUM_DEPTH`] confirmations.
 fn is_channel_ready_expected(
     channel_states: &HashMap<ChannelId, ChannelState>,
@@ -1203,6 +1213,7 @@ fn is_channel_ready_expected(
     channel_states.values().any(|state| {
         state.commitment.commitment_number == 0
             && state.next_counterparty_per_commitment_point().is_none()
+            && state.is_funding_outpoint_valid
             && bitcoin_cli.get_transaction_confirmations(state.config.funding_outpoint.txid)
                 >= MAX_MINIMUM_DEPTH
     })
@@ -3395,6 +3406,50 @@ mod tests {
             .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
 
         (executor, channel_id, target_pcp)
+    }
+
+    #[test]
+    fn execute_recv_channel_ready_invalid_funding_outpoint_is_noop() {
+        let (mut executor, channel_id, _) = recv_channel_ready_executor();
+
+        // Corrupt the negotiated opener funding pubkey so the broadcast funding
+        // transaction's output no longer pays the negotiated 2-of-2 script,
+        // marking the funding outpoint invalid.
+        executor
+            .negotiations
+            .get_mut(&ChannelId::new([0xbb; 32]))
+            .unwrap()
+            .open_channel
+            .funding_pubkey = sample_pubkey(1);
+
+        let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
+        instrs.extend([
+            Instruction {
+                operation: Operation::MineBlocks(8),
+                inputs: vec![],
+            },
+            Instruction {
+                operation: Operation::RecvChannelReady,
+                inputs: vec![],
+            },
+        ]);
+
+        // With invalid funding outpoint the target does not owe us a
+        // `channel_ready`, so `RecvChannelReady` must be a no-op.
+        executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        // The target's next per-commitment point is still unknown and the queued
+        // `channel_ready` remains untouched.
+        let state = executor.channel_states.get_mut(&channel_id).unwrap();
+        assert!(state.next_counterparty_per_commitment_point().is_none());
+        assert_eq!(executor.conn.recv_queue.len(), 1);
     }
 
     #[test]

--- a/smite/src/channel_tx/commitment.rs
+++ b/smite/src/channel_tx/commitment.rs
@@ -130,6 +130,9 @@ pub struct ChannelState {
     /// revealed by `channel_ready` and then each `revoke_and_ack`. `None` until
     /// known.
     pub acceptor_next_per_commitment_point: Option<PublicKey>,
+    /// Whether the on-chain output at the advertised funding outpoint matches
+    /// the negotiated funding script and amount.
+    pub is_funding_outpoint_valid: bool,
 }
 
 impl Side {
@@ -153,13 +156,19 @@ impl HolderIdentity {
 impl ChannelState {
     /// Constructs a channel state with both next per-commitment points unknown.
     #[must_use]
-    pub fn new(config: ChannelConfig, holder: HolderIdentity, commitment: CommitmentState) -> Self {
+    pub fn new(
+        config: ChannelConfig,
+        holder: HolderIdentity,
+        commitment: CommitmentState,
+        is_funding_outpoint_valid: bool,
+    ) -> Self {
         Self {
             config,
             holder,
             commitment,
             opener_next_per_commitment_point: None,
             acceptor_next_per_commitment_point: None,
+            is_funding_outpoint_valid,
         }
     }
 

--- a/smite/src/channel_tx/funding.rs
+++ b/smite/src/channel_tx/funding.rs
@@ -168,6 +168,24 @@ fn predict_tx_fee(
     Amount::from_sat((u64::from(feerate_per_kw) * weight.to_wu()) / 1000)
 }
 
+impl FundingTransaction {
+    /// Returns whether the referenced funding output matches the negotiated
+    /// output script and amount.
+    #[must_use]
+    pub fn matches_funding_output(
+        &self,
+        opener_funding_pubkey: &PublicKey,
+        acceptor_funding_pubkey: &PublicKey,
+        funding_satoshis: u64,
+    ) -> bool {
+        let expected_spk =
+            build_funding_witness_script(opener_funding_pubkey, acceptor_funding_pubkey).to_p2wsh();
+        self.tx.output.get(self.vout as usize).is_some_and(|out| {
+            out.script_pubkey == expected_spk && out.value.to_sat() == funding_satoshis
+        })
+    }
+}
+
 /// Builds the funding output witness script per BOLT 3.
 pub fn build_funding_witness_script(pubkey1: &PublicKey, pubkey2: &PublicKey) -> ScriptBuf {
     let key1_bytes = pubkey1.serialize();
@@ -701,5 +719,66 @@ mod tests {
             hex::encode(funding_witness_script_1.as_bytes()),
             "5221023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb21030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c152ae"
         );
+    }
+
+    #[test]
+    fn funding_output_matches_detects_matching_and_mismatched_outputs() {
+        let opener_funding_pubkey =
+            pubkey("023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb");
+        let acceptor_funding_pubkey =
+            pubkey("030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c1");
+        let funding_satoshis = 10_000_000;
+
+        let utxos = vec![Utxo {
+            amount: Amount::from_sat(5_000_000_000),
+            outpoint: OutPoint {
+                txid: "fd2105607605d2302994ffea703b09f66b6351816ee737a93e42a841ea20bbad"
+                    .parse()
+                    .expect("valid txid"),
+                vout: 0,
+            },
+            script_pubkey: ScriptBuf::from(
+                hex::decode("0014a10d9257489e685dda030662390dc177852faf13")
+                    .expect("valid P2WPKH scriptpubkey hex"),
+            ),
+        }];
+        let change_spk = ScriptBuf::from(
+            hex::decode("00143ca33c2e4446f4a305f23c80df8ad1afdcf652f9")
+                .expect("valid P2WPKH scriptpubkey hex"),
+        );
+        let funding = build_funding_transaction(
+            &opener_funding_pubkey,
+            &acceptor_funding_pubkey,
+            funding_satoshis,
+            15_000,
+            utxos,
+            change_spk,
+        )
+        .expect("inputs should cover funding amount and fees");
+
+        // The referenced funding output matches the negotiated output script
+        // and amount.
+        assert!(funding.matches_funding_output(
+            &opener_funding_pubkey,
+            &acceptor_funding_pubkey,
+            funding_satoshis,
+        ));
+
+        // A different funding pubkey yields a different script and does not match.
+        let other_pubkey =
+            pubkey("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa");
+        assert!(!funding.matches_funding_output(
+            &opener_funding_pubkey,
+            &other_pubkey,
+            funding_satoshis,
+        ));
+
+        // A mismatched funding amount does not match.
+        let other_amount = 10_000;
+        assert!(!funding.matches_funding_output(
+            &opener_funding_pubkey,
+            &acceptor_funding_pubkey,
+            other_amount
+        ));
     }
 }


### PR DESCRIPTION
When the advertised funding outpoint does not pay the negotiated 2-of-2 funding script and amount, the target is unlikely to complete the funding flow or send an error, so we should not expect a `channel_ready` back. Track whether the advertised funding outpoint is valid and require it before expecting `channel_ready`, keeping `RecvChannelReady` a no-op otherwise