### PR TITLE
smite-scenarios: add support for suppressing known violations

### DIFF
--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -106,8 +106,16 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
                 log::debug!("[{:?}] invalid commitment: {e}", start.elapsed());
             }
             Err(ExecuteError::Violation(v)) => {
-                // The target broke a protocol invariant.
-                return ScenarioResult::Fail(v.to_string());
+                let violation = v.to_string();
+                if T::is_violation_known(&violation) {
+                    log::debug!(
+                        "[{:?}] suppressed known violation: {violation}",
+                        start.elapsed(),
+                    );
+                } else {
+                    // The target broke a protocol invariant.
+                    return ScenarioResult::Fail(violation);
+                }
             }
         }
 

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -77,4 +77,39 @@ pub trait Target: Sized {
     ///
     /// Returns [`TargetError::Crashed`] if the target has crashed.
     fn check_alive(&mut self) -> Result<(), TargetError>;
+
+    /// Known protocol violations for this target that should be suppressed.
+    ///
+    /// Each entry is a sequence of patterns that must appear in the violation
+    /// message in the specified order, without overlapping. Include stable
+    /// context around variable parts to avoid suppressing unrelated violations.
+    ///
+    /// Every entry must describe the behavior justifying it, and be removed
+    /// once the upstream fix lands.
+    #[must_use]
+    fn known_violations() -> &'static [&'static [&'static str]] {
+        &[]
+    }
+
+    /// Check if a violation matches a known pattern for this target.
+    #[must_use]
+    fn is_violation_known(violation: &str) -> bool {
+        Self::known_violations()
+            .iter()
+            .any(|pattern| Self::contains_in_order(violation, pattern))
+    }
+
+    /// Returns true if every fragment in a pattern appears in the violation
+    /// message in the specified order, without overlapping.
+    #[must_use]
+    fn contains_in_order(violation: &str, pattern: &[&str]) -> bool {
+        let mut pos = 0;
+        for fragment in pattern {
+            match violation[pos..].find(fragment) {
+                Some(offset) => pos += offset + fragment.len(),
+                None => return false,
+            }
+        }
+        true
+    }
 }

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -248,4 +248,17 @@ impl Target for ClnTarget {
         }
         Ok(())
     }
+
+    /// Known violations suppressed until fixed upstream:
+    ///
+    /// - CLN currently allows `funding_satoshis` values above the total Bitcoin
+    ///   supply during `open_channel` and `accept_channel` negotiation. These
+    ///   values should be rejected early, as they cannot result in a valid
+    ///   channel. See: <https://github.com/ElementsProject/lightning/pull/9368>
+    fn known_violations() -> &'static [&'static [&'static str]] {
+        &[&[
+            "accepted invalid open_channel: funding_satoshis",
+            "exceeds maximum funding of 2100000000000000 sat",
+        ]]
+    }
 }

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -255,10 +255,21 @@ impl Target for ClnTarget {
     ///   supply during `open_channel` and `accept_channel` negotiation. These
     ///   values should be rejected early, as they cannot result in a valid
     ///   channel. See: <https://github.com/ElementsProject/lightning/pull/9368>
+    ///
+    /// - CLN currently allows `dust_limit_satoshis` values below 354 during
+    ///   `open_channel` negotiation. These values should be rejected early, as
+    ///   required by BOLT 2.
+    ///   See: <https://github.com/ElementsProject/lightning/issues/9403>
     fn known_violations() -> &'static [&'static [&'static str]] {
-        &[&[
-            "accepted invalid open_channel: funding_satoshis",
-            "exceeds maximum funding of 2100000000000000 sat",
-        ]]
+        &[
+            &[
+                "accepted invalid open_channel: funding_satoshis",
+                "exceeds maximum funding of 2100000000000000 sat",
+            ],
+            &[
+                "accepted invalid open_channel: dust_limit_satoshis",
+                "is below the minimum of 354 sat",
+            ],
+        ]
     }
 }

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -236,4 +236,17 @@ impl Target for EclairTarget {
         }
         Ok(())
     }
+
+    /// Known violations suppressed until fixed upstream:
+    ///
+    /// - Eclair currently allows `funding_satoshis` values above the total Bitcoin
+    ///   supply during `open_channel` and `accept_channel` negotiation. These
+    ///   values should be rejected early, as they cannot result in a valid
+    ///   channel. See: <https://github.com/ACINQ/eclair/issues/3349>
+    fn known_violations() -> &'static [&'static [&'static str]] {
+        &[&[
+            "accepted invalid open_channel: funding_satoshis",
+            "exceeds maximum funding of 2100000000000000 sat",
+        ]]
+    }
 }

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -243,10 +243,20 @@ impl Target for EclairTarget {
     ///   supply during `open_channel` and `accept_channel` negotiation. These
     ///   values should be rejected early, as they cannot result in a valid
     ///   channel. See: <https://github.com/ACINQ/eclair/issues/3349>
+    ///
+    /// - Eclair currently does not properly validate `channel_reserve_satoshis`
+    ///   against the `dust_limit_satoshis` from `open_channel` in `accept_channel`,
+    ///   as required by BOLT 2. See: <https://github.com/ACINQ/eclair/issues/3350>
     fn known_violations() -> &'static [&'static [&'static str]] {
-        &[&[
-            "accepted invalid open_channel: funding_satoshis",
-            "exceeds maximum funding of 2100000000000000 sat",
-        ]]
+        &[
+            &[
+                "accepted invalid open_channel: funding_satoshis",
+                "exceeds maximum funding of 2100000000000000 sat",
+            ],
+            &[
+                "invalid accept_channel: channel_reserve_satoshis",
+                "is below the open_channel dust_limit_satoshis",
+            ],
+        ]
     }
 }

--- a/smite-scenarios/src/targets/lnd.rs
+++ b/smite-scenarios/src/targets/lnd.rs
@@ -316,4 +316,13 @@ impl Target for LndTarget {
         }
         Ok(())
     }
+
+    /// Known violations suppressed until fixed upstream:
+    ///
+    /// - LND allows `open_channel` with an omitted `channel_type`, violating
+    ///   BOLT 2 even though it signals the required `option_channel_type` feature.
+    ///   See: <https://github.com/lightningnetwork/lnd/pull/11064>
+    fn known_violations() -> &'static [&'static [&'static str]] {
+        &[&["accepted invalid open_channel: open_channel does not include a channel_type"]]
+    }
 }


### PR DESCRIPTION
Targets can now declare known violations that should be
suppressed until they are fixed upstream. IR scenario will
check if a violation is in the known list and skip the failure
if so, logging it as debug instead. This provides the foundation
for handling multiple oracles as they're added in the future,
establishing the standard process for suppressing known violations
until upstream fixes land.

Currently known violations that are suppressed are:

- CLN currently allows `funding_satoshis` values exceeding
total Bitcoin supply during `open_channel` and `accept_channel`
negotiation. These values should be rejected early as they cannot
result in a valid channel. This is tracked upstream and will be
suppressed until fixed.

- LND allows `open_channel` with an omitted `channel_type`,
violating BOLT 2 even though it signals the required
`option_channel_type` feature bit. This will be tracked
upstream and will be suppressed until fixed.

- CLN currently allows `dust_limit_satoshis` values below 354 during
`open_channel` negotiation, violating BOLT 2 which requires rejection
of such values. This will be tracked upstream and will be suppressed
until fixed.