### PR TITLE
smitebot: add print-ir command to decode fuzzer inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,11 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "log",
+ "postcard",
  "serde",
  "serde_json",
  "simple_logger",
+ "smite-ir",
  "tempfile",
  "thiserror",
  "toml",

--- a/smitebot/Cargo.toml
+++ b/smitebot/Cargo.toml
@@ -10,9 +10,11 @@ workspace = true
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
 log.workspace = true
+postcard.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 simple_logger.workspace = true
+smite-ir = { path = "../smite-ir" }
 thiserror.workspace = true
 toml = "0.8"
 

--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -145,3 +145,16 @@ JSON output example:
   "overall": false
 }
 ```
+
+### smitebot print-ir
+
+Decodes a serialized IR program and prints it to standard output. IR programs are opaque postcard-encoded `Program`s, the same form the fuzzing loop serializes them in; point it at one to see what it actually does.
+
+```bash
+smitebot print-ir <path>
+smitebot print-ir output/default/crashes/id:000000,sig:06,...
+```
+
+`<path>` is a path to a postcard-encoded IR program.
+
+The program is printed using the IR's `Display` format, the same textual form the `smite-ir` mutator emits in its trim logs. An empty program prints `(empty program)`.

--- a/smitebot/src/commands.rs
+++ b/smitebot/src/commands.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod config;
 pub mod doctor;
+pub mod print_ir;
 pub mod start;
 pub mod status;
 pub mod stop;
@@ -8,6 +9,7 @@ pub mod stop;
 pub use build::{BuildArgs, BuildCommand};
 pub use config::{ConfigArgs, ConfigCommand};
 pub use doctor::{DoctorArgs, DoctorCommand};
+pub use print_ir::{PrintIrArgs, PrintIrCommand};
 pub use start::{StartArgs, StartCommand};
 pub use status::{StatusArgs, StatusCommand};
 pub use stop::{StopArgs, StopCommand};

--- a/smitebot/src/commands/print_ir.rs
+++ b/smitebot/src/commands/print_ir.rs
@@ -1,0 +1,97 @@
+//! Decodes a serialized IR program and prints it to standard output.
+//!
+//! IR programs are postcard-encoded [`Program`]s; that is how the fuzzing loop
+//! serializes them (see `smite-ir-mutator`). This command decodes one and
+//! prints it using the IR's `Display` format, the same textual form the mutator
+//! emits in its trim logs.
+
+use std::fs;
+use std::path::PathBuf;
+
+use clap::Args;
+use smite_ir::Program;
+
+/// Command handler for `smitebot print-ir`.
+pub struct PrintIrCommand;
+
+/// CLI arguments for `smitebot print-ir`.
+#[derive(Debug, Args)]
+pub struct PrintIrArgs {
+    /// Path to a postcard-encoded IR program.
+    path: PathBuf,
+}
+
+impl PrintIrCommand {
+    /// Decodes the input at `args.path` and prints it as readable IR.
+    pub fn execute(args: &PrintIrArgs) -> bool {
+        let bytes = match fs::read(&args.path) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                log::error!("failed to read {}: {e}", args.path.display());
+                return false;
+            }
+        };
+
+        match render(&bytes) {
+            Ok(text) => {
+                // `Program`'s Display terminates every instruction with a
+                // newline, so an empty program renders to an empty string.
+                if text.is_empty() {
+                    println!("(empty program)");
+                }
+                print!("{text}");
+                true
+            }
+            Err(e) => {
+                log::error!(
+                    "failed to decode IR program from {}: {e}",
+                    args.path.display()
+                );
+                false
+            }
+        }
+    }
+}
+
+/// Decodes postcard-encoded bytes into an IR program and renders it as text.
+fn render(bytes: &[u8]) -> Result<String, postcard::Error> {
+    let program: Program = postcard::from_bytes(bytes)?;
+    Ok(program.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smite_ir::{Instruction, Operation};
+
+    /// Postcard is how smite IR programs are serialized in the fuzzing loop.
+    fn encode(program: &Program) -> Vec<u8> {
+        postcard::to_allocvec(program).expect("postcard serialization")
+    }
+
+    #[test]
+    fn render_decodes_and_formats_program() {
+        let program = Program {
+            instructions: vec![Instruction {
+                operation: Operation::LoadAmount(1000),
+                inputs: vec![],
+            }],
+        };
+        let text = render(&encode(&program)).unwrap();
+        assert_eq!(text, program.to_string());
+        assert!(text.starts_with("v0 = "), "unexpected rendering: {text:?}");
+    }
+
+    #[test]
+    fn render_empty_program_is_empty_string() {
+        let program = Program {
+            instructions: vec![],
+        };
+        assert_eq!(render(&encode(&program)).unwrap(), "");
+    }
+
+    #[test]
+    fn render_rejects_invalid_serialization() {
+        assert!(render(&[0xFF; 8]).is_err());
+    }
+}

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -11,8 +11,8 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 
 use commands::{
-    BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, DoctorArgs, DoctorCommand, StartArgs,
-    StartCommand, StatusArgs, StatusCommand, StopArgs, StopCommand,
+    BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, DoctorArgs, DoctorCommand, PrintIrArgs,
+    PrintIrCommand, StartArgs, StartCommand, StatusArgs, StatusCommand, StopArgs, StopCommand,
 };
 
 #[derive(Debug, Parser)]
@@ -30,6 +30,8 @@ enum Commands {
     Config(ConfigArgs),
     /// Validate host prerequisites for running Smite campaigns.
     Doctor(DoctorArgs),
+    /// Decode a fuzzer input and print it as readable IR.
+    PrintIr(PrintIrArgs),
     /// Launch a fuzzing campaign.
     Start(StartArgs),
     /// Report the status of a campaign.
@@ -46,6 +48,7 @@ fn main() -> ExitCode {
         Commands::Build(args) => BuildCommand::execute(&args),
         Commands::Config(args) => ConfigCommand::execute(&args),
         Commands::Doctor(args) => DoctorCommand::execute(&args),
+        Commands::PrintIr(args) => PrintIrCommand::execute(&args),
         Commands::Start(args) => StartCommand::execute(&args),
         Commands::Status(args) => StatusCommand::execute(&args),
         Commands::Stop(args) => StopCommand::execute(&args),


### PR DESCRIPTION
Decodes a postcard-encoded IR Program from an AFL++ corpus input and prints it using the IR's Display format, the same textual form the mutator emits in its trim logs.

This is a debugging utility: corpus inputs and crash cases are opaque binary blobs, so being able to render one as readable IR makes it easy to inspect what a given input actually does.

Example:
```
smitebot print-ir ./input.bin
v0 = LoadFeatures(0xbb4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f20d097)
v1 = LoadChainHashFromContext()
v2 = LoadShortChannelId(4787506x4576190x23663)
v3 = LoadPrivateKey(0x09a5c4b72d85bcaf2d0e6990f7cbf36b8be8eca48d36908bf138f8528d42fd3b)
v4 = LoadPrivateKey(0x02d5f395ea524e698d414e58188a412fe4e55db32c46698cc2fcaf7b3370129e)
v5 = LoadPrivateKey(0xb32af3467c4f00c4b447caab5c9bd55118630a58c59334c3d830fc4af517edcd)
v6 = BuildChannelAnnouncement(v0, v1, v2, v3, v3, v4, v5)
SendMessage(v6)
v8 = LoadChainHashFromContext()
v9 = LoadShortChannelId(15555470x7816195x59946)
v10 = LoadPrivateKey(0x19befbb4b8058c1c812d00b6ae44b695952095a30d58b9203218510d7c014191)
v11 = LoadPrivateKey(0xf229e1d5138f7cf0835ea349595ab9666ec70d9875170a7569671eca2275f3a4)
v12 = LoadPrivateKey(0x6eb114624cfbdb83b915760509cafa0a769825419c137944c3e2c047f2184e6c)
v13 = LoadPrivateKey(0xf79d5ba72ff62037eecfd8735f80f7e7d9a2c96d67cf050e21bf95654b851241)
v14 = LoadPrivateKey(0x3bf11310182921c1e93bd8049094d1a8c5cd7323ab20520d782d7ee2c09cbef0)
v15 = LoadPrivateKey(0xb6e0ef0fa2ec27cac8ee3bce163b12e835a9cce9e314752babe52e653beda769)
v16 = BuildChannelAnnouncement(v0, v8, v9, v12, v13, v14, v15)
SendMessage(v16)
v18 = LoadPrivateKey(0xc2e13851e6d5403280f4d1e18d2ed1595181661b1187e792eae70f948f365db5)
v19 = DerivePoint(v18)
v20 = LoadAmount(255)
v21 = LoadFeeratePerKw(2334404166)
v22 = LoadChannelId(0x082a7725ba8d959cc23f4e8cd0bd79f746f519d011878b05fbfb5ca700b1448c)
v23 = CreateFundingTransaction(v19, v19, v20, v21)
v24 = SendFundingCreated(v23, v10, v22)
BroadcastTransaction(v23)
v26 = RecvFundingSigned(v24)
v27 = LoadPrivateKey(0x4371b6249a961a18c1daafbe47711853a31262f2457d0258898721593db97270)
v28 = BuildChannelAnnouncement(v0, v8, v9, v10, v11, v18, v27)
SendMessage(v28)
```