### PR TITLE
smite: add accept_channel oracle

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -13,10 +13,11 @@ use smite::bolt::{
     OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, Shutdown, msg_type,
 };
 use smite::channel_tx::{
-    ChannelConfig, ChannelPartyConfig, ChannelState, CommitmentCost, FundingTransaction,
-    HolderIdentity, Side, build_funding_transaction,
+    ChannelConfig, ChannelPartyConfig, ChannelState, FundingTransaction, HolderIdentity, Side,
+    build_funding_transaction,
 };
 use smite::noise::{ConnectionError, NoiseConnection};
+use smite::oracles::{AcceptChannelContext, AcceptChannelOracle, Oracle};
 use smite::pending_channel::PendingChannel;
 use smite::violation::Violation;
 use smite_ir::operation::AcceptChannelField;
@@ -477,7 +478,11 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                     log::debug!("[{:?}] RecvAcceptChannel: waiting", start.elapsed());
                     let ac = recv_accept_channel(&mut self.conn)?;
                     log::debug!("[{:?}] RecvAcceptChannel: received", start.elapsed());
-                    record_recv_accept_channel(&mut self.negotiations, &ac)?;
+                    AcceptChannelOracle.evaluate(&AcceptChannelContext {
+                        accept_channel: &ac,
+                        negotiation: self.negotiations.get(&ac.temporary_channel_id),
+                    })?;
+                    record_recv_accept_channel(&mut self.negotiations, &ac);
                     Some(Variable::AcceptChannel(ac))
                 }
 
@@ -1317,9 +1322,8 @@ fn is_channel_ready_expected(
 /// # Errors
 ///
 /// Returns [`Violation::UnknownChannel`] if no channel state exists for the
-/// given `channel_id`, [`Violation::OpenerCannotAffordFee`] if the opener
-/// cannot afford the commitment feerate, or [`Violation::InvalidCounterpartySignature`]
-/// if the signature is invalid for the holder's initial commitment transaction.
+/// given `channel_id`, or [`Violation::InvalidCounterpartySignature`] if the
+/// signature is invalid for the holder's initial commitment transaction.
 fn verify_funding_signed(
     fs: &FundingSigned,
     channel_states: &HashMap<ChannelId, ChannelState>,
@@ -1327,17 +1331,6 @@ fn verify_funding_signed(
     let state = channel_states
         .get(&fs.channel_id)
         .ok_or(Violation::UnknownChannel(fs.channel_id))?;
-
-    // The opener cannot afford the fee, so the acceptor must not send
-    // `funding_signed`. Receiving one is a protocol violation.
-    let commitment_cost =
-        CommitmentCost::new(state.commitment.feerate_per_kw, &state.config.channel_type);
-    if (state.commitment.opener.balance_msat / 1000)
-        .checked_sub(commitment_cost.total_sat())
-        .is_none()
-    {
-        return Err(Violation::OpenerCannotAffordFee(fs.channel_id));
-    }
 
     state
         .config
@@ -1377,29 +1370,18 @@ fn record_send_open_channel(
 /// Pairs a received `accept_channel` with the recorded `open_channel` of the
 /// same `temporary_channel_id`.
 ///
-/// # Errors
+/// # Panics
 ///
-/// Returns [`Violation::UnknownChannel`] if no `open_channel` was recorded
-/// for the message's `temporary_channel_id`.
-///
-/// Returns [`Violation::TempChannelIdReuse`] if the negotiation already has an
-/// `accept_channel` but has not yet reached `funding_created`.
+/// Panics if no matching `open_channel` exists. This should be unreachable, as
+/// `AcceptChannelOracle` reports such messages as a [`Violation`].
 fn record_recv_accept_channel(
     negotiations: &mut HashMap<ChannelId, PendingChannel>,
     accept_channel: &AcceptChannel,
-) -> Result<(), Violation> {
-    let pending = negotiations
+) {
+    negotiations
         .get_mut(&accept_channel.temporary_channel_id)
-        .ok_or(Violation::UnknownChannel(
-            accept_channel.temporary_channel_id,
-        ))?;
-    if pending.accept_channel.is_some() && !pending.funding_built {
-        return Err(Violation::TempChannelIdReuse(
-            accept_channel.temporary_channel_id,
-        ));
-    }
-    pending.accept_channel = Some(accept_channel.clone());
-    Ok(())
+        .expect("AcceptChannelOracle guaranteed this temporary_channel_id exists")
+        .accept_channel = Some(accept_channel.clone());
 }
 
 /// Extracts a field from a parsed `accept_channel` message.
@@ -1620,7 +1602,7 @@ mod tests {
             first_per_commitment_point: sample_pubkey(6),
             tlvs: AcceptChannelTlvs {
                 upfront_shutdown_script: Some(vec![0xde, 0xad]),
-                channel_type: Some(vec![0x01]),
+                channel_type: Some(vec![0x40, 0x10, 0x00]),
             },
         }
     }
@@ -1705,7 +1687,7 @@ mod tests {
                 inputs: vec![],
             },
             Instruction {
-                operation: Operation::LoadFeatures(vec![]),
+                operation: Operation::LoadFeatures(vec![0x40, 0x10, 0x00]),
                 inputs: vec![],
             },
         ]
@@ -1894,7 +1876,7 @@ mod tests {
         assert_eq!(oc.first_per_commitment_point, pk);
         assert_eq!(oc.channel_flags, 1);
         assert_eq!(oc.tlvs.upfront_shutdown_script, Some(vec![]));
-        assert!(oc.tlvs.channel_type.is_none());
+        assert_eq!(oc.tlvs.channel_type, Some(vec![0x40, 0x10, 0x00]));
     }
 
     #[test]
@@ -2650,9 +2632,55 @@ mod tests {
             )
             .unwrap_err();
 
-        assert!(
-            matches!(err, ExecuteError::Violation(Violation::UnknownChannel(id)) if id == unknown_id)
+        let ExecuteError::Violation(Violation::InvalidAcceptChannel(id, reason)) = &err else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert_eq!(*id, unknown_id);
+        assert!(reason.contains(
+            "unknown temporary_channel_id: no open_channel was sent for this negotiation"
+        ));
+    }
+
+    #[test]
+    fn execute_recv_accept_channel_opener_cannot_afford_fee() {
+        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
+
+        // Set `push_msat` so the opener cannot afford the commitment fee
+        // requiring the peer to reject the `open_channel` per BOLT 2.
+        let mut instrs = send_open_channel_instructions();
+        instrs[3] = Instruction {
+            operation: Operation::LoadAmount(99_900_000),
+            inputs: vec![],
+        };
+        let sent_open_channel = instrs.len() - 1;
+        instrs.push(Instruction {
+            operation: Operation::RecvAcceptChannel,
+            inputs: vec![sent_open_channel],
+        });
+
+        let mut executor = Executor::new(
+            MockConnection::new(),
+            MockBitcoinCli::default(),
+            sample_context(),
         );
+        executor.conn.queue_recv(ac_bytes);
+        let err = executor
+            .execute(
+                &Program {
+                    instructions: instrs,
+                },
+                std::time::Instant::now(),
+            )
+            .unwrap_err();
+
+        let ExecuteError::Violation(Violation::InvalidAcceptChannel(id, reason)) = &err else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert_eq!(*id, temporary_channel_id);
+        assert!(reason.contains(
+            "invalid open_channel: opener balance 100 sat cannot cover the commitment fee"
+        ));
     }
 
     #[test]
@@ -2692,9 +2720,13 @@ mod tests {
                 std::time::Instant::now(),
             )
             .unwrap_err();
-        assert!(matches!(
-            err,
-            ExecuteError::Violation(Violation::TempChannelIdReuse(id)) if id == temporary_channel_id
+
+        let ExecuteError::Violation(Violation::InvalidAcceptChannel(id, reason)) = &err else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert_eq!(*id, temporary_channel_id);
+        assert!(reason.contains(
+            "temporary_channel_id reuse: previous negotiation has not reached funding_created"
         ));
     }
 
@@ -3572,54 +3604,6 @@ mod tests {
     }
 
     #[test]
-    fn execute_recv_funding_signed_opener_cannot_afford_fee() {
-        let mock_cli = MockBitcoinCli {
-            utxos: vec![sample_utxo()],
-            change_spk: sample_change_spk(),
-            ..Default::default()
-        };
-
-        let channel_id = ChannelId::v1_from_funding_outpoint(OutPoint {
-            txid: "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
-                .parse()
-                .unwrap(),
-            vout: 0,
-        });
-
-        // The expected signature here was computed using LDK as the source of
-        // truth.
-        let fs_bytes = Message::FundingSigned(FundingSigned {
-            channel_id,
-            signature: "304502210096c5e8ad834af46b42a4301828852205655d16dc8d55333831de49642d70c60a02205466283b9557447dd4c5374b90eda80f023017164dd04deb7c45cfc472e03023".parse().unwrap(),
-        })
-        .encode();
-
-        let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
-        executor.conn.queue_recv(fs_bytes);
-
-        // Increase the pushed amount so the opener cannot afford the required
-        // fee when the commitment is built and funding_signed is received.
-        let mut negotiation = sample_funding_negotiation();
-        negotiation.open_channel.push_msat = 10_000_000_000;
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), negotiation);
-
-        let err = executor
-            .execute(
-                &Program {
-                    instructions: send_funding_created_and_recv_funding_signed_instructions(),
-                },
-                std::time::Instant::now(),
-            )
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            ExecuteError::Violation(Violation::OpenerCannotAffordFee(id)) if id == channel_id
-        ));
-    }
-
-    #[test]
     fn execute_recv_funding_signed_invalid_signature() {
         let mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],
