### PR TITLE
ci(ldk): also run fmt/clippy in workloads/ldk

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            workloads/ldk
 
       - name: Install taplo
         run: curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
@@ -31,13 +35,17 @@ jobs:
         run: taplo format --check
 
       - name: Check Rust formatting
-        run: cargo fmt --all --check
+        run: |
+          cargo fmt --all --check
+          cargo fmt --check --manifest-path workloads/ldk/Cargo.toml
 
       - name: Check order of BOLT message type constants
         run: scripts/check-bolt-msg-type-order.sh
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets --manifest-path workloads/ldk/Cargo.toml -- -D warnings
 
       - name: Build
         run: cargo build --verbose

--- a/workloads/ldk/Cargo.toml
+++ b/workloads/ldk/Cargo.toml
@@ -11,3 +11,13 @@ panic = "abort"
 [dependencies]
 ldk-node = "0.7"
 libc = "0.2"
+
+[lints]
+workspace = true
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+
+[workspace.lints.rust]
+warnings = "deny"


### PR DESCRIPTION
close #201

Btw, I can recommend running the quick part of the CI locally before committing with git hooks:

```
$ mkdir .githooks
$ cat > .githooks/pre-commit <<EOF
# pre-commit hook

set -xeu

cargo fmt --all --check
cargo fmt --check --manifest-path workloads/ldk/Cargo.toml
cargo clippy --all-features --all-targets -- -D warnings
cargo clippy --all-targets --manifest-path workloads/ldk/Cargo.toml -- -D warnings
cargo test --all-features --all-targets
EOF
$ git config core.hooksPath .githooks
```