### PR TITLE
perf(ldk): replace signal poll loop with synchronous sigwait

### DIFF
--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -90,11 +90,17 @@ impl LdkTarget {
             cmd.env("LD_PRELOAD", handler);
         }
 
-        // Ignore SIGUSR1 until main() installs the real handler. Initial-block
-        // generation triggers a burst of asynchronous `-blocknotify`
-        // (`pkill -USR1`), and a stray one landing before the handler is set
+        // Ignore SIGUSR1 for the window between exec and the wrapper blocking
+        // it. Initial-block generation triggers a burst of asynchronous
+        // `-blocknotify` (`pkill -USR1`), and a stray one landing in that window
         // would kill the wrapper, since SIGUSR1 is fatal by default. SIG_IGN
         // survives exec; a caught handler would not.
+        //
+        // Signals arriving while SIG_IGN is in effect are dropped, but that ends
+        // once the wrapper calls `pthread_sigmask(SIG_BLOCK)`: blocking wins over
+        // the disposition, so SIGUSR1 then stays pending for `sigwait()` instead
+        // of being discarded. SIG_IGN therefore stays in effect for the whole run
+        // and the wrapper never needs to replace it.
         //
         // SAFETY: runs in the child after fork, before exec; calls only the
         // async-signal-safe `signal`.

--- a/workloads/ldk/src/main.rs
+++ b/workloads/ldk/src/main.rs
@@ -5,34 +5,17 @@
 //! ldk-node since we reset the VM after each fuzz iteration anyway.
 
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use ldk_node::Builder;
 use ldk_node::bitcoin::Network;
 
-/// Signal handler sets this to true to trigger shutdown.
-static SHUTDOWN: AtomicBool = AtomicBool::new(false);
-
-/// Set by the SIGUSR1 handler. bitcoind's `-blocknotify` sends SIGUSR1 on each
-/// new block so the main loop syncs immediately instead of waiting for the next
-/// 2s chain poll.
-static NEW_BLOCK: AtomicBool = AtomicBool::new(false);
-
-extern "C" fn handle_signal(_: libc::c_int) {
-    SHUTDOWN.store(true, Ordering::SeqCst);
-}
-
-extern "C" fn handle_block(_: libc::c_int) {
-    NEW_BLOCK.store(true, Ordering::SeqCst);
-}
-
 /// Path prefix the crash handler reads panic reports from.
 const PANIC_LOG_PATH: &str = "/tmp/smite-panic.log";
 
-/// Stores the panic message where the LD_PRELOADed crash handler can retrieve
+/// Stores the panic message where the `LD_PRELOADed` crash handler can retrieve
 /// it. With `panic = "abort"`, panics only reach stderr, which scenario/Nyx
-/// discards,so this allows crash reports to include the panic message and its
+/// discards, so this allows crash reports to include the panic message and its
 /// source location.
 fn install_panic_hook() {
     let path = format!("{PANIC_LOG_PATH}.{}", std::process::id());
@@ -45,18 +28,45 @@ fn install_panic_hook() {
     }));
 }
 