@@ -4141,7 +4125,7 @@ mod tests {
         );
         assert_eq!(
             extract_field(&ac, AcceptChannelField::ChannelType),
-            Variable::Features(vec![0x01])
+            Variable::Features(vec![0x40, 0x10, 0x00])
         );
     }
 

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -13,8 +13,8 @@ use smite::bolt::{
     OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, Shutdown, msg_type,
 };
 use smite::channel_tx::{
-    ChannelConfig, ChannelPartyConfig, ChannelState, FundingTransaction, HolderIdentity, Side,
-    build_funding_transaction,
+    ChannelConfig, ChannelPartyConfig, ChannelState, CommitmentCost, FundingTransaction,
+    HolderIdentity, Side, build_funding_transaction,
 };
 use smite::noise::{ConnectionError, NoiseConnection};
 use smite::pending_channel::PendingChannel;
@@ -1330,7 +1330,12 @@ fn verify_funding_signed(
 
     // The opener cannot afford the fee, so the acceptor must not send
     // `funding_signed`. Receiving one is a protocol violation.
-    if !state.config.can_opener_afford_feerate(&state.commitment) {
+    let commitment_cost =
+        CommitmentCost::new(state.commitment.feerate_per_kw, &state.config.channel_type);
+    if (state.commitment.opener.balance_msat / 1000)
+        .checked_sub(commitment_cost.total_sat())
+        .is_none()
+    {
         return Err(Violation::OpenerCannotAffordFee(fs.channel_id));
     }
 

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -2,6 +2,7 @@
 
 use bitcoin::OutPoint;
 use bitcoin::hashes::Hash;
+use bitcoin::hex::DisplayHex;
 use std::fmt;
 
 /// Maximum Lightning message size (2-byte length prefix limit).
@@ -62,6 +63,13 @@ impl ChannelId {
         res[30] ^= ((outpoint.vout >> 8) & 0xff) as u8;
         res[31] ^= (outpoint.vout & 0xff) as u8;
         Self(res)
+    }
+}
+
+impl fmt::Display for ChannelId {
+    /// Formats channel ID into hex string.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.as_hex())
     }
 }
 
@@ -201,7 +209,6 @@ impl BigSize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::hex::DisplayHex;
     use bitcoin::{OutPoint, Txid};
 
     #[test]
@@ -245,7 +252,7 @@ mod tests {
         let expected = "0202020202020202020202020202020202020202020202020202020202020203";
         let channel_id = ChannelId::v1_from_funding_outpoint(funding_outpoint);
 
-        assert_eq!(channel_id.0.as_hex().to_string(), expected);
+        assert_eq!(channel_id.to_string(), expected);
     }
 
     #[test]

--- a/smite/src/channel_tx.rs
+++ b/smite/src/channel_tx.rs
@@ -7,7 +7,7 @@ mod commitment;
 mod funding;
 
 pub use commitment::{
-    ChannelConfig, ChannelPartyConfig, ChannelState, CommitmentError, CommitmentPartyState,
-    CommitmentState, HolderIdentity, Side,
+    ChannelConfig, ChannelPartyConfig, ChannelState, CommitmentCost, CommitmentError,
+    CommitmentPartyState, CommitmentState, HolderIdentity, Side,
 };
 pub use funding::{FundingTransaction, InsufficientFunds, build_funding_transaction};

