### PR TITLE
smitebot: add bench command to measure Nyx execution speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ name = "smitebot"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "libc",
  "log",
  "postcard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ pedantic = { level = "deny", priority = -1 }
 warnings = "deny"
 
 [workspace.dependencies]
+libc = "0.2"
 log = "0.4"
 rand = { version = "0.10", default-features = false }
 simple_logger = { version = "5", default-features = false }

--- a/smite-scenarios/Cargo.toml
+++ b/smite-scenarios/Cargo.toml
@@ -22,7 +22,7 @@ thiserror.workspace = true
 bitcoin.workspace = true
 
 hex = "0.4"
-libc = "0.2"
+libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile = "3"

--- a/smitebot/Cargo.toml
+++ b/smitebot/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
+libc.workspace = true
 log.workspace = true
 postcard.workspace = true
 serde.workspace = true

--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -82,6 +82,59 @@ smitebot status <campaign-id> --summary
 - `--summary`: Print a one-shot text summary to the terminal instead of attaching to the live dashboard.
 - `<campaign-id>` is the directory name under `~/.smitebot/runs` (printed by `smitebot start`).
 
+### smitebot bench-exec
+
+Benchmarks Nyx execution speed by running a single input through the target's VM many times. Each execution is a snapshot restore plus one target run, so the results isolate VM/snapshot and target speed from AFL++'s mutation and scheduling overhead.
+
+```bash
+smitebot bench-exec campaign.toml
+smitebot bench-exec campaign.toml --input testcase.bin --iterations 5000
+```
+
+- `--input`: Input file to execute repeatedly. Defaults to a single `0x00` byte. The default is handy for quickly measuring performance gains that come from the target itself rather than a specific test case: every exec still does the live-target ping-pong the executor uses to confirm the VM is up, so it exercises that path. It's a fast way to check improvements like JVM warmup/optimization.
+- `-n`, `--iterations`: Number of timed executions per run (default `1000`).
+- `-r`, `--repeat`: Number of full boot+measure runs to average over (default `1`). Each run boots a fresh VM, so repeats capture boot- and snapshot-level variance a single run cannot.
+- `--worker-id`: Nyx worker id, which namespaces the VM's workdir files (default `0`).
+- `--cpu`: CPU to pin the benchmark and its VM to (defaults to `--worker-id`). libnyx does no CPU binding of its own, so `bench-exec` sets its own affinity before booting and QEMU inherits it, the same way `afl-fuzz` does. On a hybrid CPU, pin to a core of the type you mean to measure: a P-core and an E-core give materially different numbers.
+- `--max-input-size`: Input buffer size in bytes for the VM, which must be a multiple of 4096 (QEMU-Nyx asserts the payload buffer is page-aligned). Defaults to `1048576`, AFL++'s `MAX_FILE` and therefore the buffer a real campaign runs with.
+- `-t`, `--timeout`: Per-execution timeout in seconds; an exec that runs longer is counted as timed out (default `2`).
+- `--no-build`: Skip building the image and setting up the sharedir; reuse an existing one.
+
+Like `start`, `bench-exec` builds the Docker image and sets up the Nyx sharedir before running, so it works from a clean checkout. Pass `--no-build` to skip that and reuse an already-prepared sharedir (`sharedir/config.ron`) from a prior `start`, `bench-exec`, or `scripts/setup-nyx.sh`. Either way it needs `libnyx.so` under `aflpp_path`, which it loads at runtime the same way `afl-fuzz` does.
+
+Booting the VM is what pays for target init and root snapshot creation: libnyx does not return from boot until the guest has reached its ready-to-fuzz state, so that cost is timed on its own. Every execution after that is a snapshot restore plus one target run; they are all timed together and reported as steady-state throughput:
+
+```
+Smite Nyx benchmark
+  target:      ldk/ir
+  sharedir:    /tmp/smite-nyx
+  input size:  406 bytes
+  input buffer:1048576 bytes
+  iterations:  100
+  repeats:     1
+
+  boot + snapshot creation: 4.056 s
+  steady-state (snapshot restore + target run):
+    execs/sec: 8.8
+    exec time: 11.324 s
+    latency:   min 106.16 ms  mean 113.24 ms  median 113.84 ms  p99 116.02 ms  max 116.06 ms
+    input execution: mean 109.35 ms  median 110.31 ms   (guest runtime)
+    nyx overhead:    mean 3.89 ms  median 4.00 ms   (restore + reset + ipc; 4045 dirty pages/exec)
+    failed iterations: 0 / 100
+    coverage determinism: 84.8% stable (2808 / 18456 edges fluctuated)
+```
+
+Each per-exec latency is split into two parts read from libnyx's auxiliary buffer:
+
+- **input execution** is the guest runtime the target actually spent processing the input, measured inside the VM. This is the "true" cost of the input; use it to tell whether a change made the target's own work faster.
+- **nyx overhead** is the wall time minus that guest runtime: snapshot restore/reset plus hypercall round-trips. `dirty pages/exec` is the number of pages restored each execution, the main driver of that overhead, so a change that dirties more memory (e.g. spawning a process per block) shows up as both higher overhead and more dirty pages.
+
+`coverage determinism` reports how reproducible the target's edge coverage is across the identical executions. Each execution's AFL coverage bitmap is captured and its per-edge hit counts are bucketed with AFL's count classes; an edge whose bucketed count is not identical across all executions is counted as fluctuated, and the denominator is the edges hit at least once. High determinism (close to 100%) means the same input reliably reaches the same code; fluctuation points to nondeterminism (uninitialized memory, timing-dependent branches, ASLR, background threads) that adds noise to the fuzzer's coverage signal. Bucketing means benign loop-trip jitter is not counted.
+
+With `--repeat` greater than 1 each run is reported separately, followed by an aggregate (mean, stddev, and range of execs/sec across runs; coverage determinism is pooled over all runs).
+
+`failed iterations` counts executions that ended in a crash, timeout, or error rather than a clean run; a non-zero count means the input is not a clean steady-state case and the numbers are skewed.
+
 ### smitebot config
 
 Validates a campaign configuration file, reports the resolved settings, and checks that referenced paths exist on disk.

--- a/smitebot/src/commands.rs
+++ b/smitebot/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod bench_exec;
 pub mod build;
 pub mod config;
 pub mod corpus;
@@ -7,6 +8,7 @@ pub mod start;
 pub mod status;
 pub mod stop;
 
+pub use bench_exec::{BenchExecArgs, BenchExecCommand};
 pub use build::{BuildArgs, BuildCommand};
 pub use config::{ConfigArgs, ConfigCommand};
 pub use corpus::{CorpusArgs, CorpusCommand};

