### PR TITLE
smite-scenarios: disable wallet fsync in regtest bitcoind

### DIFF
--- a/smite-scenarios/src/targets/bitcoind.rs
+++ b/smite-scenarios/src/targets/bitcoind.rs
@@ -80,6 +80,7 @@ pub fn start(
         .arg("-txindex=1")
         .arg("-server=1")
         .arg("-rest=1")
+        .arg("-unsafesqlitesync=1")
         .arg("-printtoconsole=0")
         .stdout(Stdio::null())
         .stderr(Stdio::null());


### PR DESCRIPTION
The coinbase of every generated block pays a wallet address, so connecting it commits the sqlite wallet with synchronous=FULL, one fsync per block. `-unsafesqlitesync=1` sets synchronous=OFF, which is what Bitcoin Core's own functional test framework does.

Only matters when the datadir sits on a real filesystem, as in a local docker run: there `-generate 6` drops from ~103ms to ~4ms and startup's `-generate 101` from ~1469ms to ~40ms. Under Nyx the guest rootfs is the initramfs, where fsync is a no-op, so this changes nothing.

This flag should make docker's execution speed closer to performance when running inside the NYX VM.

```
before inside docker container:

INFO  [smite::bitcoin::metrics] bitcoin-cli: 8 calls, 123.8ms total
INFO  [smite::bitcoin::metrics]   -generate: 1 calls, 96.5ms total, 96.5ms avg, 96.5ms max (78%)
INFO  [smite::bitcoin::metrics]   getnewaddress: 1 calls, 9.5ms total, 9.5ms avg, 9.5ms max (8%)
INFO  [smite::bitcoin::metrics]   sendrawtransaction: 1 calls, 7.7ms total, 7.7ms avg, 7.7ms max (6%)
INFO  [smite::bitcoin::metrics]   getrawtransaction: 2 calls, 5.6ms total, 2.8ms avg, 4.4ms max (5%)
INFO  [smite::bitcoin::metrics]   listunspent: 1 calls, 2.2ms total, 2.2ms avg, 2.2ms max (2%)
INFO  [smite::bitcoin::metrics]   signrawtransactionwithwallet: 1 calls, 1.3ms total, 1.3ms avg, 1.3ms max (1%)
INFO  [smite::bitcoin::metrics]   lockunspent: 1 calls, 1.1ms total, 1.1ms avg, 1.1ms max (1%)

after inside docker container:

INFO  [smite::bitcoin::metrics] bitcoin-cli: 8 calls, 25.1ms total
INFO  [smite::bitcoin::metrics]   -generate: 1 calls, 8.0ms total, 8.0ms avg, 8.0ms max (32%)
INFO  [smite::bitcoin::metrics]   sendrawtransaction: 1 calls, 3.5ms total, 3.5ms avg, 3.5ms max (14%)
INFO  [smite::bitcoin::metrics]   getrawtransaction: 2 calls, 3.2ms total, 1.6ms avg, 2.1ms max (13%)
INFO  [smite::bitcoin::metrics]   listunspent: 1 calls, 2.8ms total, 2.8ms avg, 2.8ms max (11%)
INFO  [smite::bitcoin::metrics]   lockunspent: 1 calls, 2.6ms total, 2.6ms avg, 2.6ms max (10%)
INFO  [smite::bitcoin::metrics]   getnewaddress: 1 calls, 2.6ms total, 2.6ms avg, 2.6ms max (10%)
INFO  [smite::bitcoin::metrics]   signrawtransactionwithwallet: 1 calls, 2.4ms total, 2.4ms avg, 2.4ms max (10%)
```