--- a/smite/src/channel_tx/commitment.rs
+++ b/smite/src/channel_tx/commitment.rs
@@ -113,6 +113,15 @@ pub struct CommitmentState {
     // to correctly compute balances and construct HTLC outputs in the commitment transaction.
 }
 
+/// Costs associated with a commitment transaction, including transaction fee
+/// and anchor outputs.
+pub struct CommitmentCost {
+    /// Commitment transaction fee in satoshis.
+    pub fee_sat: u64,
+    /// Total cost of anchor outputs in satoshis.
+    pub anchor_cost_sat: u64,
+}
+
 /// State of a single channel, including its static configuration, holder
 /// identity, and current commitment state.
 pub struct ChannelState {
@@ -266,19 +275,6 @@ impl ChannelConfig {
         })
     }
 
-    /// Checks whether the opener can afford the commitment fee at the given
-    /// feerate, after accounting for the anchor outputs.
-    #[must_use]
-    pub fn can_opener_afford_feerate(&self, state: &CommitmentState) -> bool {
-        let fee = commit_tx_fee_sat(state.feerate_per_kw, &self.channel_type);
-        let anchor_cost = total_anchors_sat(&self.channel_type);
-
-        (state.opener.balance_msat / 1000)
-            .checked_sub(fee)
-            .and_then(|balance| balance.checked_sub(anchor_cost))
-            .is_some()
-    }
-
     /// Builds the signature for the counterparty's commitment transaction.
     #[must_use]
     pub fn sign_counterparty_commitment(
@@ -390,13 +386,10 @@ impl ChannelConfig {
         let anchor = supports_option_anchors(&self.channel_type);
 
         // Fee and balances.
-        let fee = commit_tx_fee_sat(state.feerate_per_kw, &self.channel_type);
-        let anchor_cost = total_anchors_sat(&self.channel_type);
-
+        let commitment_cost = CommitmentCost::new(state.feerate_per_kw, &self.channel_type);
+        let opener_balance =
+            (state.opener.balance_msat / 1000).saturating_sub(commitment_cost.total_sat());
         let acceptor_balance = state.acceptor.balance_msat / 1000;
-        let opener_balance = (state.opener.balance_msat / 1000)
-            .saturating_sub(fee)
-            .saturating_sub(anchor_cost);
 
         // Map opener/acceptor to local/remote for this commitment side.
         let (to_local_value, to_remote_value) = match local_side {
@@ -473,6 +466,23 @@ impl CommitmentState {
 
     // TODO: When adding HTLC support, add `get_next_commitment_state` to build the next
     // commitment state based on the previous state and the HTLCs claimed by both sides.
+}
+
+impl CommitmentCost {
+    /// Calculates the total cost of a commitment transaction.
+    #[must_use]
+    pub fn new(feerate_per_kw: u32, channel_type: &[u8]) -> CommitmentCost {
+        CommitmentCost {
+            fee_sat: commit_tx_fee_sat(feerate_per_kw, channel_type),
+            anchor_cost_sat: total_anchors_sat(channel_type),
+        }
+    }
+
+    /// Returns the total cost (fee + anchor outputs) in satoshis.
+    #[must_use]
+    pub fn total_sat(&self) -> u64 {
+        self.fee_sat + self.anchor_cost_sat
+    }
 }
 
 /// Get the fee cost of a commitment tx in satoshis.
@@ -1365,39 +1375,39 @@ mod tests {
     }
 
     #[test]
-    fn can_opener_afford_feerate_checks() {
+    fn opener_balance_after_commitment_cost_total_sat_checks() {
         let feerate_per_kw: u32 = 15_000;
-        let sample_key =
-            pubkey("03b28f7c5a9d1e4f8c6a7b2d3e9f1048576a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e");
+        let anchor_channel_type = [0x40, 0x00, 0x00];
         // Legacy fee: 15000 * 724 / 1000 = 10_860 sat
         // Anchor fee: 15000 * 1124 / 1000 = 16_860 sat; anchor_cost = 660 sat
 
         // Comfortably affordable
-        let chan_config = sample_chan_config(20_000, vec![]);
-        let state = chan_config
-            .new_initial_commitment(0, feerate_per_kw, sample_key, sample_key)
-            .expect("valid commitment");
-        assert!(chan_config.can_opener_afford_feerate(&state));
+        let opener_balance_sat: u64 = 20_000;
+        assert_eq!(
+            opener_balance_sat.checked_sub(CommitmentCost::new(feerate_per_kw, &[]).total_sat()),
+            Some(9_140),
+        );
 
         // Exact zero opener balance
-        let chan_config = sample_chan_config(11_860, vec![]);
-        let state = chan_config
-            .new_initial_commitment(1_000_000, feerate_per_kw, sample_key, sample_key)
-            .expect("valid commitment");
-        assert!(chan_config.can_opener_afford_feerate(&state));
+        let opener_balance_sat: u64 = 10_860;
+        assert_eq!(
+            opener_balance_sat.checked_sub(CommitmentCost::new(feerate_per_kw, &[]).total_sat()),
+            Some(0),
+        );
 
-        // Push fits but fee does not
-        let chan_config = sample_chan_config(10_000, vec![]);
-        let state = chan_config
-            .new_initial_commitment(0, feerate_per_kw, sample_key, sample_key)
-            .expect("valid commitment");
-        assert!(!chan_config.can_opener_afford_feerate(&state));
+        // Balance does not cover the fee
+        let opener_balance_sat: u64 = 10_000;
+        assert_eq!(
+            opener_balance_sat.checked_sub(CommitmentCost::new(feerate_per_kw, &[]).total_sat()),
+            None
+        );
 
-        // Push + fee fit but anchor cost does not
-        let chan_config = sample_chan_config(17_500, vec![0x40, 0x00, 0x00]);
-        let state = chan_config
-            .new_initial_commitment(0, feerate_per_kw, sample_key, sample_key)
-            .expect("valid commitment");
-        assert!(!chan_config.can_opener_afford_feerate(&state));
+        // Balance covers the fee but not the anchor outputs
+        let opener_balance_sat: u64 = 17_500;
+        assert_eq!(
+            opener_balance_sat
+                .checked_sub(CommitmentCost::new(feerate_per_kw, &anchor_channel_type).total_sat()),
+            None,
+        );
     }
 }

--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -10,7 +10,7 @@
 //! - [`bolt`] - BOLT message encoding and decoding.
 //! - [`channel_tx`] - BOLT 3 channel transaction construction (funding and commitment).
 //! - [`noise`] - BOLT 8 `Noise_XK` encrypted transport.
-//! - [`oracles`] - Post-scenario invariant checks.
+//! - [`oracles`] - Protocol invariant checks.
 //! - [`pending_channel`] - BOLT 2 channel negotiation state.
 //! - [`process`] - Managed subprocess utilities.
 //! - [`runners`] - Fuzz input delivery (Nyx and local modes).

--- a/smite/src/oracles.rs
+++ b/smite/src/oracles.rs
@@ -1,19 +1,18 @@
-//! Oracle trait for post-scenario invariant checks.
+//! Oracle trait for protocol invariant checks.
 //!
 //! Oracles evaluate conditions beyond simple crashes.
 
-/// Result of an oracle evaluation
-pub enum OracleResult {
-    /// The check passed
-    Pass,
-    /// The check failed with a reason
-    Fail(String),
-}
+mod accept_channel;
+
+use super::violation::Violation;
+pub use accept_channel::{AcceptChannelContext, AcceptChannelOracle};
 
 /// `Oracle` evaluates a condition against some context
 pub trait Oracle<C> {
     /// Evaluate the oracle against the given context
-    fn evaluate(&self, context: &C) -> OracleResult;
-    /// Return the name of this oracle for logging
-    fn name(&self) -> &str;
+    ///
+    /// # Errors
+    ///
+    /// Returns `Violation` if an oracle invariant is violated.
+    fn evaluate(&self, context: &C) -> Result<(), Violation>;
 }

--- a/smite/src/oracles/accept_channel.rs
+++ b/smite/src/oracles/accept_channel.rs
@@ -8,6 +8,11 @@ use crate::violation::Violation;
 
 use bitcoin::Amount;
 
+// Constants from the BOLT 2 `open_channel` requirements:
+// https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#requirements-8
+const MAX_ACCEPTED_HTLCS_LIMIT: u16 = 483;
+const MIN_DUST_LIMIT_SATOSHIS: u64 = 354;
+
 /// Context for `AcceptChannelOracle`
 pub struct AcceptChannelContext<'a> {
     /// The `accept_channel` received from the peer.
@@ -62,6 +67,13 @@ impl Oracle<AcceptChannelContext<'_>> for AcceptChannelOracle {
 /// Returns an error if our `open_channel` breaches a BOLT 2 requirement, i.e.
 /// the reason its receiver had to fail the channel instead of accepting it,
 /// or `Ok(())` if it breaches none.
+///
+/// # Deferred oracle checks
+///
+/// - dust limit greater than channel reserve: BOLT 2 requires the dust limit to
+///   be less than or equal to the channel reserve. However, implementations
+///   such as LDK accept zero channel reserves on the receiving side, so we do
+///   not enforce this check on the target's receiving side.
 fn verify_accepted_open_channel(open_channel: &OpenChannel) -> Result<(), String> {
     // Check that the funding amounts are valid.
     // FIXME: Varies if `option_support_large_channel` is not negotiated.
@@ -82,19 +94,83 @@ fn verify_accepted_open_channel(open_channel: &OpenChannel) -> Result<(), String
     }
 
     // Check that the channel type was included.
+    // TODO: Check option_channel_type in negotiated features since it is
+    // assumed to be supported.
     let Some(channel_type) = open_channel.tlvs.channel_type.as_deref() else {
         return Err("open_channel does not include a channel_type".to_string());
     };
 
-    // Check that the opener can afford the proposed feerate.
-    let opener_balance_sat = (funding_msat - open_channel.push_msat) / 1000;
-    let commitment_cost = CommitmentCost::new(open_channel.feerate_per_kw, channel_type);
-    if opener_balance_sat
-        .checked_sub(commitment_cost.total_sat())
-        .is_none()
-    {
+    // Check the HTLC limit is within the maximum.
+    // FIXME: Does not apply to channels whose `channel_type` includes
+    // `zero_fee_commitments`. These channel types have a lower upper limit on
+    // `max_accepted_htlcs`, so we are currently safe.
+    if open_channel.max_accepted_htlcs > MAX_ACCEPTED_HTLCS_LIMIT {
         return Err(format!(
-            "opener balance {opener_balance_sat} sat cannot cover the commitment fee and anchor cost",
+            "max_accepted_htlcs {} exceeds the limit of {MAX_ACCEPTED_HTLCS_LIMIT}",
+            open_channel.max_accepted_htlcs,
+        ));
+    }
+
+    // Check the dust limit is not below the minimum.
+    if open_channel.dust_limit_satoshis < MIN_DUST_LIMIT_SATOSHIS {
+        return Err(format!(
+            "dust_limit_satoshis {} is below the minimum of {MIN_DUST_LIMIT_SATOSHIS} sat",
+            open_channel.dust_limit_satoshis,
+        ));
+    }
+
+    // Check the initial commitment satisfies the channel reserve.
+    verify_initial_commitment(
+        open_channel,
+        channel_type,
+        open_channel.channel_reserve_satoshis,
+    )
+}
+
+/// Verifies that the initial commitment can cover its fee and satisfies the
+/// channel reserve requirement, returning an error if it breaches either, or
+/// `Ok(())` if both are met.
+///
+/// NOTE: This check is safe from false positives for `zero_fee_commitments`
+/// and `option_simple_taproot`, although the reported error may be misleading:
+///
+/// - `zero_fee_commitments` requires `feerate_per_kw == 0`, which we currently
+///   do not enforce. A non-zero feerate may cause the error to be reported here
+///   even though it is invalid for this channel type.
+/// - `option_simple_taproot` has a different commitment fee (968-byte weight),
+///   but we calculate it using the lower 724-byte weight. This may allow some
+///   invalid cases through, but cannot cause a false positive.
+/// - Anchor costs are only included when `option_anchors` is negotiated, so
+///   they are not unnecessarily subtracted for these channel types.
+fn verify_initial_commitment(
+    open_channel: &OpenChannel,
+    channel_type: &[u8],
+    channel_reserve_satoshis: u64,
+) -> Result<(), String> {
+    // Check that the opener can afford the proposed feerate.
+    let opener_balance_sat = (open_channel.funding_satoshis * 1000 - open_channel.push_msat) / 1000;
+    let commitment_cost = CommitmentCost::new(open_channel.feerate_per_kw, channel_type);
+    let Some(balance_after_fee) = opener_balance_sat.checked_sub(commitment_cost.fee_sat) else {
+        return Err(format!(
+            "opener balance {opener_balance_sat} sat cannot cover the commitment fee of {} sat",
+            commitment_cost.fee_sat
+        ));
+    };
+
+    // For `option_anchors` channel types, check that the opener's remaining
+    // balance can cover the anchor cost.
+    let Some(to_local_sat) = balance_after_fee.checked_sub(commitment_cost.anchor_cost_sat) else {
+        return Err(format!(
+            "opener balance {opener_balance_sat} sat cannot cover anchor cost of {} sat (after fee deduction)",
+            commitment_cost.anchor_cost_sat
+        ));
+    };
+
+    // Check the initial commitment keeps at least one side above its reserve.
+    let to_remote_sat = open_channel.push_msat / 1000;
+    if to_local_sat <= channel_reserve_satoshis && to_remote_sat <= channel_reserve_satoshis {
+        return Err(format!(
+            "neither side exceeds channel reserve: to_local {to_local_sat} sat, to_remote {to_remote_sat} sat, reserve {channel_reserve_satoshis} sat",
         ));
     }
 
@@ -260,6 +336,30 @@ mod tests {
     }
 
     #[test]
+    fn open_channel_max_accepted_htlcs_above_the_limit() {
+        let mut oc = open_channel();
+        oc.max_accepted_htlcs = MAX_ACCEPTED_HTLCS_LIMIT + 1;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: max_accepted_htlcs 484 exceeds the limit of 483",
+        );
+    }
+
+    #[test]
+    fn open_channel_dust_limit_below_the_minimum() {
+        let mut oc = open_channel();
+        oc.dust_limit_satoshis = MIN_DUST_LIMIT_SATOSHIS - 1;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: dust_limit_satoshis 353 is below the minimum of 354 sat",
+        );
+    }
+
+    #[test]
     fn opener_cannot_afford_commitment_fee() {
         let mut oc = open_channel();
         oc.push_msat = oc.funding_satoshis * 1000 - 10_000_000;
@@ -280,7 +380,19 @@ mod tests {
         assert_fail(
             &accept_channel(),
             Some(&pending_negotiation(oc)),
-            "invalid open_channel: opener balance 17000 sat cannot cover the commitment fee and anchor cost",
+            "invalid open_channel: opener balance 17000 sat cannot cover anchor cost of 660 sat (after fee deduction)",
+        );
+    }
+
+    #[test]
+    fn open_channel_initial_commitment_below_reserves() {
+        let mut oc = open_channel();
+        oc.channel_reserve_satoshis = 7_000_000;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: neither side exceeds channel reserve",
         );
     }
 

--- a/smite/src/oracles/accept_channel.rs
+++ b/smite/src/oracles/accept_channel.rs
@@ -1,0 +1,307 @@
+//! BOLT 2 `accept_channel` oracle, for the v1 outbound channel funding flow.
+
+use super::Oracle;
+use crate::bolt::{AcceptChannel, OpenChannel};
+use crate::channel_tx::CommitmentCost;
+use crate::pending_channel::PendingChannel;
+use crate::violation::Violation;
+
+use bitcoin::Amount;
+
+/// Context for `AcceptChannelOracle`
+pub struct AcceptChannelContext<'a> {
+    /// The `accept_channel` received from the peer.
+    pub accept_channel: &'a AcceptChannel,
+    /// The negotiation the `accept_channel` answers, identified by its
+    /// `temporary_channel_id`, or `None` if no matching `open_channel` was sent.
+    pub negotiation: Option<&'a PendingChannel>,
+}
+
+/// Checks whether the `open_channel` answered by an `accept_channel` satisfied
+/// the BOLT 2 v1 channel establishment requirements for acceptance, and that
+/// the negotiated `temporary_channel_id` was not reused.
+pub struct AcceptChannelOracle;
+
+impl Oracle<AcceptChannelContext<'_>> for AcceptChannelOracle {
+    fn evaluate(&self, context: &AcceptChannelContext<'_>) -> Result<(), Violation> {
+        // Check that the `accept_channel` answers a known `open_channel`.
+        let Some(PendingChannel {
+            open_channel,
+            accept_channel: previous_accept_channel,
+            funding_built,
+        }) = context.negotiation
+        else {
+            return Err(Violation::InvalidAcceptChannel(
+                context.accept_channel.temporary_channel_id,
+                "unknown temporary_channel_id: no open_channel was sent for this negotiation"
+                    .to_string(),
+            ));
+        };
+
+        // Check that the `open_channel` was valid to accept.
+        if let Err(reason) = verify_accepted_open_channel(open_channel) {
+            return Err(Violation::InvalidAcceptChannel(
+                context.accept_channel.temporary_channel_id,
+                format!("accepted invalid open_channel: {reason}"),
+            ));
+        }
+
+        // Check that the `temporary_channel_id` was not reused.
+        if previous_accept_channel.is_some() && !funding_built {
+            return Err(Violation::InvalidAcceptChannel(
+                context.accept_channel.temporary_channel_id,
+                "temporary_channel_id reuse: previous negotiation has not reached funding_created"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns an error if our `open_channel` breaches a BOLT 2 requirement, i.e.
+/// the reason its receiver had to fail the channel instead of accepting it,
+/// or `Ok(())` if it breaches none.
+fn verify_accepted_open_channel(open_channel: &OpenChannel) -> Result<(), String> {
+    // Check that the funding amounts are valid.
+    // FIXME: Varies if `option_support_large_channel` is not negotiated.
+    let total_supply_satoshis = Amount::MAX_MONEY.to_sat();
+    if open_channel.funding_satoshis > total_supply_satoshis {
+        return Err(format!(
+            "funding_satoshis {} exceeds maximum funding of {total_supply_satoshis} sat",
+            open_channel.funding_satoshis,
+        ));
+    }
+
+    let funding_msat = open_channel.funding_satoshis * 1000;
+    if open_channel.push_msat > funding_msat {
+        return Err(format!(
+            "push_msat {} exceeds funding amount {} msat",
+            open_channel.push_msat, funding_msat,
+        ));
+    }
+
+    // Check that the channel type was included.
+    let Some(channel_type) = open_channel.tlvs.channel_type.as_deref() else {
+        return Err("open_channel does not include a channel_type".to_string());
+    };
+
+    // Check that the opener can afford the proposed feerate.
+    let opener_balance_sat = (funding_msat - open_channel.push_msat) / 1000;
+    let commitment_cost = CommitmentCost::new(open_channel.feerate_per_kw, channel_type);
+    if opener_balance_sat
+        .checked_sub(commitment_cost.total_sat())
+        .is_none()
+    {
+        return Err(format!(
+            "opener balance {opener_balance_sat} sat cannot cover the commitment fee and anchor cost",
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bolt::{AcceptChannel, AcceptChannelTlvs, ChannelId, OpenChannelTlvs};
+    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+    fn pubkey(seed: u8) -> PublicKey {
+        let sk = SecretKey::from_slice(&[seed; 32]).expect("valid secret key");
+        PublicKey::from_secret_key(&Secp256k1::new(), &sk)
+    }
+
+    /// Valid `open_channel` message for testing.
+    fn open_channel() -> OpenChannel {
+        let key = pubkey(1);
+        OpenChannel {
+            chain_hash: [0u8; 32],
+            temporary_channel_id: ChannelId::new([1u8; 32]),
+            funding_satoshis: 10_000_000,
+            push_msat: 3_000_000_000,
+            dust_limit_satoshis: 546,
+            max_htlc_value_in_flight_msat: 100_000_000,
+            channel_reserve_satoshis: 10_000,
+            htlc_minimum_msat: 1_000,
+            feerate_per_kw: 15_000,
+            to_self_delay: 144,
+            max_accepted_htlcs: 483,
+            funding_pubkey: key,
+            revocation_basepoint: key,
+            payment_basepoint: key,
+            delayed_payment_basepoint: key,
+            htlc_basepoint: key,
+            first_per_commitment_point: key,
+            channel_flags: 1,
+            tlvs: OpenChannelTlvs {
+                upfront_shutdown_script: None,
+                channel_type: Some(vec![0x10, 0x00]),
+            },
+        }
+    }
+
+    /// Valid `accept_channel` message for testing.
+    fn accept_channel() -> AcceptChannel {
+        let key = pubkey(2);
+        AcceptChannel {
+            temporary_channel_id: ChannelId::new([1u8; 32]),
+            dust_limit_satoshis: 546,
+            max_htlc_value_in_flight_msat: 100_000_000,
+            channel_reserve_satoshis: 10_000,
+            htlc_minimum_msat: 1_000,
+            minimum_depth: 6,
+            to_self_delay: 144,
+            max_accepted_htlcs: 483,
+            funding_pubkey: key,
+            revocation_basepoint: key,
+            payment_basepoint: key,
+            delayed_payment_basepoint: key,
+            htlc_basepoint: key,
+            first_per_commitment_point: key,
+            tlvs: AcceptChannelTlvs {
+                upfront_shutdown_script: None,
+                channel_type: Some(vec![0x10, 0x00]),
+            },
+        }
+    }
+
+    /// Pending channel negotiation for testing.
+    fn pending_negotiation(oc: OpenChannel) -> PendingChannel {
+        PendingChannel {
+            open_channel: oc,
+            accept_channel: None,
+            funding_built: false,
+        }
+    }
+
+    #[track_caller]
+    fn assert_pass(accept_channel: &AcceptChannel, negotiation: Option<&PendingChannel>) {
+        if let Err(err) = AcceptChannelOracle.evaluate(&AcceptChannelContext {
+            accept_channel,
+            negotiation,
+        }) {
+            panic!("expected pass, got: {err}");
+        }
+    }
+
+    #[track_caller]
+    fn assert_fail(
+        accept_channel: &AcceptChannel,
+        negotiation: Option<&PendingChannel>,
+        expected: &str,
+    ) {
+        match AcceptChannelOracle.evaluate(&AcceptChannelContext {
+            accept_channel,
+            negotiation,
+        }) {
+            Err(Violation::InvalidAcceptChannel(chan_id, reason)) => {
+                assert_eq!(accept_channel.temporary_channel_id, chan_id);
+                assert!(
+                    reason.contains(expected),
+                    "unexpected failure reason: {reason}"
+                );
+            }
+            _ => panic!("expected failure: {expected}"),
+        }
+    }
+
+    #[test]
+    fn conforming_negotiation_passes() {
+        assert_pass(
+            &accept_channel(),
+            Some(&pending_negotiation(open_channel())),
+        );
+    }
+
+    #[test]
+    fn accept_channel_for_unknown_temporary_channel_id() {
+        assert_fail(
+            &accept_channel(),
+            None,
+            "unknown temporary_channel_id: no open_channel was sent for this negotiation",
+        );
+    }
+
+    #[test]
+    fn funding_satoshis_above_bitcoins_total_supply() {
+        let mut oc = open_channel();
+        oc.funding_satoshis = Amount::MAX_MONEY.to_sat() + 1;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: funding_satoshis 2100000000000001 exceeds maximum funding",
+        );
+    }
+
+    #[test]
+    fn push_msat_above_the_funding_amount() {
+        let mut oc = open_channel();
+        oc.push_msat = oc.funding_satoshis * 1000 + 1;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: push_msat 10000000001 exceeds funding amount",
+        );
+    }
+
+    #[test]
+    fn open_channel_without_a_channel_type() {
+        let mut oc = open_channel();
+        oc.tlvs.channel_type = None;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: open_channel does not include a channel_type",
+        );
+    }
+
+    #[test]
+    fn opener_cannot_afford_commitment_fee() {
+        let mut oc = open_channel();
+        oc.push_msat = oc.funding_satoshis * 1000 - 10_000_000;
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: opener balance 10000 sat cannot cover the commitment fee",
+        );
+    }
+
+    #[test]
+    fn opener_cannot_cover_anchor_outputs() {
+        let mut oc = open_channel();
+        oc.push_msat = oc.funding_satoshis * 1000 - 17_000_000;
+        oc.tlvs.channel_type = Some(vec![0x40, 0x10, 0x00]);
+
+        assert_fail(
+            &accept_channel(),
+            Some(&pending_negotiation(oc)),
+            "invalid open_channel: opener balance 17000 sat cannot cover the commitment fee and anchor cost",
+        );
+    }
+
+    #[test]
+    fn temporary_channel_id_reuse_before_funding_created() {
+        let mut negotiation = pending_negotiation(open_channel());
+        negotiation.accept_channel = Some(accept_channel());
+
+        assert_fail(
+            &accept_channel(),
+            Some(&negotiation),
+            "temporary_channel_id reuse: previous negotiation has not reached funding_created",
+        );
+    }
+
+    #[test]
+    fn temporary_channel_id_reuse_after_funding_created() {
+        let mut negotiation = pending_negotiation(open_channel());
+        negotiation.accept_channel = Some(accept_channel());
+        negotiation.funding_built = true;
+
+        assert_pass(&accept_channel(), Some(&negotiation));
+    }
+}

--- a/smite/src/oracles/accept_channel.rs
+++ b/smite/src/oracles/accept_channel.rs
@@ -8,7 +8,7 @@ use crate::violation::Violation;
 
 use bitcoin::Amount;
 
-// Constants from the BOLT 2 `open_channel` requirements:
+// Constants from the BOLT 2 `open_channel` and `accept_channel` requirements:
 // https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#requirements-8
 const MAX_ACCEPTED_HTLCS_LIMIT: u16 = 483;
 const MIN_DUST_LIMIT_SATOSHIS: u64 = 354;
@@ -23,8 +23,9 @@ pub struct AcceptChannelContext<'a> {
 }
 
 /// Checks whether the `open_channel` answered by an `accept_channel` satisfied
-/// the BOLT 2 v1 channel establishment requirements for acceptance, and that
-/// the negotiated `temporary_channel_id` was not reused.
+/// the BOLT 2 v1 channel establishment requirements for acceptance, whether the
+/// `accept_channel` itself satisfies them, and that the negotiated
+/// `temporary_channel_id` was not reused.
 pub struct AcceptChannelOracle;
 
 impl Oracle<AcceptChannelContext<'_>> for AcceptChannelOracle {
@@ -48,6 +49,14 @@ impl Oracle<AcceptChannelContext<'_>> for AcceptChannelOracle {
             return Err(Violation::InvalidAcceptChannel(
                 context.accept_channel.temporary_channel_id,
                 format!("accepted invalid open_channel: {reason}"),
+            ));
+        }
+
+        // Check that the `accept_channel` itself is valid.
+        if let Err(reason) = verify_accept_channel(context.accept_channel, open_channel) {
+            return Err(Violation::InvalidAcceptChannel(
+                context.accept_channel.temporary_channel_id,
+                format!("invalid accept_channel: {reason}"),
             ));
         }
 
@@ -127,6 +136,72 @@ fn verify_accepted_open_channel(open_channel: &OpenChannel) -> Result<(), String
     )
 }
 