--- a/smitebot/src/commands/bench_exec.rs
+++ b/smitebot/src/commands/bench_exec.rs
@@ -1,0 +1,971 @@
+//! Single-input Nyx benchmark.
+//!
+//! Boots the target's Nyx VM and runs one fixed input through it a fixed number
+//! of times, measuring steady-state throughput and per-execution latency.
+//! Because each execution is a snapshot restore plus one target run, the numbers
+//! isolate VM/snapshot and target speed from AFL++'s mutation and scheduling
+//! overhead.
+//!
+//! Like `start`, `bench-exec` builds the Docker image and sets up the Nyx
+//! sharedir before running. Pass `--no-build` to skip that and reuse an
+//! already-prepared sharedir (e.g. from a prior `start`, `bench-exec`, or
+//! `scripts/setup-nyx.sh`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use clap::Args;
+
+use crate::commands::build::{BuildInputs, run_build};
+use crate::config::CampaignConfig;
+use crate::latency_stats::{LatencyStats, avg_duration, mean_stddev};
+use crate::libnyx::{Libnyx, PAYLOAD_HEADER_SIZE};
+use crate::utils::{pin_to_cpu, setup_nyx};
+
+/// Default number of timed executions when `--iterations` is not given.
+const DEFAULT_ITERATIONS: u64 = 1000;
+
+/// Upper bound on `--iterations`. The run preallocates and retains timing
+/// samples per iteration, so an unbounded count would reserve gigabytes.
+const MAX_ITERATIONS: u64 = 1_000_000;
+
+/// Upper bound on `--repeat`, which likewise sizes a preallocation.
+const MAX_REPEAT: u32 = 1_000;
+
+/// Guest page size (x86-64 base page, `x86_64_PAGE_SIZE` in QEMU-Nyx) that the
+/// input buffer must be a whole multiple of.
+///
+/// QEMU-Nyx maps the payload buffer into the guest one page at a time and
+/// asserts `shared_payload_buffer_size % x86_64_PAGE_SIZE == 0`
+/// (`nyx_mode/QEMU-Nyx/nyx/memory_access.c`), so any buffer size we pass must be
+/// page-rounded or the VM aborts. AFL++ never trips this because its buffer is a
+/// page-multiple 1 MiB.
+const NYX_PAGE_SIZE: u32 = 4096;
+
+/// Input buffer size the VM is booted with unless `--max-input-size` says
+/// otherwise: AFL++'s `MAX_FILE`, which is what afl-fuzz hands to
+/// `nyx_config_set_input_buffer_size`.
+///
+/// Matching AFL++ by default means the benchmark measures the buffer a real
+/// campaign runs with. Page-aligned, so it satisfies the QEMU-Nyx assertion
+/// above.
+const DEFAULT_MAX_INPUT_SIZE: u32 = 1 << 20;
+
+/// Default per-execution timeout in seconds. An input that runs longer is
+/// reported as a failed (timed-out) iteration rather than hanging the run.
+const BENCH_TIMEOUT_SECS: u8 = 2;
+
+/// Command handler for `smitebot bench-exec`.
+pub struct BenchExecCommand;
+
+/// CLI arguments for `smitebot bench-exec`.
+#[derive(Debug, Args)]
+pub struct BenchExecArgs {
+    /// Path to the campaign configuration TOML file.
+    path: PathBuf,
+    /// Input file to execute repeatedly; defaults to a single 0x00 byte.
+    #[arg(long, short)]
+    input: Option<PathBuf>,
+    /// Number of timed executions to run (at most 1000000, since every
+    /// execution's timing samples are held until the run ends).
+    #[arg(long, short = 'n', default_value_t = DEFAULT_ITERATIONS)]
+    iterations: u64,
+    /// Number of full boot+measure runs to repeat and average over (at most 1000).
+    ///
+    /// Each run boots a fresh VM, so repeats capture boot- and snapshot-level
+    /// variance that a single run cannot. Results are reported per run plus an
+    /// aggregate.
+    #[arg(long, short = 'r', default_value_t = 1)]
+    repeat: u32,
+    /// Nyx worker id for the VM, which namespaces its workdir files so several
+    /// VMs can share a workdir.
+    #[arg(long, default_value_t = 0)]
+    worker_id: u32,
+    /// CPU to pin the benchmark and its VM to; defaults to `--worker-id`.
+    ///
+    /// Pinning keeps the scheduler from migrating the VM mid-run. On a hybrid
+    /// CPU, pick a core of the type you mean to measure: a P-core and an E-core
+    /// give materially different numbers.
+    #[arg(long)]
+    cpu: Option<usize>,
+    /// Input buffer size in bytes for the Nyx VM; must be a multiple of 4096.
+    ///
+    /// Defaults to AFL++'s 1 MiB, the buffer a real campaign runs with.
+    #[arg(long, default_value_t = DEFAULT_MAX_INPUT_SIZE)]
+    max_input_size: u32,
+    /// Per-execution timeout in seconds before an exec is counted as timed out.
+    /// Must be at least 1; Nyx reads zero as "no timeout".
+    #[arg(long = "timeout", short = 't', default_value_t = BENCH_TIMEOUT_SECS)]
+    timeout_secs: u8,
+    /// Skip building the image and setting up the sharedir; reuse an existing one.
+    #[arg(long)]
+    no_build: bool,
+}
+
+impl BenchExecCommand {
+    /// Runs the benchmark and returns whether it completed successfully.
+    pub fn execute(args: &BenchExecArgs) -> bool {
+        let iterations = match validate_iterations(args.iterations) {
+            Ok(n) => n,
+            Err(e) => {
+                log::error!("{e}");
+                return false;
+            }
+        };
+        let repeat = match validate_repeat(args.repeat) {
+            Ok(n) => n,
+            Err(e) => {
+                log::error!("{e}");
+                return false;
+            }
+        };
+        // A zero timeout causes Nyx to silently turn off the timing the
+        // benchmark exists to measure.
+        if args.timeout_secs == 0 {
+            log::error!("Nyx requires --timeout to be at least 1 second");
+            return false;
+        }
+
+        let config = match CampaignConfig::load(&args.path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::error!("{e}");
+                return false;
+            }
+        };
+
+        let input = match load_input(args) {
+            Ok(input) => input,
+            Err(e) => {
+                log::error!("{e}");
+                return false;
+            }
+        };
+        let max_input_size = match validate_max_input_size(args.max_input_size, input.len()) {
+            Ok(size) => size,
+            Err(e) => {
+                log::error!("{e}");
+                return false;
+            }
+        };
+
+        let Some(libnyx_path) = locate_libnyx(&config) else {
+            return false;
+        };
+
+        if !ensure_sharedir(&config, args.no_build) {
+            return false;
+        }
+
+        let libnyx = match Libnyx::load(&libnyx_path) {
+            Ok(lib) => lib,
+            Err(e) => {
+                log::error!("failed to load {}: {e}", libnyx_path.display());
+                return false;
+            }
+        };
+
+        // Pin before booting: libnyx spawns QEMU as a child, so the VM inherits
+        // this affinity mask. Doing it here also pins the timing loop itself.
+        let cpu = args.cpu.unwrap_or(args.worker_id as usize);
+        if let Err(e) = pin_to_cpu(cpu) {
+            log::error!("{e}");
+            return false;
+        }
+        log::info!("pinned to CPU {cpu}");
+
+        // Each repeat is a fresh VM boot so the aggregate captures boot- and
+        // snapshot-level variance, which dominates run-to-run spread.
+        let mut runs = Vec::with_capacity(repeat);
+        for run_index in 0..repeat {
+            if repeat > 1 {
+                log::info!("benchmark run {}/{repeat}", run_index + 1);
+            }
+            match run_once(
+                &libnyx,
+                &config,
+                &input,
+                args,
+                max_input_size,
+                iterations,
+                run_index,
+            ) {
+                Ok(result) => runs.push(result),
+                Err(e) => {
+                    log::error!("{e}");
+                    return false;
+                }
+            }
+        }
+
+        let report = BenchReport {
+            target: format!("{}/{}", config.target, config.scenario),
+            sharedir: config.sharedir.clone(),
+            input_len: input.len(),
+            max_input_size,
+            iterations,
+            runs,
+        };
+        report.print();
+
+        true
+    }
+}
+
+/// Boots a fresh VM, times one benchmark run, and tears the VM down.
+fn run_once(
+    libnyx: &Libnyx,
+    config: &CampaignConfig,
+    input: &[u8],
+    args: &BenchExecArgs,
+    max_input_size: u32,
+    iterations: usize,
+    run_index: usize,
+) -> Result<RunResult, String> {
+    let workdir = BenchWorkdir::create(&config.output_dir, run_index)
+        .map_err(|e| format!("failed to create benchmark workdir: {e}"))?;
+
+    // libnyx does not return until the guest reaches the ready-to-fuzz state, so
+    // this call is where VM boot, target init, and root snapshot creation are
+    // paid for (`QemuProcess::new` in libnyx spins until `result.state == 3`).
+    log::info!("booting Nyx VM from {}", config.sharedir.display());
+    let boot_start = Instant::now();
+    let mut vm = libnyx.boot(
+        &config.sharedir,
+        workdir.path(),
+        max_input_size,
+        args.worker_id,
+        args.timeout_secs,
+    )?;
+    let boot_time = boot_start.elapsed();
+
+    // The coverage bitmap lets us measure how deterministic the target's edge
+    // coverage is across identical executions. Skip it if libnyx reports no map.
+    let bitmap_size = vm.bitmap_size();
+    let mut coverage = (bitmap_size > 0).then(|| CoverageTracker::new(bitmap_size));
+    let mut bitmap_buf = vec![0u8; bitmap_size];
+
+    log::info!("running {iterations} timed executions");
+    let mut latencies = Vec::with_capacity(iterations);
+    let mut target_runtimes = Vec::with_capacity(iterations);
+    let mut overheads = Vec::with_capacity(iterations);
+    let mut failed_iterations = 0u64;
+    let mut dirty_pages_total = 0u64;
+    // Throughput is the sum of the timed exec latencies, not the loop's wall
+    // clock.
+    let mut total = Duration::ZERO;
+    for _ in 0..iterations {
+        let exec_start = Instant::now();
+        let stats = vm.exec_with_stats(input);
+        let latency = exec_start.elapsed();
+        total += latency;
+
+        latencies.push(latency);
+        target_runtimes.push(stats.target_runtime);
+        // Overhead is the wall time not spent running the target: snapshot
+        // restore/reset plus hypercall round-trips. Saturating guards the rare
+        // case where the guest-measured runtime rounds above the host latency.
+        overheads.push(latency.saturating_sub(stats.target_runtime));
+        dirty_pages_total += u64::from(stats.dirty_pages);
+        if !stats.result.is_normal() {
+            failed_iterations += 1;
+        }
+
+        if let Some(tracker) = coverage.as_mut() {
+            vm.copy_bitmap_into(&mut bitmap_buf);
+            tracker.record(&bitmap_buf);
+        }
+    }
+
+    // `vm` (QEMU shutdown) then `workdir` (rm -rf) drop in reverse order here.
+    Ok(RunResult {
+        boot_time,
+        total,
+        failed_iterations,
+        mean_dirty_pages: mean_u64(dirty_pages_total, iterations),
+        stats: LatencyStats::summarize(&mut latencies),
+        target: LatencyStats::summarize(&mut target_runtimes),
+        overhead: LatencyStats::summarize(&mut overheads),
+        coverage: coverage.map(|c| c.summary()),
+    })
+}
+
+/// Tracks per-edge coverage stability across the executions of one run.
+///
+/// AFL++'s bitmap holds one byte per edge, a raw hit count. The same input on a
+/// deterministic target should light the same edges with the same *bucketed*
+/// count every execution; an edge whose bucketed count varies across executions
+/// is unstable (nondeterminism from uninitialized memory, timing-dependent
+/// branches, ASLR, background threads, etc.). Bucketing with AFL++'s live count
+/// classes means benign within-bucket jitter (e.g. 100 vs 101 iterations, both
+/// in `[64..127]`) is not flagged, matching what actually perturbs AFL's
+/// coverage.
+struct CoverageTracker {
+    /// Bucketed hit count from the first recorded execution, per edge.
+    reference: Vec<u8>,
+    /// Whether each edge was hit (nonzero) in any recorded execution.
+    hit: Vec<bool>,
+    /// Whether each edge's bucketed count ever differed from `reference`.
+    fluctuated: Vec<bool>,
+    /// Number of executions recorded so far.
+    samples: u64,
+}
+
+impl CoverageTracker {
+    fn new(bitmap_size: usize) -> Self {
+        Self {
+            reference: vec![0; bitmap_size],
+            hit: vec![false; bitmap_size],
+            fluctuated: vec![false; bitmap_size],
+            samples: 0,
+        }
+    }
+
+    /// Folds one execution's raw bitmap into the running tally.
+    fn record(&mut self, bitmap: &[u8]) {
+        for (i, &raw) in bitmap.iter().enumerate() {
+            let bucket = classify_count(raw);
+            if bucket != 0 {
+                self.hit[i] = true;
+            }
+            if self.samples == 0 {
+                self.reference[i] = bucket;
+            } else if bucket != self.reference[i] {
+                self.fluctuated[i] = true;
+            }
+        }
+        self.samples += 1;
+    }
+
+    /// Collapses the tally into executed- and fluctuated-edge counts.
+    fn summary(&self) -> CoverageSummary {
+        let executed_edges = self.hit.iter().filter(|&&h| h).count() as u64;
+        let fluctuated_edges = self.fluctuated.iter().filter(|&&f| f).count() as u64;
+        CoverageSummary {
+            executed_edges,
+            fluctuated_edges,
+        }
+    }
+}
+
+/// AFL's count-class bucketing: raw hit counts collapse to fixed buckets so that
+/// small variations within a bucket are treated as identical coverage.
+///
+/// Returns the bucket's index rather than AFL's bucket value. Only equality
+/// between two executions matters here, so the index is equivalent and keeps the
+/// ranges and their labels lined up.
+fn classify_count(count: u8) -> u8 {
+    match count {
+        0 => 0,
+        1 => 1,
+        2..=3 => 2,
+        4..=7 => 3,
+        8..=15 => 4,
+        16..=31 => 5,
+        32..=63 => 6,
+        64..=127 => 7,
+        128..=255 => 8,
+    }
+}
+
+/// Executed- and fluctuated-edge counts for one run's coverage stability.
+#[derive(Clone, Copy)]
+struct CoverageSummary {
+    /// Edges hit (nonzero) in at least one execution.
+    executed_edges: u64,
+    /// Executed edges whose bucketed count was not identical across executions.
+    fluctuated_edges: u64,
+}
+
+impl CoverageSummary {
+    /// Percentage of executed edges that were stable across all executions.
+    #[allow(clippy::cast_precision_loss)] // display figure; edge counts are small
+    fn stable_pct(&self) -> f64 {
+        if self.executed_edges == 0 {
+            100.0
+        } else {
+            let stable = self.executed_edges - self.fluctuated_edges;
+            stable as f64 / self.executed_edges as f64 * 100.0
+        }
+    }
+}
+
+/// Mean of a summed total over `count` samples, as a float (0.0 if no samples).
+#[allow(clippy::cast_precision_loss)] // display figure; exact precision unneeded
+fn mean_u64(total: u64, count: usize) -> f64 {
+    if count == 0 {
+        0.0
+    } else {
+        total as f64 / count as f64
+    }
+}
+
+/// Validates `--iterations` and returns it as a `usize`, the length the run's
+/// sample vectors are allocated from.
+fn validate_iterations(iterations: u64) -> Result<usize, String> {
+    if iterations == 0 {
+        return Err("--iterations must be at least 1".to_string());
+    }
+    if iterations > MAX_ITERATIONS {
+        return Err(format!(
+            "--iterations must be at most {MAX_ITERATIONS}, got {iterations}"
+        ));
+    }
+    usize::try_from(iterations)
+        .map_err(|_| format!("--iterations is {iterations}, more than this platform can address"))
+}
+
+/// Validates `--repeat` and returns it as the capacity for the results vector.
+fn validate_repeat(repeat: u32) -> Result<usize, String> {
+    if repeat == 0 {
+        return Err("--repeat must be at least 1".to_string());
+    }
+    if repeat > MAX_REPEAT {
+        return Err(format!(
+            "--repeat must be at most {MAX_REPEAT}, got {repeat}"
+        ));
+    }
+    usize::try_from(repeat)
+        .map_err(|_| format!("--repeat is {repeat}, more than this platform can address"))
+}
+
+/// Validates `--max-input-size` against the input it has to carry.
+///
+/// The size reaches QEMU-Nyx verbatim, so it is rejected rather than adjusted:
+/// silently resizing the buffer would change the very thing the benchmark
+/// measures.
+fn validate_max_input_size(size: u32, input_len: usize) -> Result<u32, String> {
+    if size == 0 || !size.is_multiple_of(NYX_PAGE_SIZE) {
+        return Err(format!(
+            "--max-input-size must be a nonzero multiple of {NYX_PAGE_SIZE} (QEMU-Nyx asserts \
+             the payload buffer is page-aligned), got {size}"
+        ));
+    }
+    // Saturating: the sum only has to be compared against a `u32`, so clamping an
+    // absurd length at `u64::MAX` still rejects it, where adding would overflow.
+    if (input_len as u64).saturating_add(u64::from(PAYLOAD_HEADER_SIZE)) > u64::from(size) {
+        return Err(format!(
+            "input is {input_len} bytes and its {PAYLOAD_HEADER_SIZE}-byte length prefix shares \
+             the buffer, but --max-input-size is {size}; raise it (the guest allocates the whole \
+             buffer every execution, so it must fit the VM's RAM)"
+        ));
+    }
+    Ok(size)
+}
+
+/// Loads the input to benchmark, defaulting to a single zero byte.
+fn load_input(args: &BenchExecArgs) -> Result<Vec<u8>, String> {
+    match &args.input {
+        Some(path) => {
+            fs::read(path).map_err(|e| format!("failed to read input {}: {e}", path.display()))
+        }
+        None => Ok(vec![0u8]),
+    }
+}
+
+/// Validates `aflpp_path` and locates `libnyx.so`, returning its path.
+///
+/// AFL++'s Nyx build is required both to prepare the sharedir (setup-nyx.sh)
+/// and to drive the VM at runtime, so it is checked before either.
+fn locate_libnyx(config: &CampaignConfig) -> Option<PathBuf> {
+    if !config.aflpp_path.exists() {
+        log::error!("aflpp_path does not exist: {}", config.aflpp_path.display());
+        return None;
+    }
+
+    let libnyx_path = config.aflpp_path.join("libnyx.so");
+    if !libnyx_path.exists() {
+        log::error!(
+            "{} not found; build AFL++ with Nyx support (see nyx_mode/README.md)",
+            libnyx_path.display()
+        );
+        return None;
+    }
+
+    Some(libnyx_path)
+}
+
+/// Builds the image and sets up the sharedir, or (when `no_build`) verifies an
+/// existing sharedir is present.
+///
+/// libnyx writes `config.ron` into the sharedir during setup-nyx.sh; its
+/// absence means the sharedir was never prepared.
+fn ensure_sharedir(config: &CampaignConfig, no_build: bool) -> bool {
+    if no_build {
+        let config_ron = config.sharedir.join("config.ron");
+        if !config_ron.exists() {
+            log::error!(
+                "Nyx sharedir is not set up ({} missing); drop --no-build, or run \
+                 `smitebot start` / scripts/setup-nyx.sh first",
+                config_ron.display()
+            );
+            return false;
+        }
+        return true;
+    }
+
+    let image = config.image_tag();
+    log::info!("building Docker image {image}");
+    if !run_build(&BuildInputs::from_config(config, &image)) {
+        return false;
+    }
+
+    log::info!("setting up Nyx sharedir at {}", config.sharedir.display());
+    setup_nyx(config, &image)
+}
+
+/// A dedicated scratch directory for libnyx, removed on drop.
+///
+/// libnyx wipes its workdir on startup, so it must not be shared with campaign
+/// output. A unique per-process directory keeps concurrent benchmarks isolated.
+struct BenchWorkdir {
+    path: PathBuf,
+}
+
+impl BenchWorkdir {
+    fn create(output_dir: &Path, run_index: usize) -> std::io::Result<Self> {
+        let path = output_dir.join(format!(".bench-{}-{run_index}", std::process::id()));
+        fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for BenchWorkdir {
+    fn drop(&mut self) {
+        if let Err(e) = fs::remove_dir_all(&self.path) {
+            log::debug!(
+                "failed to remove benchmark workdir {}: {e}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+/// Timing results from a single boot+measure run.
+struct RunResult {
+    /// Wall time of `libnyx.boot`: VM boot, target init, and snapshot creation.
+    boot_time: Duration,
+    /// Summed exec latency over the run (throughput denominator); excludes
+    /// harness bookkeeping so it equals `iterations * mean latency`.
+    total: Duration,
+    failed_iterations: u64,
+    /// Mean pages restored per execution (the Nyx overhead's main driver).
+    mean_dirty_pages: f64,
+    /// Per-exec wall time (target run + Nyx overhead).
+    stats: LatencyStats,
+    /// Per-exec guest runtime of the target alone (the "true" input execution).
+    target: LatencyStats,
+    /// Per-exec Nyx overhead (wall time minus target runtime).
+    overhead: LatencyStats,
+    /// Edge-coverage stability across the run, if a bitmap was available.
+    coverage: Option<CoverageSummary>,
+}
+
+impl RunResult {
+    /// Steady-state throughput for this run.
+    // Execs/sec is a display figure; f64 precision loss on the exec count is
+    // immaterial at any realistic iteration count.
+    #[allow(clippy::cast_precision_loss)]
+    fn execs_per_sec(&self, iterations: usize) -> f64 {
+        iterations as f64 / self.total.as_secs_f64()
+    }
+}
+
+/// A completed benchmark (one or more runs), ready to print.
+struct BenchReport {
+    target: String,
+    sharedir: PathBuf,
+    input_len: usize,
+    max_input_size: u32,
+    /// Timed executions per run, validated to fit a `usize` before the runs start.
+    iterations: usize,
+    runs: Vec<RunResult>,
+}
+
+impl BenchReport {
+    fn print(&self) {
+        println!("Smite Nyx benchmark");
+        println!("  target:      {}", self.target);
+        println!("  sharedir:    {}", self.sharedir.display());
+        println!("  input size:  {} bytes", self.input_len);
+        println!("  input buffer:{} bytes", self.max_input_size);
+        println!("  iterations:  {}", self.iterations);
+        println!("  repeats:     {}", self.runs.len());
+
+        for (i, run) in self.runs.iter().enumerate() {
+            self.print_run(i, run);
+        }
+
+        if self.runs.len() > 1 {
+            self.print_aggregate();
+        }
+    }
+
+    /// Prints the full detail for a single run.
+    fn print_run(&self, index: usize, run: &RunResult) {
+        println!();
+        if self.runs.len() > 1 {
+            println!("  run {}/{}:", index + 1, self.runs.len());
+        }
+        println!(
+            "  boot + snapshot creation: {}",
+            format_duration(run.boot_time)
+        );
+        println!("  steady-state (snapshot restore + target run):");
+        println!("    execs/sec: {:.1}", run.execs_per_sec(self.iterations));
+        println!("    exec time: {}", format_duration(run.total));
+        println!(
+            "    latency:   min {}  mean {}  median {}  p99 {}  max {}",
+            format_duration(run.stats.min),
+            format_duration(run.stats.mean),
+            format_duration(run.stats.median),
+            format_duration(run.stats.p99),
+            format_duration(run.stats.max),
+        );
+        // Split the per-exec latency into the target's own guest runtime and the
+        // Nyx machinery around it, so a change's effect on real target work is
+        // visible separately from snapshot restore cost.
+        println!(
+            "    input execution: mean {}  median {}   (guest runtime)",
+            format_duration(run.target.mean),
+            format_duration(run.target.median),
+        );
+        println!(
+            "    nyx overhead:    mean {}  median {}   (restore + reset + ipc; {:.0} dirty pages/exec)",
+            format_duration(run.overhead.mean),
+            format_duration(run.overhead.median),
+            run.mean_dirty_pages,
+        );
+        println!(
+            "    failed iterations: {} / {}",
+            run.failed_iterations, self.iterations
+        );
+        if let Some(cov) = &run.coverage {
+            println!(
+                "    coverage determinism: {:.1}% stable ({} / {} edges fluctuated)",
+                cov.stable_pct(),
+                cov.fluctuated_edges,
+                cov.executed_edges,
+            );
+        }
+    }
+
+    /// Prints mean (and spread) of each metric across all runs.
+    fn print_aggregate(&self) {
+        let eps: Vec<f64> = self
+            .runs
+            .iter()
+            .map(|r| r.execs_per_sec(self.iterations))
+            .collect();
+        let (eps_mean, eps_stddev) = mean_stddev(&eps);
+        let eps_min = eps.iter().copied().fold(f64::INFINITY, f64::min);
+        let eps_max = eps.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let total_failed_iterations: u64 = self.runs.iter().map(|r| r.failed_iterations).sum();
+        let total_execs = self.iterations * self.runs.len();
+
+        println!();
+        println!("  aggregate over {} runs:", self.runs.len());
+        println!(
+            "    execs/sec: mean {eps_mean:.1}  stddev {eps_stddev:.1}  min {eps_min:.1}  max {eps_max:.1}"
+        );
+        println!(
+            "    boot + snapshot: mean {}",
+            format_duration(avg_duration(self.runs.iter().map(|r| r.boot_time)))
+        );
+        println!("    latency (mean across runs):");
+        println!(
+            "      min {}  mean {}  median {}  p99 {}  max {}",
+            format_duration(avg_duration(self.runs.iter().map(|r| r.stats.min))),
+            format_duration(avg_duration(self.runs.iter().map(|r| r.stats.mean))),
+            format_duration(avg_duration(self.runs.iter().map(|r| r.stats.median))),
+            format_duration(avg_duration(self.runs.iter().map(|r| r.stats.p99))),
+            format_duration(avg_duration(self.runs.iter().map(|r| r.stats.max))),
+        );
+        println!(
+            "    input execution (mean across runs): mean {}  median {}",
+            format_duration(avg_duration(self.runs.iter().map(|r| r.target.mean))),
+            format_duration(avg_duration(self.runs.iter().map(|r| r.target.median))),
+        );
+        println!(
+            "    nyx overhead (mean across runs):     mean {}  median {}",
+            format_duration(avg_duration(self.runs.iter().map(|r| r.overhead.mean))),
+            format_duration(avg_duration(self.runs.iter().map(|r| r.overhead.median))),
+        );
+        println!("    failed iterations: {total_failed_iterations} / {total_execs}");
+
+        // Each run measures its own snapshot's determinism; summing the counts
+        // over runs gives a pooled stable percentage (an edge stable in every
+        // run of every boot). Skip if no run produced a bitmap.
+        let covs: Vec<CoverageSummary> = self.runs.iter().filter_map(|r| r.coverage).collect();
+        if !covs.is_empty() {
+            let pooled = CoverageSummary {
+                executed_edges: covs.iter().map(|c| c.executed_edges).sum(),
+                fluctuated_edges: covs.iter().map(|c| c.fluctuated_edges).sum(),
+            };
+            println!(
+                "    coverage determinism: {:.1}% stable ({} / {} edges fluctuated, summed over runs)",
+                pooled.stable_pct(),
+                pooled.fluctuated_edges,
+                pooled.executed_edges,
+            );
+        }
+    }
+}
+
+/// Formats a duration with a scale-appropriate unit (µs/ms/s).
+// Nanosecond counts small enough to display never exceed f64's mantissa.
+#[allow(clippy::cast_precision_loss)]
+fn format_duration(d: Duration) -> String {
+    let ns = d.as_nanos();
+    if ns < 1_000_000 {
+        format!("{:.1} µs", ns as f64 / 1_000.0)
+    } else if ns < 1_000_000_000 {
+        format!("{:.2} ms", ns as f64 / 1_000_000.0)
+    } else {
+        format!("{:.3} s", d.as_secs_f64())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_duration_scales_units() {
+        assert_eq!(format_duration(Duration::from_nanos(500)), "0.5 µs");
+        assert_eq!(format_duration(Duration::from_micros(250)), "250.0 µs");
+        assert_eq!(format_duration(Duration::from_micros(1_500)), "1.50 ms");
+        assert_eq!(format_duration(Duration::from_millis(1_500)), "1.500 s");
+    }
+
+    #[test]
+    fn default_max_input_size_matches_afl_and_is_page_aligned() {
+        // AFL++'s MAX_FILE, and a page multiple so it never trips the QEMU-Nyx
+        // payload-buffer assertion.
+        assert_eq!(DEFAULT_MAX_INPUT_SIZE, 1_048_576);
+        assert_eq!(DEFAULT_MAX_INPUT_SIZE % NYX_PAGE_SIZE, 0);
+    }
+
+    #[test]
+    fn validate_iterations_accepts_up_to_the_cap() {
+        assert!(validate_iterations(0).is_err());
+        assert_eq!(validate_iterations(1), Ok(1));
+        assert_eq!(validate_iterations(DEFAULT_ITERATIONS), Ok(1000));
+        assert_eq!(
+            validate_iterations(MAX_ITERATIONS),
+            Ok(usize::try_from(MAX_ITERATIONS).unwrap())
+        );
+    }
+
+    #[test]
+    fn validate_iterations_rejects_counts_past_the_cap() {
+        // The sample vectors are preallocated from this count, so a stray extra
+        // digit must be an error, not several GiB reserved up front.
+        for n in [MAX_ITERATIONS + 1, 100_000_000, u64::MAX] {
+            assert!(validate_iterations(n).is_err(), "{n}");
+        }
+    }
+
+    #[test]
+    fn validate_repeat_bounds_the_results_vector() {
+        assert!(validate_repeat(0).is_err());
+        assert_eq!(validate_repeat(1), Ok(1));
+        assert_eq!(validate_repeat(MAX_REPEAT), Ok(MAX_REPEAT as usize));
+        assert!(validate_repeat(MAX_REPEAT + 1).is_err());
+        assert!(validate_repeat(u32::MAX).is_err());
+    }
+
+    #[test]
+    fn validate_max_input_size_passes_a_size_the_input_fits() {
+        // The size is used as given, never shrunk to the input: a smaller buffer
+        // than the default is the point of the flag.
+        assert_eq!(validate_max_input_size(4096, 1), Ok(4096));
+        assert_eq!(validate_max_input_size(4096, 4092), Ok(4096));
+        assert_eq!(
+            validate_max_input_size(DEFAULT_MAX_INPUT_SIZE, 10),
+            Ok(DEFAULT_MAX_INPUT_SIZE)
+        );
+        // Above AFL++'s default is allowed; the guest just has to have the RAM.
+        assert_eq!(validate_max_input_size(4 << 20, 2 << 20), Ok(4 << 20));
+    }
+
+    #[test]
+    fn validate_max_input_size_rejects_input_larger_than_the_buffer() {
+        // An input filling the buffer exactly leaves no room for the length
+        // prefix, so it is rejected just like one past the buffer.
+        for len in [4093usize, 4096, 4097, usize::MAX] {
+            let err = validate_max_input_size(4096, len).unwrap_err();
+            assert!(err.contains("--max-input-size"), "{err}");
+        }
+        // The default buffer carries anything four bytes short of 1 MiB.
+        let max_len = DEFAULT_MAX_INPUT_SIZE - PAYLOAD_HEADER_SIZE;
+        assert!(validate_max_input_size(DEFAULT_MAX_INPUT_SIZE, max_len as usize).is_ok());
+        assert!(validate_max_input_size(DEFAULT_MAX_INPUT_SIZE, max_len as usize + 1).is_err());
+    }
+
+    #[test]
+    fn validate_max_input_size_rejects_a_non_page_aligned_size() {
+        // These reach QEMU-Nyx verbatim and would abort the VM on its
+        // page-multiple assertion, so they are caught here instead.
+        for size in [1u32, 4095, 4097, 1_000_000] {
+            let err = validate_max_input_size(size, 0).unwrap_err();
+            assert!(err.contains("multiple"), "{err}");
+        }
+        // Zero is page-aligned by arithmetic but is not a usable buffer.
+        assert!(validate_max_input_size(0, 0).is_err());
+    }
+
+    #[test]
+    fn load_input_defaults_to_zero_byte() {
+        let args = BenchExecArgs {
+            path: PathBuf::from("unused.toml"),
+            input: None,
+            iterations: DEFAULT_ITERATIONS,
+            repeat: 1,
+            worker_id: 0,
+            cpu: None,
+            max_input_size: DEFAULT_MAX_INPUT_SIZE,
+            timeout_secs: BENCH_TIMEOUT_SECS,
+            no_build: false,
+        };
+        assert_eq!(load_input(&args).unwrap(), vec![0u8]);
+    }
+
+    #[test]
+    fn load_input_reads_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("seed");
+        fs::write(&input_path, b"hello").unwrap();
+        let args = BenchExecArgs {
+            path: PathBuf::from("unused.toml"),
+            input: Some(input_path),
+            iterations: DEFAULT_ITERATIONS,
+            repeat: 1,
+            worker_id: 0,
+            cpu: None,
+            max_input_size: DEFAULT_MAX_INPUT_SIZE,
+            timeout_secs: BENCH_TIMEOUT_SECS,
+            no_build: false,
+        };
+        assert_eq!(load_input(&args).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn load_input_reports_missing_file() {
+        let args = BenchExecArgs {
+            path: PathBuf::from("unused.toml"),
+            input: Some(PathBuf::from("/no/such/input")),
+            iterations: DEFAULT_ITERATIONS,
+            repeat: 1,
+            worker_id: 0,
+            cpu: None,
+            max_input_size: DEFAULT_MAX_INPUT_SIZE,
+            timeout_secs: BENCH_TIMEOUT_SECS,
+            no_build: false,
+        };
+        assert!(load_input(&args).is_err());
+    }
+
+    #[test]
+    fn classify_count_buckets_hits() {
+        // AFL++'s live count classes, as bucket indices: 0, 1, [2..3], [4..7],
+        // [8..15], [16..31], [32..63], [64..127], [128..255].
+        assert_eq!(classify_count(0), 0);
+        assert_eq!(classify_count(1), 1);
+        assert_eq!(classify_count(2), 2);
+        assert_eq!(classify_count(3), 2);
+        assert_eq!(classify_count(4), 3);
+        assert_eq!(classify_count(7), 3);
+        assert_eq!(classify_count(8), 4);
+        assert_eq!(classify_count(15), 4);
+        assert_eq!(classify_count(31), 5);
+        assert_eq!(classify_count(63), 6);
+        assert_eq!(classify_count(64), 7);
+        assert_eq!(classify_count(127), 7);
+        assert_eq!(classify_count(255), 8);
+        // Every raw count lands in exactly one class, and the classes only ever
+        // step upward: a change of class is what flags an unstable edge.
+        for count in 0..=u8::MAX {
+            assert!(classify_count(count) <= classify_count(count.saturating_add(1)));
+        }
+    }
+
+    #[test]
+    fn coverage_flags_two_vs_three_bucket_change() {
+        // 2 and 3 land in different buckets under the retired OLD table but the
+        // same bucket under AFL++'s live table; pin the live behaviour so a
+        // 2<->3 edge counts as stable.
+        let mut tracker = CoverageTracker::new(1);
+        tracker.record(&[2]);
+        tracker.record(&[3]);
+        assert_eq!(tracker.summary().fluctuated_edges, 0);
+    }
+
+    #[test]
+    fn coverage_stable_when_bitmaps_identical() {
+        let mut tracker = CoverageTracker::new(4);
+        for _ in 0..5 {
+            tracker.record(&[0, 3, 0, 10]);
+        }
+        let summary = tracker.summary();
+        assert_eq!(summary.executed_edges, 2);
+        assert_eq!(summary.fluctuated_edges, 0);
+        assert!((summary.stable_pct() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn coverage_flags_edges_that_change_bucket() {
+        let mut tracker = CoverageTracker::new(3);
+        tracker.record(&[5, 5, 0]);
+        // Edge 0 stays in the same bucket (4..=7 -> 4); edge 1 jumps a bucket
+        // (4 -> 32); edge 2 lights up only now (0 -> executed and fluctuated).
+        tracker.record(&[7, 40, 1]);
+        let summary = tracker.summary();
+        assert_eq!(summary.executed_edges, 3);
+        assert_eq!(summary.fluctuated_edges, 2);
+    }
+
+    #[test]
+    fn coverage_ignores_within_bucket_jitter() {
+        let mut tracker = CoverageTracker::new(1);
+        // 100 and 101 both bucket to 64, so this is not instability.
+        tracker.record(&[100]);
+        tracker.record(&[101]);
+        assert_eq!(tracker.summary().fluctuated_edges, 0);
+    }
+
+    #[test]
+    fn coverage_no_hits_is_fully_stable() {
+        let mut tracker = CoverageTracker::new(2);
+        tracker.record(&[0, 0]);
+        let summary = tracker.summary();
+        assert_eq!(summary.executed_edges, 0);
+        assert_eq!(summary.fluctuated_edges, 0);
+        assert!((summary.stable_pct() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bench_workdir_is_removed_on_drop() {
+        let base = tempfile::tempdir().unwrap();
+        let path = {
+            let workdir = BenchWorkdir::create(base.path(), 0).unwrap();
+            let p = workdir.path().to_path_buf();
+            assert!(p.exists());
+            p
+        };
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn bench_workdir_is_unique_per_run_index() {
+        let base = tempfile::tempdir().unwrap();
+        let a = BenchWorkdir::create(base.path(), 0).unwrap();
+        let b = BenchWorkdir::create(base.path(), 1).unwrap();
+        assert_ne!(a.path(), b.path());
+    }
+}

--- a/smitebot/src/commands/start.rs
+++ b/smitebot/src/commands/start.rs
@@ -16,7 +16,7 @@ use crate::commands::build::{BuildInputs, run_build};
 use crate::config::CampaignConfig;
 use crate::state::{CampaignState, RunnerState, Status};
 use crate::tmux;
-use crate::utils::shell_quote;
+use crate::utils::{setup_nyx, shell_quote};
 
 /// How long to wait for `fuzzer_stats` before treating alive runners as started.
 ///
@@ -166,36 +166,6 @@ impl StartCommand {
 
         true
     }
-}
-
-/// Runs `scripts/setup-nyx.sh` to prepare the Nyx sharedir.
-fn setup_nyx(config: &CampaignConfig, image: &str) -> bool {
-    let script = config.smite_dir.join("scripts").join("setup-nyx.sh");
-    if !script.exists() {
-        log::error!("setup-nyx.sh not found: {}", script.display());
-        return false;
-    }
-
-    let status = match Command::new(&script)
-        .arg(&config.sharedir)
-        .arg(image)
-        .arg(&config.aflpp_path)
-        .status()
-    {
-        Ok(status) => status,
-        Err(e) => {
-            log::error!("failed to run setup-nyx.sh: {e}");
-            return false;
-        }
-    };
-
-    if !status.success() {
-        log::error!("setup-nyx.sh failed with {status}");
-        return false;
-    }
-
-    log::info!("Nyx sharedir ready at {}", config.sharedir.display());
-    true
 }
 
 /// Spawns all runners inside a tmux session, verifies they produce

--- a/smitebot/src/latency_stats.rs
+++ b/smitebot/src/latency_stats.rs
@@ -1,0 +1,145 @@
+//! Statistical summaries for benchmark timings.
+
+use std::time::Duration;
+
+/// Per-execution latency summary, all fields in nanoseconds via [`Duration`].
+pub struct LatencyStats {
+    pub min: Duration,
+    pub mean: Duration,
+    pub median: Duration,
+    pub p99: Duration,
+    pub max: Duration,
+}
+
+impl LatencyStats {
+    /// Computes summary statistics, sorting `latencies` in place.
+    pub fn summarize(latencies: &mut [Duration]) -> Self {
+        assert!(!latencies.is_empty(), "latencies must be non-empty");
+        latencies.sort_unstable();
+
+        Self {
+            min: latencies[0],
+            mean: avg_duration(latencies.iter().copied()),
+            median: percentile(latencies, 50),
+            p99: percentile(latencies, 99),
+            max: latencies[latencies.len() - 1],
+        }
+    }
+}
+
+/// Returns the value at the given percentile from a sorted slice.
+pub fn percentile(sorted: &[Duration], pct: usize) -> Duration {
+    assert!(!sorted.is_empty(), "sorted must be non-empty");
+    assert!(pct <= 100, "percentile must be <= 100");
+    // Nearest-rank on a zero-based slice: rank ceil(pct/100 * n) mapped to index.
+    let rank = (pct * sorted.len()).div_ceil(100);
+    let idx = rank.saturating_sub(1).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+/// Returns the sample mean and standard deviation of `values`.
+///
+/// Standard deviation uses Bessel's correction (n-1); with a single value it is
+/// `0.0`.
+// Run counts are tiny, so usize->f64 precision loss cannot occur in practice.
+#[allow(clippy::cast_precision_loss)]
+pub fn mean_stddev(values: &[f64]) -> (f64, f64) {
+    assert!(!values.is_empty(), "values must be non-empty");
+    let n = values.len();
+    let mean = values.iter().sum::<f64>() / n as f64;
+    if n < 2 {
+        return (mean, 0.0);
+    }
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
+    (mean, variance.sqrt())
+}
+
+/// Averages an iterator of durations (nanosecond precision).
+pub fn avg_duration(durations: impl Iterator<Item = Duration>) -> Duration {
+    let mut sum = 0u128;
+    let mut count = 0u128;
+    for d in durations {
+        sum += d.as_nanos();
+        count += 1;
+    }
+    assert!(count > 0, "durations must be non-empty");
+    Duration::from_nanos(u64::try_from(sum / count).unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn percentile_nearest_rank() {
+        let mut v: Vec<Duration> = (1..=100).map(ms).collect();
+        v.sort_unstable();
+        assert_eq!(percentile(&v, 0), ms(1));
+        assert_eq!(percentile(&v, 50), ms(50));
+        assert_eq!(percentile(&v, 99), ms(99));
+        assert_eq!(percentile(&v, 100), ms(100));
+    }
+
+    #[test]
+    fn percentile_single_element() {
+        let v = vec![ms(7)];
+        assert_eq!(percentile(&v, 50), ms(7));
+        assert_eq!(percentile(&v, 99), ms(7));
+    }
+
+    #[test]
+    fn latency_stats_basic() {
+        let mut v = vec![ms(4), ms(1), ms(3), ms(2)];
+        let stats = LatencyStats::summarize(&mut v);
+        assert_eq!(stats.min, ms(1));
+        assert_eq!(stats.max, ms(4));
+        // mean of 1..=4 ms = 2.5 ms
+        assert_eq!(stats.mean, Duration::from_micros(2_500));
+        assert_eq!(stats.median, ms(2));
+    }
+
+    #[test]
+    fn latency_stats_single_element() {
+        let mut v = vec![ms(7)];
+        let stats = LatencyStats::summarize(&mut v);
+        assert_eq!(stats.min, ms(7));
+        assert_eq!(stats.mean, ms(7));
+        assert_eq!(stats.median, ms(7));
+        assert_eq!(stats.p99, ms(7));
+        assert_eq!(stats.max, ms(7));
+    }
+
+    #[test]
+    fn mean_stddev_single_value_has_zero_spread() {
+        let (mean, stddev) = mean_stddev(&[42.0]);
+        assert!((mean - 42.0).abs() < 1e-9);
+        assert!(stddev.abs() < 1e-9);
+    }
+
+    #[test]
+    fn mean_stddev_computes_sample_stddev() {
+        // For [2, 4, 4, 4, 5, 5, 7, 9]: mean 5, sample stddev ~2.138.
+        let (mean, stddev) = mean_stddev(&[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]);
+        assert!((mean - 5.0).abs() < 1e-9, "mean was {mean}");
+        assert!((stddev - 2.1380).abs() < 1e-3, "stddev was {stddev}");
+    }
+
+    #[test]
+    fn avg_duration_averages_nanoseconds() {
+        let avg = avg_duration([ms(10), ms(20), ms(30)].into_iter());
+        assert_eq!(avg, ms(20));
+    }
+
+    #[test]
+    fn avg_duration_prevents_overflow() {
+        // Each value is 1e19 ns; the sum (2e19) overflows a u64 accumulator but
+        // fits in the u128 one, so the average comes back exact.
+        let big = Duration::from_secs(10_000_000_000);
+        let avg = avg_duration([big, big].into_iter());
+        assert_eq!(avg, big);
+    }
+}

--- a/smitebot/src/libnyx.rs
+++ b/smitebot/src/libnyx.rs
@@ -1,0 +1,510 @@
+//! Runtime bindings to AFL++'s `libnyx.so`.
+//!
+//! smitebot links nothing against libnyx at build time: the library lives in
+//! the user's AFL++ tree (`aflpp_path/libnyx.so`) and is resolved at runtime
+//! with `dlopen`, mirroring how `afl-fuzz` itself loads it (see
+//! `src/afl-forkserver.c` in `AFLplusplus`). Only the handful of host-side
+//! entry points needed to boot a Nyx VM and drive single executions are bound;
+//! the full C API is documented in `nyx_mode/libnyx/libnyx/libnyx.h`.
+
+use std::ffi::{CStr, CString, c_char, c_void};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::time::Duration;
+
+/// Layout of the fields we read from libnyx's 4 KiB auxiliary buffer.
+///
+/// The buffer is a fixed sequence of sections; the per-execution `result`
+/// section (`auxilary_buffer_result_s`) starts at byte 896. Within it, the
+/// `#[repr(C, packed)]` fields we care about sit at fixed offsets. QEMU-Nyx
+/// rewrites these on every execution, so they describe the exec that just ran.
+/// See `nyx_mode/libnyx/fuzz_runner/src/nyx/aux_buffer.rs` in AFL++.
+mod aux {
+    /// `0x54502d554d4551` ("QEMU-PT" little-endian), at buffer offset 0.
+    pub const MAGIC: u64 = 0x0054_502d_554d_4551;
+    /// Aux-buffer format version this binding's offsets were derived from.
+    pub const VERSION: u16 = 3;
+    /// Hash defined on libnyx
+    pub const QEMU_PT_HASH: u16 = 84;
+
+    /// Start of the `result` section within the buffer.
+    const RESULT: usize = 896;
+    /// `result.dirty_pages` (`u32`): pages restored for the last exec.
+    pub const DIRTY_PAGES: usize = RESULT + 16;
+    /// `result.runtime_usec` (`u32`): microsecond part of guest payload runtime.
+    pub const RUNTIME_USEC: usize = RESULT + 28;
+    /// `result.runtime_sec` (`u32`): second part of guest payload runtime.
+    pub const RUNTIME_SEC: usize = RESULT + 32;
+}
+
+/// A single Nyx execution outcome, matching libnyx's `NyxReturnValue` enum.
+///
+/// The enum is `#[repr(C)]` in libnyx, so it crosses the FFI boundary as a
+/// plain `int`; `Normal` is `0`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NyxReturn {
+    Normal,
+    Crash,
+    Asan,
+    Timeout,
+    InvalidWriteToPayload,
+    Error,
+    IoError,
+    Abort,
+    /// A value libnyx returned that this binding does not know about.
+    Unknown(i32),
+}
+
+impl NyxReturn {
+    fn from_raw(value: i32) -> Self {
+        match value {
+            0 => Self::Normal,
+            1 => Self::Crash,
+            2 => Self::Asan,
+            3 => Self::Timeout,
+            4 => Self::InvalidWriteToPayload,
+            5 => Self::Error,
+            6 => Self::IoError,
+            7 => Self::Abort,
+            other => Self::Unknown(other),
+        }
+    }
+
+    /// Whether the execution completed cleanly (no crash, timeout, or error).
+    #[must_use]
+    pub fn is_normal(self) -> bool {
+        self == Self::Normal
+    }
+}
+
+/// Bytes the payload's length prefix takes up at the front of the input buffer.
+///
+/// The buffer holds a `kAFL_payload` (`smite-nyx-sys/src/nyx.h`): an `int32_t`
+/// size followed by the data, and libnyx writes the input at that offset
+/// (`set_input_ptr` in `nyx_mode/libnyx`). A buffer of `n` bytes therefore
+/// carries only `n - PAYLOAD_HEADER_SIZE` bytes of input, so whoever sizes the
+/// buffer has to budget for the prefix.
+pub const PAYLOAD_HEADER_SIZE: u32 = 4;
+
+/// `NyxProcessRole::StandAlone` — a single VM not sharing a snapshot with peers.
+const ROLE_STANDALONE: u32 = 0;
+
+// Host-side function signatures from `libnyx.h`. Opaque `config` and
+// `NyxProcess` handles are represented as `*mut c_void`.
+type ConfigLoad = unsafe extern "C" fn(*const c_char) -> *mut c_void;
+type ConfigFree = unsafe extern "C" fn(*mut c_void);
+type ConfigSetWorkdir = unsafe extern "C" fn(*mut c_void, *const c_char);
+type ConfigSetU32 = unsafe extern "C" fn(*mut c_void, u32);
+type ConfigSetBool = unsafe extern "C" fn(*mut c_void, bool);
+type New = unsafe extern "C" fn(*mut c_void, u32) -> *mut c_void;
+type OptionSetBool = unsafe extern "C" fn(*mut c_void, bool);
+type OptionSetTimeout = unsafe extern "C" fn(*mut c_void, u8, u32);
+type OptionApply = unsafe extern "C" fn(*mut c_void);
+type SetInput = unsafe extern "C" fn(*mut c_void, *mut u8, u32);
+type Exec = unsafe extern "C" fn(*mut c_void) -> i32;
+type GetAuxBuffer = unsafe extern "C" fn(*mut c_void) -> *mut u8;
+type GetBitmapBuffer = unsafe extern "C" fn(*mut c_void) -> *mut u8;
+type GetBitmapBufferSize = unsafe extern "C" fn(*mut c_void) -> usize;
+type Shutdown = unsafe extern "C" fn(*mut c_void);
+
+/// A loaded `libnyx.so` with its host-side entry points resolved once.
+///
+/// Function pointers are resolved up front so the hot execution loop performs
+/// no per-call symbol lookup; `handle` is the `dlopen` handle, retained to keep
+/// the object mapped for as long as those pointers are used and closed on drop.
+pub struct Libnyx {
+    handle: *mut c_void,
+    config_load: ConfigLoad,
+    config_free: ConfigFree,
+    config_set_workdir: ConfigSetWorkdir,
+    config_set_input_buffer_size: ConfigSetU32,
+    config_set_input_buffer_write_protection: ConfigSetBool,
+    config_set_process_role: ConfigSetU32,
+    new: New,
+    option_set_reload_mode: OptionSetBool,
+    option_set_timeout: OptionSetTimeout,
+    option_apply: OptionApply,
+    set_afl_input: SetInput,
+    exec: Exec,
+    get_aux_buffer: GetAuxBuffer,
+    get_bitmap_buffer: GetBitmapBuffer,
+    get_bitmap_buffer_size: GetBitmapBufferSize,
+    shutdown: Shutdown,
+}
+
+/// Per-execution measurements split into the target's own runtime and the Nyx
+/// machinery around it, read from the auxiliary buffer after an execution.
+#[derive(Clone, Copy, Debug)]
+pub struct ExecStats {
+    /// The execution outcome.
+    pub result: NyxReturn,
+    /// Guest time the target actually spent running the input, measured inside
+    /// the VM. Excludes the host-side snapshot restore/reset, so subtracting it
+    /// from the host-observed exec wall time isolates the Nyx overhead.
+    pub target_runtime: Duration,
+    /// Pages the VM had to restore for this execution. The dominant driver of
+    /// restore cost, so it explains variation in the Nyx overhead.
+    pub dirty_pages: u32,
+}
+
+/// Resolves a required function symbol from a `dlopen` handle into a typed
+/// function pointer, erroring by name if it is absent.
+///
+/// Every libnyx symbol we bind is a function, so a null `dlsym` result means the
+/// symbol is missing; there is no data symbol whose real address could be null.
+///
+/// # Safety
+/// `handle` must be a live `dlopen` handle for a genuine `libnyx.so`, and `T`
+/// must be the `extern "C"` fn pointer type matching `name`'s C signature.
+unsafe fn sym<T: Copy>(handle: *mut c_void, name: &CStr) -> Result<T, String> {
+    const { assert!(size_of::<T>() == size_of::<*mut c_void>()) }
+    // SAFETY: the caller guarantees `handle` is live, and `name` is a `CStr` so
+    // it is NUL-terminated by construction.
+    let ptr = unsafe { libc::dlsym(handle, name.as_ptr()) };
+    if ptr.is_null() {
+        return Err(format!(
+            "libnyx.so is missing required symbol `{}`",
+            name.to_string_lossy()
+        ));
+    }
+    // SAFETY: the const assert pins `T` to pointer width and the caller vouches
+    // for the signature; transmuting a `dlsym` address to an `extern "C"` fn
+    // pointer is the standard idiom.
+    Ok(unsafe { std::mem::transmute_copy(&ptr) })
+}
+
+impl Libnyx {
+    /// Loads `libnyx.so` from `path` and resolves its host-side API.
+    ///
+    /// # Errors
+    /// Returns an error if the library cannot be opened or a required symbol is
+    /// missing.
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let path_c = path_to_cstring(path)?;
+
+        // `RTLD_NOW` resolves every symbol at load time (surfacing an
+        // incompatible libnyx immediately rather than mid-run); `RTLD_LOCAL`
+        // keeps its symbols out of the global namespace.
+        // SAFETY: `path_c` is a valid NUL-terminated path. dlopen runs the
+        // library's initializers; libnyx has no problematic constructors.
+        let handle = unsafe { libc::dlopen(path_c.as_ptr(), libc::RTLD_NOW | libc::RTLD_LOCAL) };
+        if handle.is_null() {
+            return Err(format!(
+                "failed to dlopen {}: {}",
+                path.display(),
+                dlerror_string()
+            ));
+        }
+
+        // SAFETY: `handle` is the live handle just returned by dlopen.
+        match unsafe { Self::resolve(handle) } {
+            Ok(libnyx) => Ok(libnyx),
+            Err(e) => {
+                // A symbol was missing; close the handle we opened before failing.
+                // SAFETY: `handle` came from dlopen above and is closed once.
+                unsafe { libc::dlclose(handle) };
+                Err(e)
+            }
+        }
+    }
+
+    /// Binds every host-side entry point from an open `dlopen` handle.
+    ///
+    /// # Safety
+    /// `handle` must be a live `dlopen` handle for a genuine `libnyx.so`.
+    unsafe fn resolve(handle: *mut c_void) -> Result<Self, String> {
+        // SAFETY: the caller guarantees `handle` is a live libnyx handle. Each
+        // field's declared type is the fn signature libnyx.h gives for that
+        // symbol, which is what `sym` requires.
+        unsafe {
+            Ok(Self {
+                config_load: sym(handle, c"nyx_config_load")?,
+                config_free: sym(handle, c"nyx_config_free")?,
+                config_set_workdir: sym(handle, c"nyx_config_set_workdir_path")?,
+                config_set_input_buffer_size: sym(handle, c"nyx_config_set_input_buffer_size")?,
+                config_set_input_buffer_write_protection: sym(
+                    handle,
+                    c"nyx_config_set_input_buffer_write_protection",
+                )?,
+                config_set_process_role: sym(handle, c"nyx_config_set_process_role")?,
+                new: sym(handle, c"nyx_new")?,
+                option_set_reload_mode: sym(handle, c"nyx_option_set_reload_mode")?,
+                option_set_timeout: sym(handle, c"nyx_option_set_timeout")?,
+                option_apply: sym(handle, c"nyx_option_apply")?,
+                set_afl_input: sym(handle, c"nyx_set_afl_input")?,
+                exec: sym(handle, c"nyx_exec")?,
+                get_aux_buffer: sym(handle, c"nyx_get_aux_buffer")?,
+                get_bitmap_buffer: sym(handle, c"nyx_get_bitmap_buffer")?,
+                get_bitmap_buffer_size: sym(handle, c"nyx_get_bitmap_buffer_size")?,
+                shutdown: sym(handle, c"nyx_shutdown")?,
+                handle,
+            })
+        }
+    }
+
+    /// Boots a standalone Nyx VM from `sharedir`, using `workdir` as libnyx's
+    /// scratch directory (which libnyx wipes on startup).
+    ///
+    /// The returned [`NyxVm`] restores the snapshot before every execution
+    /// (reload mode) so each [`NyxVm::exec`] measures one snapshot restore plus
+    /// one target run. `timeout_secs` bounds a single execution; an input that
+    /// runs longer trips [`NyxReturn::Timeout`] instead of hanging the caller.
+    ///
+    /// # Errors
+    /// Returns an error string if the sharedir path is not valid UTF-8 with no
+    /// interior NUL, or if libnyx fails to create the VM.
+    pub fn boot(
+        &self,
+        sharedir: &Path,
+        workdir: &Path,
+        input_buffer_size: u32,
+        worker_id: u32,
+        timeout_secs: u8,
+    ) -> Result<NyxVm<'_>, String> {
+        let sharedir_c = path_to_cstring(sharedir)?;
+        let workdir_c = path_to_cstring(workdir)?;
+
+        // SAFETY: every pointer below is a live handle produced by libnyx or a
+        // NUL-terminated string that outlives the call. The sequence mirrors
+        // AFL++'s `afl_fsrv_start` Nyx setup.
+        let process = unsafe {
+            let config = (self.config_load)(sharedir_c.as_ptr());
+            if config.is_null() {
+                return Err(format!(
+                    "nyx_config_load failed for sharedir {}",
+                    sharedir.display()
+                ));
+            }
+            (self.config_set_workdir)(config, workdir_c.as_ptr());
+            (self.config_set_input_buffer_size)(config, input_buffer_size);
+            (self.config_set_input_buffer_write_protection)(config, true);
+            (self.config_set_process_role)(config, ROLE_STANDALONE);
+
+            let process = (self.new)(config, worker_id);
+            (self.config_free)(config);
+            if process.is_null() {
+                return Err("nyx_new failed to create the VM".to_string());
+            }
+            process
+        };
+
+        // The bitmap size is fixed for the life of the VM; read it once here so
+        // `bitmap_size()` is a field access on hot paths rather than an FFI call.
+        // SAFETY: `process` is the live handle just returned by `nyx_new`.
+        let bitmap_size = unsafe { (self.get_bitmap_buffer_size)(process) };
+
+        let mut vm = NyxVm {
+            lib: self,
+            process,
+            bitmap_size,
+            input_buffer_size,
+        };
+        vm.set_reload_mode(true);
+        vm.set_timeout(timeout_secs, 0);
+        vm.assert_aux_buffer_layout_matches();
+        Ok(vm)
+    }
+}
+
+/// A booted Nyx VM. Dropping it shuts the VM down.
+pub struct NyxVm<'a> {
+    lib: &'a Libnyx,
+    process: *mut c_void,
+    /// Coverage bitmap size, fixed once the VM is booted. Cached so hot loops
+    /// don't re-cross the FFI boundary for a constant.
+    bitmap_size: usize,
+    /// Input buffer size the VM was booted with; the largest input it can run.
+    input_buffer_size: u32,
+}
+
+impl NyxVm<'_> {
+    /// Enables or disables snapshot reload before each execution.
+    pub fn set_reload_mode(&mut self, enable: bool) {
+        // SAFETY: `process` is a live handle; option changes require a following
+        // `option_apply` to take effect.
+        unsafe {
+            (self.lib.option_set_reload_mode)(self.process, enable);
+            (self.lib.option_apply)(self.process);
+        }
+    }
+
+    /// Sets the per-execution timeout.
+    pub fn set_timeout(&mut self, seconds: u8, micros: u32) {
+        // SAFETY: `process` is a live handle.
+        unsafe {
+            (self.lib.option_set_timeout)(self.process, seconds, micros);
+            (self.lib.option_apply)(self.process);
+        }
+    }
+
+    /// Runs `input` once through the VM and returns the outcome.
+    ///
+    /// `input` is copied into libnyx's input buffer, so the same slice can be
+    /// executed repeatedly. libnyx treats the buffer as read-only (write
+    /// protection is enabled at boot), but its C signature takes `*mut u8`.
+    ///
+    /// # Panics
+    ///
+    /// If `input` does not fit the buffer the VM was booted with, alongside the
+    /// length prefix libnyx stores in front of it. Callers size that buffer from
+    /// the input, so an input that does not fit is a bug in that validation
+    /// rather than a runtime condition.
+    pub fn exec(&mut self, input: &[u8]) -> NyxReturn {
+        // libnyx writes the input at `PAYLOAD_HEADER_SIZE` into the buffer, after
+        // the payload's length prefix, so the prefix eats into what fits.
+        assert!(
+            input.len() as u64 + u64::from(PAYLOAD_HEADER_SIZE)
+                <= u64::from(self.input_buffer_size),
+            "input is {} bytes plus a {PAYLOAD_HEADER_SIZE}-byte length prefix, but the VM's \
+             input buffer is {} bytes",
+            input.len(),
+            self.input_buffer_size
+        );
+        let len = u32::try_from(input.len()).expect("bounded by the input buffer size above");
+        // SAFETY: `input` outlives the call; libnyx copies at most `len` bytes
+        // out of it and does not retain the pointer past the call.
+        let raw = unsafe {
+            (self.lib.set_afl_input)(self.process, input.as_ptr().cast_mut(), len);
+            (self.lib.exec)(self.process)
+        };
+        NyxReturn::from_raw(raw)
+    }
+
+    /// Runs `input` once and returns the outcome plus the auxiliary-buffer
+    /// measurements ([`ExecStats`]) for that execution: the target's own guest
+    /// runtime and the pages restored. The caller's own wall-clock timing of
+    /// this call, minus [`ExecStats::target_runtime`], is the Nyx overhead.
+    pub fn exec_with_stats(&mut self, input: &[u8]) -> ExecStats {
+        let result = self.exec(input);
+        // SAFETY: `nyx_get_aux_buffer` returns libnyx's live 4 KiB aux-buffer
+        // mapping; QEMU-Nyx has just written this exec's `result` section. The
+        // field offsets are byte-aligned within that mapping, so the reads stay
+        // in bounds and are correctly aligned; `read_unaligned` is used anyway
+        // because the source struct is `#[repr(packed)]`.
+        let (target_runtime, dirty_pages) = unsafe {
+            let aux = (self.lib.get_aux_buffer)(self.process).cast_const();
+            let sec = read_u32(aux, aux::RUNTIME_SEC);
+            let usec = read_u32(aux, aux::RUNTIME_USEC);
+            let dirty = read_u32(aux, aux::DIRTY_PAGES);
+            let runtime = Duration::new(u64::from(sec), usec.saturating_mul(1_000));
+            (runtime, dirty)
+        };
+        ExecStats {
+            result,
+            target_runtime,
+            dirty_pages,
+        }
+    }
+
+    /// Asserts that the auxiliary buffer has the magic, version, and hash this binding's
+    /// field offsets were derived from, ensuring [`ExecStats`] readings are trustworthy.
+    ///
+    /// # Panics
+    ///
+    /// Panics immediately if the magic, version, or hash do not match, failing fast
+    /// to prevent benchmarking with garbage or corrupt layout data.\
+    pub fn assert_aux_buffer_layout_matches(&self) {
+        // SAFETY: as in `exec_with_stats`; the header sits at offset 0.
+        unsafe {
+            let aux = (self.lib.get_aux_buffer)(self.process).cast_const();
+            let magic = aux.cast::<u64>().read_unaligned();
+            let version = aux.add(8).cast::<u16>().read_unaligned();
+            let hash = aux.add(10).cast::<u16>().read_unaligned();
+
+            assert_eq!(
+                magic,
+                aux::MAGIC,
+                "Aux buffer magic mismatch (expected {:#x}, got {:#x})",
+                aux::MAGIC,
+                magic
+            );
+            assert_eq!(
+                version,
+                aux::VERSION,
+                "Aux buffer version mismatch (expected {}, got {})",
+                aux::VERSION,
+                version
+            );
+            assert_eq!(
+                hash,
+                aux::QEMU_PT_HASH,
+                "Aux buffer hash mismatch (expected {:#x}, got {:#x})",
+                aux::QEMU_PT_HASH,
+                hash
+            );
+        }
+    }
+
+    /// Size in bytes of the AFL coverage bitmap backing this VM (one byte per
+    /// edge). Zero if libnyx reports no bitmap.
+    #[must_use]
+    pub fn bitmap_size(&self) -> usize {
+        self.bitmap_size
+    }
+
+    /// Copies the current coverage bitmap into `dst`.
+    ///
+    /// The bitmap is a live mapping QEMU-Nyx overwrites on every execution, so
+    /// to compare coverage across executions it must be copied out before the
+    /// next `exec`. At most `min(bitmap_size(), dst.len())` bytes are copied;
+    /// pass a `dst` of `bitmap_size()` bytes to capture the whole map.
+    pub fn copy_bitmap_into(&self, dst: &mut [u8]) {
+        let n = self.bitmap_size().min(dst.len());
+        // SAFETY: `get_bitmap_buffer` returns the live bitmap mapping whose
+        // length is `get_bitmap_buffer_size`; copying the min of that and
+        // `dst.len()` stays in bounds of both, and the regions do not overlap.
+        unsafe {
+            let src = (self.lib.get_bitmap_buffer)(self.process);
+            std::ptr::copy_nonoverlapping(src, dst.as_mut_ptr(), n);
+        }
+    }
+}
+
+/// Reads a little-endian `u32` at `offset` bytes into the aux buffer at `base`.
+///
+/// # Safety
+/// `base + offset .. + 4` must lie within the mapped aux buffer.
+unsafe fn read_u32(base: *const u8, offset: usize) -> u32 {
+    unsafe { base.add(offset).cast::<u32>().read_unaligned() }
+}
+
+impl Drop for NyxVm<'_> {
+    fn drop(&mut self) {
+        // SAFETY: `process` is a live handle used exactly once for teardown.
+        unsafe {
+            (self.lib.shutdown)(self.process);
+        }
+    }
+}
+
+impl Drop for Libnyx {
+    fn drop(&mut self) {
+        // A `NyxVm` borrows `&Libnyx`, so all VMs are gone before this runs and
+        // no copied-out function pointer can outlive the mapping.
+        // SAFETY: `handle` came from dlopen in `load` and is closed exactly once.
+        unsafe {
+            libc::dlclose(self.handle);
+        }
+    }
+}
+
+/// Returns the dynamic loader's current error text, or a placeholder if none.
+fn dlerror_string() -> String {
+    // SAFETY: dlerror returns NULL or a pointer to a loader-owned C string; we
+    // read it immediately, before any other dl call can overwrite it.
+    let err = unsafe { libc::dlerror() };
+    if err.is_null() {
+        "unknown error".to_string()
+    } else {
+        // SAFETY: `err` is non-null and points to a valid NUL-terminated string.
+        unsafe { CStr::from_ptr(err) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+/// Converts a path to a C string.
+fn path_to_cstring(path: &Path) -> Result<CString, String> {
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| format!("path contains an interior NUL byte: {}", path.display()))
+}

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -2,6 +2,8 @@
 
 mod commands;
 mod config;
+mod latency_stats;
+mod libnyx;
 mod state;
 mod tmux;
 mod utils;
@@ -11,9 +13,9 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 
 use commands::{
-    BuildArgs, BuildCommand, ConfigArgs, ConfigCommand, CorpusArgs, CorpusCommand, DoctorArgs,
-    DoctorCommand, PrintIrArgs, PrintIrCommand, StartArgs, StartCommand, StatusArgs, StatusCommand,
-    StopArgs, StopCommand,
+    BenchExecArgs, BenchExecCommand, BuildArgs, BuildCommand, ConfigArgs, ConfigCommand,
+    CorpusArgs, CorpusCommand, DoctorArgs, DoctorCommand, PrintIrArgs, PrintIrCommand, StartArgs,
+    StartCommand, StatusArgs, StatusCommand, StopArgs, StopCommand,
 };
 
 #[derive(Debug, Parser)]
@@ -25,6 +27,8 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Benchmark Nyx execution speed by running one input many times.
+    BenchExec(BenchExecArgs),
     /// Build Smite workload Docker images.
     Build(BuildArgs),
     /// Validate a campaign configuration file.
@@ -48,6 +52,7 @@ fn main() -> ExitCode {
 
     let cli = Cli::parse();
     let success = match cli.command {
+        Commands::BenchExec(args) => BenchExecCommand::execute(&args),
         Commands::Build(args) => BuildCommand::execute(&args),
         Commands::Config(args) => ConfigCommand::execute(&args),
         Commands::Corpus(args) => CorpusCommand::execute(&args),

--- a/smitebot/src/utils.rs
+++ b/smitebot/src/utils.rs
@@ -3,7 +3,10 @@
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::config::CampaignConfig;
 
 /// Returns the current Unix timestamp in seconds.
 pub fn epoch_secs() -> u64 {
@@ -39,6 +42,36 @@ fn find_in_path_with_path(tool: &str, path_var: &OsStr) -> Option<PathBuf> {
     std::env::split_paths(path_var)
         .map(|dir| dir.join(tool))
         .find(|candidate| candidate.is_file() && is_executable(candidate))
+}
+
+/// Runs `scripts/setup-nyx.sh` to prepare the Nyx sharedir.
+pub fn setup_nyx(config: &CampaignConfig, image: &str) -> bool {
+    let script = config.smite_dir.join("scripts").join("setup-nyx.sh");
+    if !script.exists() {
+        log::error!("setup-nyx.sh not found: {}", script.display());
+        return false;
+    }
+
+    let status = match Command::new(&script)
+        .arg(&config.sharedir)
+        .arg(image)
+        .arg(&config.aflpp_path)
+        .status()
+    {
+        Ok(status) => status,
+        Err(e) => {
+            log::error!("failed to run setup-nyx.sh: {e}");
+            return false;
+        }
+    };
+
+    if !status.success() {
+        log::error!("setup-nyx.sh failed with {status}");
+        return false;
+    }
+
+    log::info!("Nyx sharedir ready at {}", config.sharedir.display());
+    true
 }
 
 #[cfg(test)]

--- a/smitebot/src/utils.rs
+++ b/smitebot/src/utils.rs
@@ -74,10 +74,83 @@ pub fn setup_nyx(config: &CampaignConfig, image: &str) -> bool {
     true
 }
 
+/// Pins the calling thread, and every process it later spawns, to `cpu`.
+///
+/// # Errors
+/// Returns an error if `cpu` is out of range or is not an online CPU this
+/// process is allowed to run on.
+pub fn pin_to_cpu(cpu: usize) -> Result<(), String> {
+    // `CPU_SET` writes a bit at `cpu` in a fixed-size mask, so an index past the
+    // mask has to be rejected before the call rather than after.
+    let max = libc::CPU_SETSIZE as usize;
+    if cpu >= max {
+        return Err(format!("CPU {cpu} is out of range (0..{max})"));
+    }
+
+    // SAFETY: `set` is zero-initialized before use, `CPU_SET` writes within it
+    // given the bound check above, and `sched_setaffinity` reads exactly
+    // `size_of::<cpu_set_t>()` bytes from the pointer. A pid of 0 means the
+    // calling thread.
+    let failed = unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(cpu, &mut set);
+        libc::sched_setaffinity(0, size_of::<libc::cpu_set_t>(), &raw const set) != 0
+    };
+    if failed {
+        return Err(format!(
+            "failed to pin to CPU {cpu}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::OsString;
+
+    #[test]
+    fn pin_to_cpu_rejects_an_out_of_range_cpu() {
+        // Past the mask `CPU_SET` can address; must be caught before the call,
+        // since setting a bit out of bounds would be undefined behavior.
+        assert!(pin_to_cpu(libc::CPU_SETSIZE as usize).is_err());
+        assert!(pin_to_cpu(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn pin_to_cpu_binds_the_calling_thread() {
+        // Affinity is per-thread, and this runs on the test's own thread, so
+        // pinning here leaves the rest of the suite alone. Pin to a CPU the
+        // process is already allowed on so a restricted cpuset does not fail it.
+        let mut set: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::CPU_ZERO(&mut set) };
+
+        let size = size_of::<libc::cpu_set_t>();
+        assert_eq!(
+            unsafe { libc::sched_getaffinity(0, size, &raw mut set) },
+            0,
+            "sched_getaffinity failed"
+        );
+
+        let allowed = (0..libc::CPU_SETSIZE as usize)
+            .find(|&cpu| unsafe { libc::CPU_ISSET(cpu, &set) })
+            .expect("process is allowed on at least one CPU");
+
+        pin_to_cpu(allowed).unwrap();
+
+        let mut pinned: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::CPU_ZERO(&mut pinned) };
+
+        assert_eq!(
+            unsafe { libc::sched_getaffinity(0, size, &raw mut pinned) },
+            0
+        );
+        assert!(unsafe { libc::CPU_ISSET(allowed, &pinned) });
+        assert_eq!(unsafe { libc::CPU_COUNT(&pinned) }, 1);
+    }
 
     #[test]
     fn find_in_path_with_path_finds_existing_executable() {


### PR DESCRIPTION
The goal is to tell whether a change concretely improved the target's throughput or not: run bench before and after and compare execs/sec.

It runs a single input through the target's Nyx VM many times, timing the snapshot-restore-plus-target-run loop. Each exec is one snapshot restore plus one target run, so the numbers isolate VM/snapshot and target speed from AFL++'s mutation and scheduling overhead.

Like start, it builds the image and sets up the sharedir by default (pass --no-build to reuse an existing one), and loads libnyx.so at runtime the same way afl-fuzz does. --repeat averages over several fresh VM boots so a real change stands out from boot/snapshot variance, and --timeout bounds a single execution (default 2s).