+/// Blocks SIGUSR1, SIGTERM, and SIGINT so they can be synchronously handled
+/// with `sigwait()`.
+///
+/// Blocking supersedes the disposition inherited across exec, which for SIGUSR1
+/// is `SIG_IGN` (set by the scenario's pre-exec hook, see `LdkTarget::start`).
+/// That distinction is the whole point: an *ignored* signal is discarded the
+/// moment it is delivered, while a *blocked* one stays pending until `sigwait()`
+/// consumes it, regardless of its disposition. So this call is what makes
+/// bitcoind's `-blocknotify` SIGUSR1 observable, and why nothing here calls
+/// `sigaction`: the wait loop below is the only consumer these signals need.
+///
+/// Standard signals do not queue, so a burst of SIGUSR1 collapses into one
+/// pending instance and thus one wakeup. That is fine here: each wakeup syncs
+/// the wallet against bitcoind's current tip, not against a single block.
+fn setup_signal_set() -> libc::sigset_t {
+    // SAFETY: `set` is zeroed and then initialized by `sigemptyset` before any
+    // read; every call receives a valid pointer to it. The null `oldset` is
+    // explicitly allowed by `pthread_sigmask`, which discards the previous mask.
+    unsafe {
+        let mut set: libc::sigset_t = std::mem::zeroed();
+
+        libc::sigemptyset(&raw mut set);
+        libc::sigaddset(&raw mut set, libc::SIGUSR1);
+        libc::sigaddset(&raw mut set, libc::SIGTERM);
+        libc::sigaddset(&raw mut set, libc::SIGINT);
+
+        let ret = libc::pthread_sigmask(libc::SIG_BLOCK, &raw const set, std::ptr::null_mut());
+        assert_eq!(ret, 0, "failed to block signals");
+
+        set
+    }
+}
+
 fn main() {
     install_panic_hook();
 
-    // Set up signal handlers for graceful shutdown
-    unsafe {
-        // Cast through pointer to satisfy Rust's function-to-integer cast rules
-        let sighandler = handle_signal as *const () as libc::sighandler_t;
-        libc::signal(libc::SIGTERM, sighandler);
-        libc::signal(libc::SIGINT, sighandler);
-        let blockhandler = handle_block as *const () as libc::sighandler_t;
-        libc::signal(libc::SIGUSR1, blockhandler);
-    }
+    // bitcoind's -blocknotify sends SIGUSR1 for each new block.
+    // SIGTERM/SIGINT are used for graceful shutdown.
+    let signal_set = setup_signal_set();
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 5 {
@@ -99,25 +109,39 @@ fn main() {
         std::thread::sleep(Duration::from_secs(1));
     }
 
-    // Output for LdkTarget to parse
+    // Output for LdkTarget to parse.
     println!("PUBKEY:{}", node.node_id());
     println!("READY");
 
-    // Wait for shutdown signal
-    while !SHUTDOWN.load(Ordering::SeqCst) {
-        // Sync the wallet whenever bitcoind signals a new block. ldk-node's own
-        // 2s background poll keeps running, so this is technically redundant and
-        // may race it, but that's safe: ldk-node coalesces concurrent syncs, so
-        // whichever loses the race just waits on the in-flight sync's result
-        // rather than applying the block twice. We accept the redundancy to sync
-        // on the block instead of up to 2s later.
-        if NEW_BLOCK.swap(false, Ordering::SeqCst)
-            && let Err(e) = node.sync_wallets()
-        {
-            eprintln!("sync_wallets failed: {e}");
-        }
+    // Wait for signals. sigwait() blocks here without polling and returns
+    // immediately when bitcoind sends SIGUSR1 or the process receives
+    // SIGTERM/SIGINT.
+    loop {
+        let mut signal = 0;
 
-        std::thread::sleep(Duration::from_millis(50));
+        // SAFETY: both pointers refer to live locals, and `signal_set` was
+        // initialized by `setup_signal_set` above.
+        let ret = unsafe { libc::sigwait(&raw const signal_set, &raw mut signal) };
+        assert_eq!(ret, 0, "sigwait failed: {ret}");
+
+        match signal {
+            libc::SIGUSR1 => {
+                // Sync the wallet whenever bitcoind signals a new block.
+                // ldk-node's own 2s background poll keeps running, so this is
+                // technically redundant and may race it, but that's safe:
+                // ldk-node coalesces concurrent syncs, so whichever loses the
+                // race just waits on the in-flight sync's result rather than
+                // applying the block twice. We accept the redundancy to sync on
+                // the block instead of up to 2s later.
+                if let Err(e) = node.sync_wallets() {
+                    eprintln!("sync_wallets failed: {e}");
+                }
+            }
+            libc::SIGTERM | libc::SIGINT => {
+                break;
+            }
+            _ => unreachable!("received unexpected signal {signal}"),
+        }
     }
 
     node.stop().expect("node stop");


### PR DESCRIPTION
Replaced asynchronous signal handlers (`libc::signal` + `AtomicBool`) and a 50ms polling sleep with `pthread_sigmask` and blocking `libc::sigwait`.

before:

```
  aggregate over 5 runs:
    execs/sec: mean 8.8  stddev 0.1  min 8.7  max 8.9
    boot + snapshot: mean 4.041 s
    latency (mean across runs):
      min 107.27 ms  mean 113.35 ms  median 113.30 ms  p99 118.16 ms  max 137.89 ms
    input execution (mean across runs): mean 109.22 ms  median 109.09 ms
    nyx overhead (mean across runs):     mean 4.13 ms  median 4.22 ms
    failed iterations: 0 / 500
    coverage determinism: 83.5% stable (15222 / 92312 edges fluctuated, summed over runs)

INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [5.071µs] Executing IR program (40 instructions, 406 input bytes)
DEBUG [smite_scenarios::executor] [119.157µs] SendOpenChannel: 327 bytes
DEBUG [smite_scenarios::executor] [126.085µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [1.911781ms] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [7.146892ms] SendFundingCreated: 132 bytes
DEBUG [smite_scenarios::executor] [7.182271ms] RecvFundingSigned: waiting
DEBUG [smite_scenarios::executor] [9.630999ms] RecvFundingSigned: received
DEBUG [smite_scenarios::executor] [9.977985ms] BroadcastTransaction: txid=de0cf6c15ea6cce7a6bc8ad5fe9e83c7545f50586a9f2586817838423ad82bbe
DEBUG [smite_scenarios::executor] [22.79079ms] MineBlocks: mined 6 block(s)
DEBUG [smite_scenarios::executor] [22.882372ms] SendChannelReady: 67 bytes
DEBUG [smite_scenarios::executor] [24.780335ms] RecvChannelReady: waiting
DEBUG [smite_scenarios::executor] [61.01623ms] RecvChannelReady: received
DEBUG [smite_scenarios::scenarios::ir] [61.031084ms] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [101.260578ms] Target responded with pong
```

after:

```
  aggregate over 5 runs:
    execs/sec: mean 14.2  stddev 0.1  min 14.1  max 14.3
    boot + snapshot: mean 4.029 s
    latency (mean across runs):
      min 67.81 ms  mean 70.41 ms  median 70.14 ms  p99 81.12 ms  max 81.61 ms
    input execution (mean across runs): mean 68.34 ms  median 68.15 ms
    nyx overhead (mean across runs):     mean 2.07 ms  median 1.83 ms
    failed iterations: 0 / 500
    coverage determinism: 80.3% stable (18070 / 91809 edges fluctuated, summed over runs)

INFO  [smite::runners] Reading input from "/input.bin"
DEBUG [smite_scenarios::scenarios::ir] [4.611µs] Executing IR program (40 instructions, 406 input bytes)
DEBUG [smite_scenarios::executor] [113.28µs] SendOpenChannel: 327 bytes
DEBUG [smite_scenarios::executor] [119.826µs] RecvAcceptChannel: waiting
DEBUG [smite_scenarios::executor] [883.175µs] RecvAcceptChannel: received
DEBUG [smite_scenarios::executor] [6.123234ms] SendFundingCreated: 132 bytes
DEBUG [smite_scenarios::executor] [6.157739ms] RecvFundingSigned: waiting
DEBUG [smite_scenarios::executor] [8.2297ms] RecvFundingSigned: received
DEBUG [smite_scenarios::executor] [8.592972ms] BroadcastTransaction: txid=7c52544c5646978c4757c5342bd8bbdbf22c302a932dbd3b7d44602b15d80914
DEBUG [smite_scenarios::executor] [21.934378ms] MineBlocks: mined 6 block(s)
DEBUG [smite_scenarios::executor] [22.055101ms] SendChannelReady: 67 bytes
DEBUG [smite_scenarios::executor] [25.280867ms] RecvChannelReady: waiting
DEBUG [smite_scenarios::executor] [35.929502ms] RecvChannelReady: received
DEBUG [smite_scenarios::scenarios::ir] [35.948273ms] Program executed successfully
DEBUG [smite_scenarios::scenarios::ir] [76.452444ms] Target responded with pong
```