+/// Verifies the `accept_channel` against the BOLT 2 requirements it must meet,
+/// returning an error if it breaches one, or `Ok(())` if it meets them all.
+///
+/// # Deferred oracle checks
+///
+/// - `open_channel` channel reserve less than `accept_channel` dust limit: BOLT 2
+///   requires the dust limit to be less than or equal to the channel reserve.
+///   However, implementations such as LDK accept zero channel reserves on the
+///   receiving side, so we enforce this only on the target's sending side.
+fn verify_accept_channel(
+    accept_channel: &AcceptChannel,
+    open_channel: &OpenChannel,
+) -> Result<(), String> {
+    // Check that the channel type was included.
+    let Some(channel_type) = accept_channel.tlvs.channel_type.as_deref() else {
+        return Err("accept_channel does not include a channel_type".to_string());
+    };
+
+    // Check that the channel type matches the one in open_channel.
+    if open_channel.tlvs.channel_type != accept_channel.tlvs.channel_type {
+        return Err("accept_channel channel_type does not match open_channel".to_string());
+    }
+
+    // Check the acceptor's channel reserve covers the opener's dust limit.
+    if accept_channel.channel_reserve_satoshis < open_channel.dust_limit_satoshis {
+        return Err(format!(
+            "channel_reserve_satoshis {} is below the open_channel dust_limit_satoshis {}",
+            accept_channel.channel_reserve_satoshis, open_channel.dust_limit_satoshis,
+        ));
+    }
+
+    // Check the channel reserve covers the dust limit.
+    if accept_channel.dust_limit_satoshis > accept_channel.channel_reserve_satoshis {
+        return Err(format!(
+            "dust_limit_satoshis {} exceeds channel_reserve_satoshis {}",
+            accept_channel.dust_limit_satoshis, accept_channel.channel_reserve_satoshis,
+        ));
+    }
+
+    // Check the HTLC limit is within the maximum.
+    // FIXME: Does not apply to channels whose `channel_type` includes
+    // `zero_fee_commitments`. These channel types have a lower upper limit on
+    // `max_accepted_htlcs`, so we are currently safe.
+    if accept_channel.max_accepted_htlcs > MAX_ACCEPTED_HTLCS_LIMIT {
+        return Err(format!(
+            "max_accepted_htlcs {} exceeds the limit of {MAX_ACCEPTED_HTLCS_LIMIT}",
+            accept_channel.max_accepted_htlcs,
+        ));
+    }
+
+    // Check the dust limit is not below the minimum.
+    if accept_channel.dust_limit_satoshis < MIN_DUST_LIMIT_SATOSHIS {
+        return Err(format!(
+            "dust_limit_satoshis {} is below the minimum of {MIN_DUST_LIMIT_SATOSHIS} sat",
+            accept_channel.dust_limit_satoshis,
+        ));
+    }
+
+    // Check the initial commitment satisfies the channel reserve.
+    verify_initial_commitment(
+        open_channel,
+        channel_type,
+        accept_channel.channel_reserve_satoshis,
+    )
+}
+
 /// Verifies that the initial commitment can cover its fee and satisfies the
 /// channel reserve requirement, returning an error if it breaches either, or
 /// `Ok(())` if both are met.
