### PR TITLE
smitebot: document tmux_session in sample config

### DIFF
--- a/smitebot/sample-campaign.toml
+++ b/smitebot/sample-campaign.toml
@@ -27,6 +27,9 @@ sharedir = "/tmp/smite-nyx"
 # Docker image tag override (default: smite-<target>-<scenario>).
 # image = "smite-lnd-encrypted_bytes"
 
+# Custom tmux session name (default: campaign ID).
+# tmux_session = "my-lnd-campaign"
+
 # Extra environment variables passed to AFL++ instances.
 # [afl_env]
 # AFL_KEEP_TIMEOUTS = "1"


### PR DESCRIPTION
`tmux_session` is a supported optional config key (added in #139 ) but was missing from the sample file. Added it as an example.
