### PR TITLE
smite-nyx-sys+workloads/ldk: include panic messages in crash reports

### DIFF
--- a/smite-nyx-sys/src/nyx-crash-handler.c
+++ b/smite-nyx-sys/src/nyx-crash-handler.c
@@ -34,6 +34,8 @@
 #include "nyx.h"
 #endif
 
+// Must match PANIC_LOG_PATH in workloads/ldk/src/main.rs.
+#define PANIC_LOG_PATH "/tmp/smite-panic.log"
 #define ASAN_LOG_PATH "/tmp/asan.log"
 #define MAX_CUSTOM_BACKTRACE_SIZE 50
 
@@ -58,11 +60,11 @@ void append_log(const char *msg) {
   strcat(log, msg);
 }
 
-// Fetch the ASan log from the log file and append it to the global log
-void append_asan_log() {
+// Fetch a report the target left behind at "<path>.<pid>" and append it to the
+// global log
+void append_target_log(const char *path) {
   char log_file_path[256];
-  snprintf(log_file_path, sizeof(log_file_path), "%s.%d", ASAN_LOG_PATH,
-           getpid());
+  snprintf(log_file_path, sizeof(log_file_path), "%s.%d", path, getpid());
 
   FILE *file = fopen(log_file_path, "r");
 
@@ -121,7 +123,8 @@ void panic_with_backtrace(const char *extra_msg) {
     append_log("\n");
   }
 
-  append_asan_log();
+  append_target_log(PANIC_LOG_PATH);
+  append_target_log(ASAN_LOG_PATH);
 
 #ifdef CUSTOM_BACKTRACE
   char custom_backtrace[0x10000];

--- a/workloads/ldk/src/main.rs
+++ b/workloads/ldk/src/main.rs
@@ -27,7 +27,27 @@ extern "C" fn handle_block(_: libc::c_int) {
     NEW_BLOCK.store(true, Ordering::SeqCst);
 }
 
+/// Path prefix the crash handler reads panic reports from.
+const PANIC_LOG_PATH: &str = "/tmp/smite-panic.log";
+
+/// Stores the panic message where the LD_PRELOADed crash handler can retrieve
+/// it. With `panic = "abort"`, panics only reach stderr, which scenario/Nyx
+/// discards,so this allows crash reports to include the panic message and its
+/// source location.
+fn install_panic_hook() {
+    let path = format!("{PANIC_LOG_PATH}.{}", std::process::id());
+    let default_hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |info| {
+        // Renders as "panicked at <file>:<line>:<col>:\n<message>".
+        let _ = std::fs::write(&path, format!("{info}\n"));
+        default_hook(info);
+    }));
+}
+
 fn main() {
+    install_panic_hook();
+
     // Set up signal handlers for graceful shutdown
     unsafe {
         // Cast through pointer to satisfy Rust's function-to-integer cast rules


### PR DESCRIPTION
LDK workload builds with `panic = "abort"`, so panic messages are only written to stderr, which the scenario/Nyx discards. As a result, crash reports contained only an `abort` with no indication of what actually failed.

see:
https://github.com/morehouse/smite/blob/06a5edfacc9a0656cca9dd6b3abc92e0ac0c5993/workloads/ldk/Cargo.toml#L7-L9

Install a panic hook that writes the panic message and its source location to `/tmp/smite-panic.log.<pid>`, and have the crash handler append target-generated logs to the crash report.

ref (fixed in https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/pulls/4833):

```sh
abort
panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lightning-0.2.1/src/sign/mod.rs:2440:9:
assertion failed: expected_max_weight <=
    spend_tx.weight().to_wu() + descriptors.len() as u64 * 3
```