@@ -180,7 +255,7 @@ fn verify_initial_commitment(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bolt::{AcceptChannel, AcceptChannelTlvs, ChannelId, OpenChannelTlvs};
+    use crate::bolt::{AcceptChannelTlvs, ChannelId, OpenChannelTlvs};
     use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 
     fn pubkey(seed: u8) -> PublicKey {
@@ -393,6 +468,92 @@ mod tests {
             &accept_channel(),
             Some(&pending_negotiation(oc)),
             "invalid open_channel: neither side exceeds channel reserve",
+        );
+    }
+
+    #[test]
+    fn accept_channel_without_a_channel_type() {
+        let mut ac = accept_channel();
+        ac.tlvs.channel_type = None;
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(open_channel())),
+            "invalid accept_channel: accept_channel does not include a channel_type",
+        );
+    }
+
+    #[test]
+    fn accept_channel_channel_type_mismatch_with_open_channel() {
+        let mut ac = accept_channel();
+        ac.tlvs.channel_type = Some(vec![0x40, 0x10, 0x00]);
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(open_channel())),
+            "invalid accept_channel: accept_channel channel_type does not match open_channel",
+        );
+    }
+
+    #[test]
+    fn accept_channel_reserve_below_the_open_channel_dust_limit() {
+        let oc = open_channel();
+        let mut ac = accept_channel();
+        ac.channel_reserve_satoshis = oc.dust_limit_satoshis - 1;
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(oc)),
+            "invalid accept_channel: channel_reserve_satoshis 545 is below the open_channel dust_limit_satoshis 546",
+        );
+    }
+
+    #[test]
+    fn accept_channel_dust_limit_above_its_channel_reserve() {
+        let mut ac = accept_channel();
+        ac.dust_limit_satoshis = 5_000;
+        ac.channel_reserve_satoshis = 4_000;
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(open_channel())),
+            "invalid accept_channel: dust_limit_satoshis 5000 exceeds channel_reserve_satoshis 4000",
+        );
+    }
+
+    #[test]
+    fn accept_channel_max_accepted_htlcs_above_the_limit() {
+        let mut ac = accept_channel();
+        ac.max_accepted_htlcs = MAX_ACCEPTED_HTLCS_LIMIT + 1;
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(open_channel())),
+            "invalid accept_channel: max_accepted_htlcs 484 exceeds the limit of 483",
+        );
+    }
+
+    #[test]
+    fn accept_channel_dust_limit_below_the_minimum() {
+        let mut ac = accept_channel();
+        ac.dust_limit_satoshis = MIN_DUST_LIMIT_SATOSHIS - 1;
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(open_channel())),
+            "invalid accept_channel: dust_limit_satoshis 353 is below the minimum of 354 sat",
+        );
+    }
+
+    #[test]
+    fn accept_channel_initial_commitment_below_reserves() {
+        let mut ac = accept_channel();
+        ac.channel_reserve_satoshis = 7_000_000;
+
+        assert_fail(
+            &ac,
+            Some(&pending_negotiation(open_channel())),
+            "invalid accept_channel: neither side exceeds channel reserve",
         );
     }
 

