### PR TITLE
smitebot: move afl_flags before [afl_env] in sample config

### DIFF
--- a/smitebot/sample-campaign.toml
+++ b/smitebot/sample-campaign.toml
@@ -30,9 +30,9 @@ sharedir = "/tmp/smite-nyx"
 # Custom tmux session name (default: campaign ID).
 # tmux_session = "my-lnd-campaign"
 
+# Extra CLI flags appended to afl-fuzz.
+# afl_flags = ["-t", "1000+"]
+
 # Extra environment variables passed to AFL++ instances.
 # [afl_env]
 # AFL_KEEP_TIMEOUTS = "1"
-
-# Extra CLI flags appended to afl-fuzz.
-# afl_flags = ["-t", "1000+"]


### PR DESCRIPTION
Resolves #175 

`afl_flags` appeared after `[afl_env]` in sample-campaign.toml. In TOML, all bare keys after a table header belong to that table, so `afl_flags` was parsed as `afl_env.afl_flags`, basically a string key receiving an array, which fails.

Move `afl_flags` before `[afl_env]` so it remains a top-level key.