--- a/smite/src/violation.rs
+++ b/smite/src/violation.rs
@@ -33,16 +33,16 @@ pub enum Violation {
     /// - it accepts an `open_channel` BOLT 2 required it to reject,
     /// - its own fields breach the `accept_channel` requirements, or
     /// - it reuses a `temporary_channel_id` still awaiting `funding_created`.
-    #[error("invalid accept_channel for temporary_channel_id {0:?}: {1}")]
+    #[error("invalid accept_channel for temporary_channel_id {0}: {1}")]
     InvalidAcceptChannel(ChannelId, String),
 
     /// The target sent a `funding_signed` or `channel_ready` for a `channel_id`
     /// we never opened, i.e. one for which no state was ever established.
-    #[error("unknown channel: no tracked state for channel_id {0:?}")]
+    #[error("unknown channel: no tracked state for channel_id {0}")]
     UnknownChannel(ChannelId),
 
     /// The target's `funding_signed` signature failed to verify against the
     /// holder's initial commitment transaction.
-    #[error("invalid counterparty signature for channel_id {0:?}")]
+    #[error("invalid counterparty signature for channel_id {0}")]
     InvalidCounterpartySignature(ChannelId),
 }

--- a/smite/src/violation.rs
+++ b/smite/src/violation.rs
@@ -26,27 +26,19 @@ pub enum Violation {
     #[error("target unexpectedly disconnected")]
     UnexpectedDisconnect,
 
-    /// The target referenced a channel for which no state was ever established.
-    /// This covers:
-    /// - a `funding_signed` or `channel_ready` for a `channel_id` we never
-    ///   opened, or
-    /// - an `accept_channel` for a `temporary_channel_id` we never sent
-    ///   `open_channel` for.
+    /// The target's `accept_channel` broke a BOLT 2 requirement, as judged by
+    /// [`crate::oracles::AcceptChannelOracle`]. The reason names the breached
+    /// requirement, one of:
+    /// - it names a `temporary_channel_id` we sent no `open_channel` for,
+    /// - it accepts an `open_channel` BOLT 2 required it to reject, or
+    /// - it reuses a `temporary_channel_id` still awaiting `funding_created`.
+    #[error("invalid accept_channel for temporary_channel_id {0:?}: {1}")]
+    InvalidAcceptChannel(ChannelId, String),
+
+    /// The target sent a `funding_signed` or `channel_ready` for a `channel_id`
+    /// we never opened, i.e. one for which no state was ever established.
     #[error("unknown channel: no tracked state for channel_id {0:?}")]
     UnknownChannel(ChannelId),
-
-    /// The target sent a second `accept_channel` for a `temporary_channel_id`
-    /// whose in-progress negotiation already has one, i.e. the id was reused
-    /// before its negotiation reached `funding_created`.
-    #[error(
-        "temporary_channel_id reuse: previous negotiation for {0:?} has not yet reached funding_created"
-    )]
-    TempChannelIdReuse(ChannelId),
-
-    /// The target sent `funding_signed` even though the opener cannot afford the
-    /// commitment feerate.
-    #[error("opener cannot afford commitment fee for channel_id {0:?}")]
-    OpenerCannotAffordFee(ChannelId),
 
     /// The target's `funding_signed` signature failed to verify against the
     /// holder's initial commitment transaction.

--- a/smite/src/violation.rs
+++ b/smite/src/violation.rs
@@ -30,7 +30,8 @@ pub enum Violation {
     /// [`crate::oracles::AcceptChannelOracle`]. The reason names the breached
     /// requirement, one of:
     /// - it names a `temporary_channel_id` we sent no `open_channel` for,
-    /// - it accepts an `open_channel` BOLT 2 required it to reject, or
+    /// - it accepts an `open_channel` BOLT 2 required it to reject,
+    /// - its own fields breach the `accept_channel` requirements, or
     /// - it reuses a `temporary_channel_id` still awaiting `funding_created`.
     #[error("invalid accept_channel for temporary_channel_id {0:?}: {1}")]
     InvalidAcceptChannel(ChannelId, String),


### PR DESCRIPTION
Add `AcceptChannelOracle` and consolidate all the previously scattered checks relevant to the initial funding flow negotiation into it, including unknown `temporary_channel_id`, `temporary_channel_id` reuse before `funding_created`, cases where the target accepted an invalid `open_channel` we sent, and cases where the target sent an `accept_channel` that does not follow the BOLT 2 `open_channel <-> accept_channel` requirements

Note: Some checks that depend on negotiated features or `channel_type` are still missing and will be added in a follow-up PR to keep this one focused
Also, I only added the checks explicitly mentioned in the BOLT 2 and haven't added some obvious checks, such as rejecting `max_accepted_htlcs < 1` in `open_channel`. I do think those checks are valuable, so I was thinking of adding them in a follow up PR to avoid adding too much here. But let me know if you think all of them (excluding feature-related checks) should be included here.

I'm also planning to add BOLT 9 feature flag primitives so feature related logic can be consolidated in one place instead of being scattered across `operation.rs`, `setup.rs`, and `AcceptChannelOracle`. The remaining feature dependent checks will be added to this oracle once that is in place